### PR TITLE
Split H5Slice_traits::read in two functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.5
+    - SliceTraits::read split in two overloads, the first one for plain C arrays
+      and the second one for other types.
+
 ## Version 1.4 - 2017/08/25
 	- Support id selection for the `select` function
 	- Suport STL containers of const elements

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.0)
 enable_testing()
 
 set(HIGHFIVE_VERSION_MAJOR 1)
-set(HIGHFIVE_VERSION_MINOR 4)
+set(HIGHFIVE_VERSION_MINOR 5)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
   ${PROJECT_SOURCE_DIR}/CMake/portability

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -66,10 +66,21 @@ class SliceTraits {
     /// An exception is raised is if the numbers of dimension of the buffer and
     /// of the dataset are different
     ///
-    /// The array type can be a N-pointer or a N-vector ( e.g int** integer two
-    /// dimensional array )
+    /// The array type can be a N-pointer or a N-vector. For plain pointers
+    /// not dimensionality checking will be performed, it is the user's
+    /// reponsibility to ensure that the right amount of space has been
+    /// allocated.
     template <typename T>
     void read(T& array) const;
+
+    ///
+    /// Read the entire dataset into a raw buffer
+    ///
+    /// No dimensionality checks will be performed, it is the user's
+    /// reponsibility to ensure that the right amount of space has been
+    /// allocated.
+    template <typename T>
+    void read(T* array) const;
 
     ///
     /// Write the integrality N-dimension buffer to this dataset
@@ -80,6 +91,16 @@ class SliceTraits {
     /// dimensional array )
     template <typename T>
     void write(const T& buffer);
+
+    ///
+    /// Write from a raw buffer into this dataset
+    ///
+    /// No dimensionality checks will be performed, it is the user's
+    /// reponsibility to ensure that the buffer holds the right amount of
+    /// elements. For n-dimensional matrices the buffer layout follows H5
+    /// default conventions.
+    template <typename T>
+    void write(const T* buffer);
 
   private:
     typedef Derivate derivate_type;

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -186,6 +186,27 @@ inline void SliceTraits<Derivate>::read(T& array) const {
 
 template <typename Derivate>
 template <typename T>
+inline void SliceTraits<Derivate>::read(T* array) const {
+
+    DataSpace space = static_cast<const Derivate*>(this)->getSpace();
+    DataSpace mem_space = static_cast<const Derivate*>(this)->getMemSpace();
+
+    // Create mem datatype
+    const AtomicType<typename details::type_of_array<T>::type> array_datatype;
+
+    if (H5Dread(
+            details::get_dataset(static_cast<const Derivate*>(this)).getId(),
+            array_datatype.getId(),
+            details::get_memspace_id((static_cast<const Derivate*>(this))),
+            space.getId(), H5P_DEFAULT,
+            static_cast<void*>(array)) < 0) {
+        HDF5ErrMapper::ToException<DataSetException>(
+            "Error during HDF5 Read: ");
+    }
+}
+
+template <typename Derivate>
+template <typename T>
 inline void SliceTraits<Derivate>::write(const T& buffer) {
     typedef typename details::remove_const<T>::type type_no_const;
 
@@ -214,6 +235,25 @@ inline void SliceTraits<Derivate>::write(const T& buffer) {
                  space.getId(), H5P_DEFAULT,
                  static_cast<const void*>(
                      converter.transform_write(nocv_buffer))) < 0) {
+        HDF5ErrMapper::ToException<DataSetException>(
+            "Error during HDF5 Write: ");
+    }
+}
+
+template <typename Derivate>
+template <typename T>
+inline void SliceTraits<Derivate>::write(const T* buffer) {
+
+    DataSpace space = static_cast<const Derivate*>(this)->getSpace();
+    DataSpace mem_space = static_cast<const Derivate*>(this)->getMemSpace();
+
+    const AtomicType<typename details::type_of_array<T>::type> array_datatype;
+
+    if (H5Dwrite(details::get_dataset(static_cast<Derivate*>(this)).getId(),
+                 array_datatype.getId(),
+                 details::get_memspace_id((static_cast<Derivate*>(this))),
+                 space.getId(), H5P_DEFAULT,
+                 static_cast<const void*>(buffer)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>(
             "Error during HDF5 Write: ");
     }


### PR DESCRIPTION
The new one is for plain C arrays. This also solves the annoyance
of having to provide an l-value for T* buffers.