### PR TITLE
fixing #106: fails to open existing file with Create flag

### DIFF
--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -42,7 +42,7 @@ inline File::File(const std::string& filename, int openFlags,
 
     openFlags = convert_open_flag(openFlags);
 
-    if (openFlags & (H5F_ACC_CREAT | H5F_ACC_TRUNC)) {
+    if (openFlags & H5F_ACC_TRUNC) {
         if ((_hid = H5Fcreate(_filename.c_str(), openFlags & (H5F_ACC_TRUNC),
                               H5P_DEFAULT, driver.getId())) < 0) {
             HDF5ErrMapper::ToException<FileException>(

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(HighFiveException) {
     BOOST_CHECK_THROW(
         {
             // triggers a file creation conflict
-            File file2("random_file_123", File::ReadWrite | File::Create);
+            File file2("random_file_123", File::ReadWrite | File::Create | File::Excl);
         },
         FileException);
 }


### PR DESCRIPTION
fix #106: where ``File file(FILE_NAME, File::ReadWrite | File::Create);`` failed to open a file when it exists. 

This also fixes the test where trigger to file creation conflict is tested.
``File file(FILE_NAME, File::ReadWrite | File::Create | File::Excl);`` should fail when the file exist.
``File file(FILE_NAME, File::ReadWrite | File::Create);``  should just open the file when it exist.