### PR TITLE
Do not throw from ~Object

### DIFF
--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -37,7 +37,8 @@ inline Object& Object::operator=(const Object& other) {
 
 inline Object::~Object() {
     if (isValid() && H5Idec_ref(_hid) < 0) {
-        throw ObjectException("Reference counter decrease failure");
+        std::cerr << "HighFive::~Object: reference counter decrease failure"
+                  << std::endl;
     }
 }
 


### PR DESCRIPTION
Triggers a warning in new compilers and it's not recommended because
it can cause double exceptions during stack unwinding.
In C++11 destructors are implicitly noexcept, so std::terminate will be
called unless noexcept(false) (C++11 only syntax) is added.