### PR TITLE
More resilient open modes

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -25,7 +25,7 @@ namespace HighFive {
 class File : public Object,
              public NodeTraits<File>,
              public AnnotateTraits<File> {
-  public:
+ public:
     /// Open flag: Read only access
     static const int ReadOnly = 0x00;
     /// Open flag: Read Write access
@@ -38,6 +38,11 @@ class File : public Object,
     static const int Debug = 0x08;
     /// Open flag: Create non existing file
     static const int Create = 0x10;
+    /// Derived open flag: common write mode (=ReadWrite | Create | Truncate)
+    static const int Overwrite = Truncate;
+    /// Derived open flag: Opens RW or exclusivelly creates
+    static const int OpenOrCreate = ReadWrite | Create;
+
 
     ///
     /// \brief File
@@ -60,11 +65,12 @@ class File : public Object,
     ///
     void flush();
 
-  private:
+ private:
     std::string _filename;
 };
-}
+}  // namespace HighFive
 
 #include "bits/H5File_misc.hpp"
 
-#endif // H5FILE_HPP
+#endif  // H5FILE_HPP
+

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -9,8 +9,10 @@
 #ifndef H5FILE_MISC_HPP
 #define H5FILE_MISC_HPP
 
+#include <string>
 #include "../H5Exception.hpp"
 #include "../H5File.hpp"
+#include "../H5Utility.hpp"
 
 #include <H5Fpublic.h>
 
@@ -34,7 +36,7 @@ inline int convert_open_flag(int openFlags) {
         res_open |= H5F_ACC_EXCL;
     return res_open;
 }
-}
+}  // namespace
 
 inline File::File(const std::string& filename, int openFlags,
                   const Properties& fileAccessProps)
@@ -42,19 +44,35 @@ inline File::File(const std::string& filename, int openFlags,
 
     openFlags = convert_open_flag(openFlags);
 
-    if (openFlags & (H5F_ACC_CREAT | H5F_ACC_TRUNC)) {
-        if ((_hid = H5Fcreate(_filename.c_str(), openFlags & (H5F_ACC_TRUNC),
-                              H5P_DEFAULT, fileAccessProps.getId())) < 0) {
-            HDF5ErrMapper::ToException<FileException>(
-                std::string("Unable to create file " + _filename));
-        }
-    } else {
-        if ((_hid = H5Fopen(_filename.c_str(), openFlags,
-                            fileAccessProps.getId())) <
-            0) {
+    int createMode = openFlags & (H5F_ACC_TRUNC | H5F_ACC_EXCL);
+    int openMode = openFlags & (H5F_ACC_RDWR | H5F_ACC_RDONLY);
+    bool mustCreate = createMode > 0;
+    bool openOrCreate = (openFlags & H5F_ACC_CREAT) > 0;
+
+    // open is default. It's skipped only if flags require creation
+    // If open fails if will try create if H5F_ACC_CREAT is set
+    if (!mustCreate) {
+        // Silence open errors if create is allowed
+        std::unique_ptr<SilenceHDF5> silencer;
+        if (openOrCreate) silencer.reset(new SilenceHDF5());
+
+        _hid = H5Fopen(_filename.c_str(), openMode, fileAccessProps.getId());
+
+        if (isValid()) return;  // Done
+
+        if (openOrCreate) {
+            // Will attempt to create ensuring wont clobber any file
+            createMode = H5F_ACC_EXCL;
+        } else {
             HDF5ErrMapper::ToException<FileException>(
                 std::string("Unable to open file " + _filename));
         }
+    }
+
+    if ((_hid = H5Fcreate(_filename.c_str(), createMode, H5P_DEFAULT,
+                          fileAccessProps.getId())) < 0) {
+        HDF5ErrMapper::ToException<FileException>(
+            std::string("Unable to create file " + _filename));
     }
 }
 
@@ -68,6 +86,6 @@ inline void File::flush() {
             std::string("Unable to flush file " + _filename));
     }
 }
-}
+}  // namespace HighFive
 
-#endif // H5FILE_MISC_HPP
+#endif  // H5FILE_MISC_HPP


### PR DESCRIPTION
Open modes/flags improved, behavior more according to posix
Added lots of tests
c++linter applied
Respects Hdf5lib better, so that only respective flags are passed to open() or create(), excluding H5F_ACC_CREAT)