### PR TITLE
Fix the CMake HDF5 requirementsto remove hdf5_cpp and hdf5_hl require…

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -34,7 +34,7 @@ function(compile_example exemple_source)
     endif()
 
     add_executable(${example_name} ${exemple_source} ${headers_highfive} ${headers_highfive_bits})
-    target_link_libraries(${example_name} ${HDF5_LIBRARIES})
+    target_link_libraries(${example_name} ${HDF5_C_LIBRARIES})
 
 endfunction()
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 file(GLOB tests_high_five_src "*.cpp")
 
 add_executable(tests_high_five_bin ${tests_high_five_src})
-target_link_libraries(tests_high_five_bin ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES} ${HDF5_C_LIBRARIES} ${HDF5_HL_LIBRARIES})
+target_link_libraries(tests_high_five_bin ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES} ${HDF5_C_LIBRARIES})
 
 add_test(NAME tests_high_five COMMAND tests_high_five_bin)
 


### PR DESCRIPTION
…ments for cmake 3.6