### PR TITLE
Initializing a size_t with a constant double gives compilation error …

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -120,18 +120,18 @@ inline AtomicType<std::string>::AtomicType() {
 
 
 
-template <> 
+template <>
 inline AtomicType<std::complex<double> >::AtomicType()
 {
 		static hid_t cplx_hid;
 		static size_t real_offset;//
 		static size_t imag_offset;//
-        
+
         cplx_hid =   H5Tcreate( H5T_COMPOUND, sizeof(std::complex<double>) );
 
-        real_offset=  0.;
+        real_offset=  0;
         imag_offset=  sizeof(double);
-        
+
 
         // h5py/numpy compatible datatype
         H5Tinsert(cplx_hid , "r" , real_offset , H5T_NATIVE_DOUBLE);


### PR DESCRIPTION
…on VS2017 (32 bits). Changed constant to 0.