### PR TITLE
Adding support for std::array

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -10,6 +10,7 @@
 #define H5DATASPACE_HPP
 
 #include <vector>
+#include <array>
 #include <cstdint>
 
 #ifdef H5_USE_BOOST
@@ -95,9 +96,14 @@ class DataSpace : public Object {
     /// Supported Containers are:
     ///  - vector of fundamental types
     ///  - vector of std::string
-    ///  - boost::multi_array
+    ///  - boost::multi_array (with H5_USE_BOOST defined)
     template <typename Value>
     static DataSpace From(const std::vector<Value>& vec);
+
+    /// Create a dataspace matching the container dimensions for a
+    /// std::array.
+    template <typename Value, std::size_t N>
+    static DataSpace From(const std::array<Value, N>&);
 
 
 #ifdef H5_USE_BOOST

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -181,16 +181,14 @@ struct data_converter<
     std::array<T, S>,
     typename std::enable_if<(
                          std::is_same<T, typename type_of_array<T>::type>::value)>::type> {
-    inline data_converter(std::array<T,S>& vec, DataSpace& space, size_t dim = 0) {
-        if(space.getDimensions().size() != 1) {
+    inline data_converter(std::array<T, S>& vec, DataSpace& space, size_t dim = 0) {
+        if (space.getDimensions().size() != 1) {
             throw DataSpaceException("Only 1D std::array supported currently.");
         }
-        if(space.getDimensions()[0] != S) {
+        if (space.getDimensions()[0] != S) {
             std::ostringstream ss;
-            ss << "Impossible to pair DataSet with "
-               << space.getDimensions()[0] << " elements into "
-                       "an array with "
-               << S << " elements.";
+            ss << "Impossible to pair DataSet with " << space.getDimensions()[0]
+               << " elements into an array with " << S << " elements.";
             throw DataSpaceException(ss.str());
         }
         (void)vec;

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -182,14 +182,16 @@ struct data_converter<
     typename std::enable_if<(
                          std::is_same<T, typename type_of_array<T>::type>::value)>::type> {
     inline data_converter(std::array<T,S>& vec, DataSpace& space, size_t dim = 0)
-    : _space(&space), _dim(dim) {
-        assert(_space->getDimensions().size() >= dim);
+    : _space(&space) {
+        assert(_space->getDimensions().size() > 0);
+        assert(_space->getDimensions().at(0) == S);
         (void)vec;
+        (void)dim;
     }
     
     inline typename type_of_array<T>::type*
     transform_read(std::array<T, S>& vec) {
-        return &(vec[0]);
+        return vec.data();
     }
     
     inline typename type_of_array<T>::type*
@@ -200,7 +202,6 @@ struct data_converter<
     inline void process_result(std::array<T, S>& vec) { (void)vec; }
     
     DataSpace* _space;
-    size_t _dim;
 };
 
 #ifdef H5_USE_BOOST
@@ -306,6 +307,7 @@ struct data_converter<std::vector<T>,
     size_t _dim;
     std::vector<typename type_of_array<T>::type> _vec_align;
 };
+
 
 // apply conversion to scalar string
 template <>

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -15,6 +15,7 @@
 #include <numeric>
 #include <sstream>
 #include <string>
+#include <array>
 
 #ifdef H5_USE_BOOST
 #include <boost/multi_array.hpp>
@@ -170,6 +171,34 @@ struct data_converter<
 
     inline void process_result(std::vector<T>& vec) { (void)vec; }
 
+    DataSpace* _space;
+    size_t _dim;
+};
+
+// apply conversion to std::array
+template <typename T, std::size_t S>
+struct data_converter<
+    std::array<T, S>,
+    typename std::enable_if<(
+                         std::is_same<T, typename type_of_array<T>::type>::value)>::type> {
+    inline data_converter(std::array<T,S>& vec, DataSpace& space, size_t dim = 0)
+    : _space(&space), _dim(dim) {
+        assert(_space->getDimensions().size() >= dim);
+        (void)vec;
+    }
+    
+    inline typename type_of_array<T>::type*
+    transform_read(std::array<T, S>& vec) {
+        return &(vec[0]);
+    }
+    
+    inline typename type_of_array<T>::type*
+    transform_write(std::array<T, S>& vec) {
+        return vec.data();
+    }
+    
+    inline void process_result(std::array<T, S>& vec) { (void)vec; }
+    
     DataSpace* _space;
     size_t _dim;
 };

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -181,10 +181,18 @@ struct data_converter<
     std::array<T, S>,
     typename std::enable_if<(
                          std::is_same<T, typename type_of_array<T>::type>::value)>::type> {
-    inline data_converter(std::array<T,S>& vec, DataSpace& space, size_t dim = 0)
-    : _space(&space) {
-        assert(_space->getDimensions().size() > 0);
-        assert(_space->getDimensions().at(0) == S);
+    inline data_converter(std::array<T,S>& vec, DataSpace& space, size_t dim = 0) {
+        if(space.getDimensions().size() != 1) {
+            throw DataSpaceException("Only 1D std::array supported currently.");
+        }
+        if(space.getDimensions()[0] != S) {
+            std::ostringstream ss;
+            ss << "Impossible to pair DataSet with "
+               << space.getDimensions()[0] << " elements into "
+                       "an array with "
+               << S << " elements.";
+            throw DataSpaceException(ss.str());
+        }
         (void)vec;
         (void)dim;
     }
@@ -200,8 +208,6 @@ struct data_converter<
     }
     
     inline void process_result(std::array<T, S>& vec) { (void)vec; }
-    
-    DataSpace* _space;
 };
 
 #ifdef H5_USE_BOOST

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -10,6 +10,7 @@
 #define H5DATASPACE_MISC_HPP
 
 #include <vector>
+#include <array>
 
 #include <H5Spublic.h>
 
@@ -150,6 +151,14 @@ inline DataSpace DataSpace::From(const ScalarValue& scalar) {
 template <typename Value>
 inline DataSpace DataSpace::From(const std::vector<Value>& container) {
     return DataSpace(details::get_dim_vector<Value>(container));
+}
+
+/// Currently only supports 1D std::array
+template <typename Value, std::size_t N>
+inline DataSpace DataSpace::From(const std::array<Value, N>& ) {
+    std::vector<size_t> dims;
+    dims.push_back(N);
+    return DataSpace(dims);
 }
 
 #ifdef H5_USE_BOOST

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -68,7 +68,7 @@ class SliceTraits {
     ///
     /// The array type can be a N-pointer or a N-vector. For plain pointers
     /// not dimensionality checking will be performed, it is the user's
-    /// reponsibility to ensure that the right amount of space has been
+    /// responsibility to ensure that the right amount of space has been
     /// allocated.
     template <typename T>
     void read(T& array) const;
@@ -77,7 +77,7 @@ class SliceTraits {
     /// Read the entire dataset into a raw buffer
     ///
     /// No dimensionality checks will be performed, it is the user's
-    /// reponsibility to ensure that the right amount of space has been
+    /// responsibility to ensure that the right amount of space has been
     /// allocated.
     template <typename T>
     void read(T* array) const;
@@ -96,7 +96,7 @@ class SliceTraits {
     /// Write from a raw buffer into this dataset
     ///
     /// No dimensionality checks will be performed, it is the user's
-    /// reponsibility to ensure that the buffer holds the right amount of
+    /// responsibility to ensure that the buffer holds the right amount of
     /// elements. For n-dimensional matrices the buffer layout follows H5
     /// default conventions.
     template <typename T>

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -167,7 +167,7 @@ inline void SliceTraits<Derivate>::read(T& array) const {
     const AtomicType<typename details::type_of_array<type_no_const>::type>
         array_datatype;
 
-    // Apply pre read convertions
+    // Apply pre-read conversions
     details::data_converter<type_no_const> converter(nocv_array, mem_space);
 
     if (H5Dread(
@@ -226,7 +226,7 @@ inline void SliceTraits<Derivate>::write(const T& buffer) {
     const AtomicType<typename details::type_of_array<type_no_const>::type>
         array_datatype;
 
-    // Apply pre write convertions
+    // Apply pre write conversions
     details::data_converter<type_no_const> converter(nocv_buffer, mem_space);
 
     if (H5Dwrite(details::get_dataset(static_cast<Derivate*>(this)).getId(),

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <array>
 
 #ifdef H5_USE_BOOST
 #include <boost/multi_array.hpp>
@@ -55,6 +56,12 @@ struct array_dims<T*> {
 template <typename T, std::size_t N>
 struct array_dims<T[N]> {
     static const size_t value = 1 + array_dims<T>::value;
+};
+
+// Only supporting 1D arrays at the moment
+template<typename T, std::size_t N>
+struct array_dims<std::array<T,N>> {
+    static const size_t value = 1;
 };
 
 #ifdef H5_USE_BOOST
@@ -97,6 +104,11 @@ struct type_of_array {
 
 template <typename T>
 struct type_of_array<std::vector<T> > {
+    typedef typename type_of_array<T>::type type;
+};
+
+template <typename T, std::size_t N>
+struct type_of_array<std::array<T, N> > {
     typedef typename type_of_array<T>::type type;
 };
 

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -40,39 +40,39 @@ namespace details {
 // determine at compile time number of dimensions of in memory datasets
 template <typename T>
 struct array_dims {
-    static const size_t value = 0;
+    static constexpr size_t value = 0;
 };
 
 template <typename T>
 struct array_dims<std::vector<T> > {
-    static const size_t value = 1 + array_dims<T>::value;
+    static constexpr size_t value = 1 + array_dims<T>::value;
 };
 
 template <typename T>
 struct array_dims<T*> {
-    static const size_t value = 1 + array_dims<T>::value;
+    static constexpr size_t value = 1 + array_dims<T>::value;
 };
 
 template <typename T, std::size_t N>
 struct array_dims<T[N]> {
-    static const size_t value = 1 + array_dims<T>::value;
+    static constexpr size_t value = 1 + array_dims<T>::value;
 };
 
 // Only supporting 1D arrays at the moment
 template<typename T, std::size_t N>
 struct array_dims<std::array<T,N>> {
-    static const size_t value = 1;
+    static constexpr size_t value = 1 + array_dims<T>::value;
 };
 
 #ifdef H5_USE_BOOST
 template <typename T, std::size_t Dims>
 struct array_dims<boost::multi_array<T, Dims> > {
-    static const size_t value = Dims;
+    static constexpr size_t value = Dims;
 };
 
 template <typename T>
 struct array_dims<boost::numeric::ublas::matrix<T> > {
-    static const size_t value = 2;
+    static constexpr size_t value = 2;
 };
 #endif
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -647,10 +647,12 @@ void readWriteVectorTest() {
     std::ostringstream filename;
     filename << "h5_rw_vec_" << typeid(T).name() << "_test.h5";
 
-    std::srand((unsigned int)std::time(0));
     const size_t x_size = 800;
     const std::string DATASET_NAME("dset");
     typename std::vector<T> vec;
+    vec.resize(x_size);
+    for(size_t i=0; i<x_size; i++)
+        vec.at(i) = i % 100;
 
     // Create a new file using the default property lists.
     File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
@@ -669,8 +671,45 @@ void readWriteVectorTest() {
 
     for (size_t i = 0; i < x_size; ++i) {
         // std::cout << result[i] << " " << vec[i] << "  ";
+        BOOST_CHECK_EQUAL(result.at(i), vec.at(i));
+    }
+}
+BOOST_AUTO_TEST_CASE_TEMPLATE(readWriteVector, T, numerical_test_types) {
+    readWriteVectorTest<T>();
+}
+
+template <typename T>
+void readWriteArrayTest() {
+    using namespace HighFive;
+
+    std::ostringstream filename;
+    filename << "h5_rw_vec_" << typeid(T).name() << "_test.h5";
+
+    const size_t x_size = 800;
+    const std::string DATASET_NAME("dset");
+    typename std::array<T, x_size> vec;
+    for(size_t i=0; i<x_size; i++)
+        vec.at(i) = i % 100;
+
+    // Create a new file using the default property lists.
+    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
+
+    // Create a dataset with double precision floating points
+    DataSet dataset = file.createDataSet<T>(DATASET_NAME, DataSpace::From(vec));
+
+    dataset.write(vec);
+
+    typename std::array<T, x_size> result;
+
+    dataset.read(result);
+
+    for (size_t i = 0; i < x_size; ++i) {
+        // std::cout << result[i] << " " << vec[i] << "  ";
         BOOST_CHECK_EQUAL(result[i], vec[i]);
     }
+}
+BOOST_AUTO_TEST_CASE_TEMPLATE(readWriteArray, T, numerical_test_types) {
+    readWriteArrayTest<T>();
 }
 
 template <typename T>

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -651,7 +651,7 @@ void readWriteVectorTest() {
     const std::string DATASET_NAME("dset");
     typename std::vector<T> vec;
     vec.resize(x_size);
-    for(size_t i=0; i<x_size; i++)
+    for(size_t i = 0; i < x_size; i++)
         vec.at(i) = i % 100;
 
     // Create a new file using the default property lists.
@@ -683,12 +683,12 @@ void readWriteArrayTest() {
     using namespace HighFive;
 
     std::ostringstream filename;
-    filename << "h5_rw_vec_" << typeid(T).name() << "_test.h5";
+    filename << "h5_rw_arr_" << typeid(T).name() << "_test.h5";
 
     const size_t x_size = 800;
     const std::string DATASET_NAME("dset");
     typename std::array<T, x_size> vec;
-    for(size_t i=0; i<x_size; i++)
+    for(size_t i = 0; i < x_size; i++)
         vec.at(i) = i % 100;
 
     // Create a new file using the default property lists.

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -688,7 +688,7 @@ void readWriteArrayTest() {
     const size_t x_size = 800;
     const std::string DATASET_NAME("dset");
     typename std::array<T, x_size> vec;
-    for(size_t i = 0; i < x_size; i++)
+    for (size_t i = 0; i < x_size; i++)
         vec.at(i) = i % 100;
 
     // Create a new file using the default property lists.


### PR DESCRIPTION
This should add support for std::array, which is missing (though inferior old C style arrays were supported!).

I tried to add a test, as well.

Edit: Addresses #100.