### PR TITLE
Dropping old toggle for C++11

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,7 +25,6 @@ if(HIGHFIVE_PARALLEL_HDF5)
 endif()
 
 target_compile_options(tests_high_five_cpp11_bin PRIVATE "${HIGHFIVE_CPP_STD_FLAG}")
-target_compile_definitions(tests_high_five_cpp11_bin PRIVATE "-DHIGHFIVE_CPP11_ENABLE=1")
 
 add_test(NAME tests_high_five_cpp11 COMMAND tests_high_five_cpp11_bin)
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -15,10 +15,7 @@
 #include <string>
 #include <typeinfo>
 #include <vector>
-
-#ifdef HIGHFIVE_CPP11_ENABLE
 #include <memory>
-#endif
 
 #include <stdio.h>
 
@@ -382,7 +379,6 @@ BOOST_AUTO_TEST_CASE(HighFiveExtensibleDataSet) {
     }
 }
 
-#ifdef HIGHFIVE_CPP11_ENABLE
 BOOST_AUTO_TEST_CASE(HighFiveRefCountMove) {
     const std::string FILE_NAME("h5_ref_count_test.h5");
     const std::string DATASET_NAME("dset");
@@ -449,8 +445,6 @@ BOOST_AUTO_TEST_CASE(HighFiveRefCountMove) {
         g2.createGroup("blabla");
     }
 }
-
-#endif
 
 BOOST_AUTO_TEST_CASE(HighFiveSimpleListing) {
     const std::string FILE_NAME("h5_list_test.h5");


### PR DESCRIPTION
Quick PR to drop the irritating C++11 checks in the tests that no longer do anything.