### PR TITLE
Deflate and shuffle properties

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -69,6 +69,26 @@ class Chunking
     std::vector<hsize_t> _dims;
 };
 
+class Deflate
+{
+  public:
+    Deflate(int level) : _level(level) {}
+
+  private:
+    friend class Properties;
+    void apply(hid_t hid) const;
+    int _level;
+};
+
+class Shuffle
+{
+  public:
+    Shuffle() {}
+
+  private:
+    friend class Properties;
+    void apply(hid_t hid) const;
+};
 
 } // HighFive
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -66,5 +66,35 @@ inline void Chunking::apply(const hid_t hid) const
             "Error setting chunk property");
     }
 }
+
+inline void Deflate::apply(const hid_t hid) const
+{
+    if (!H5Zfilter_avail(H5Z_FILTER_DEFLATE))
+    {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting deflate property");
+    }
+
+    if (H5Pset_deflate(hid, _level) < 0)
+    {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting deflate property");
+    }
+}
+
+inline void Shuffle::apply(const hid_t hid) const
+{
+    if (!H5Zfilter_avail(H5Z_FILTER_SHUFFLE))
+    {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting shuffle property");
+    }
+
+    if (H5Pset_shuffle(hid) < 0)
+    {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting shuffle property");
+    }
+}
 }
 #endif // H5PROPERTY_LIST_HPP


### PR DESCRIPTION
This adds support for the deflate (compression) and shuffle (aids compression) filters, using the same interface as for chunking. I include a simple unit-test that writes compressed datasets to files, reads them back and compares. Manual inspection with h5dump shows that the filters are being applied, e.g.:

```
$ h5dump -H -p h5_rw_deflate_x_test.h5 
HDF5 "h5_rw_deflate_x_test.h5" {
GROUP "/" {
   DATASET "dset" {
      DATATYPE  H5T_STD_I64LE
      DATASPACE  SIMPLE { ( 128, 32 ) / ( 128, 32 ) }
      STORAGE_LAYOUT {
         CHUNKED ( 16, 16 )
         SIZE 2623 (12.493:1 COMPRESSION)
      }
      FILTERS {
         PREPROCESSING SHUFFLE
         COMPRESSION DEFLATE { LEVEL 9 }
      }
      FILLVALUE {
         FILL_TIME H5D_FILL_TIME_IFSET
         VALUE  H5D_FILL_VALUE_DEFAULT
      }
      ALLOCATION_TIME {
         H5D_ALLOC_TIME_INCR
      }
   }
}
}
```