### PR TITLE
Adding variadic DataSpace and Chunking constructor

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -12,6 +12,8 @@
 #include <vector>
 #include <array>
 #include <cstdint>
+#include <type_traits>
+#include <initializer_list>
 
 #ifdef H5_USE_BOOST
 #include <boost/multi_array.hpp>
@@ -44,22 +46,28 @@ class DataSpace : public Object {
     ///  etc...
     explicit DataSpace(const std::vector<size_t>& dims);
 
+    /// Make sure that DataSpace({1,2,3}) works on GCC. This is
+    /// the shortcut form of the vector initalizer, but one some compilers (gcc)
+    /// this does not resolve correctly without this constructor.
+    explicit DataSpace(std::initializer_list<size_t> items);
+
+    /// Allow directly listing 1 or more dimensions to initialize,
+    /// that is, DataSpace(1,2) means DataSpace(std::vector<size_t>{1,2}).
+    template<typename... Args>
+    explicit DataSpace(size_t dim1, Args... dims);
+
     /// Create a dataspace from an iterator pair
-    template <typename IT>
-    DataSpace(const IT begin, const IT end);
+    ///
+    /// Explicitly disable DataSpace(int_like, int_like) from trying to use this constructor
+    template <typename IT, typename = typename std::enable_if<!std::is_integral<IT>::value,IT>::type>
+    DataSpace(const IT begin,
+              const IT end);
 
     /// \brief Create a resizable N-dimensional dataspace
     /// \params dims Initial size of dataspace
     /// \params maxdims Maximum size of the dataspace
     explicit DataSpace(const std::vector<size_t>& dims,
                        const std::vector<size_t>& maxdims);
-
-    ///
-    /// \brief DataSpace create a dataspace of a single dimension and of size
-    /// dim1
-    /// \param dim1
-    ///
-    explicit DataSpace(size_t dim1);
 
     ///
     /// \brief DataSpace create a scalar dataspace or a null dataset

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -79,6 +79,13 @@ class Chunking
   public:
     Chunking(const std::vector<hsize_t>& dims) : _dims(dims) {}
 
+    Chunking(std::initializer_list<hsize_t> items) : Chunking(std::vector<hsize_t>{items}) {}
+
+    template<typename... Args>
+    Chunking(hsize_t item, Args... args) : Chunking(std::vector<hsize_t>{item, static_cast<hsize_t>(args)...}) {}
+
+    const std::vector<hsize_t>& getDimensions() const {return _dims;}
+
   private:
     friend class Properties;
     void apply(hid_t hid) const;

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -11,6 +11,7 @@
 
 #include <vector>
 #include <array>
+#include <initializer_list>
 
 #include <H5Spublic.h>
 
@@ -24,7 +25,15 @@ namespace HighFive {
 inline DataSpace::DataSpace(const std::vector<size_t>& dims)
     : DataSpace(dims.begin(), dims.end()) {}
 
-template <class IT>
+inline DataSpace::DataSpace(std::initializer_list<size_t> items)
+    : DataSpace(std::vector<size_t>(items)) {}
+
+template<typename... Args>
+    inline DataSpace::DataSpace(size_t dim1, Args... dims)
+    : DataSpace(std::vector<size_t>{static_cast<size_t>(dim1),
+                                    static_cast<size_t>(dims)...}){}
+
+template <class IT, typename>
 inline DataSpace::DataSpace(const IT begin, const IT end) {
     std::vector<hsize_t> real_dims(begin, end);
 
@@ -53,13 +62,6 @@ inline DataSpace::DataSpace(const std::vector<size_t>& dims,
         throw DataSpaceException("Impossible to create dataspace");
     }
 } // namespace HighFive
-
-inline DataSpace::DataSpace(const size_t dim1) {
-    const hsize_t dims = hsize_t(dim1);
-    if ((_hid = H5Screate_simple(1, &dims, NULL)) < 0) {
-        throw DataSpaceException("Unable to create dataspace");
-    }
-}
 
 inline DataSpace::DataSpace(DataSpace::DataspaceType dtype) {
     H5S_class_t h5_dataspace_type;

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -657,6 +657,32 @@ BOOST_AUTO_TEST_CASE(DataSpaceVariadicTest) {
                                   space2b_ans.begin(), space2b_ans.end());
 }
 
+BOOST_AUTO_TEST_CASE(ChunkingConstructorsTest) {
+    Chunking first(1,2,3);
+
+    auto first_res = first.getDimensions();
+    std::vector<hsize_t> first_ans{1,2,3};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(first_res.begin(), first_res.end(),
+                                  first_ans.begin(), first_ans.end());
+
+    Chunking second{1,2,3};
+
+    auto second_res = second.getDimensions();
+    std::vector<hsize_t> second_ans{1,2,3};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(second_res.begin(), second_res.end(),
+                                  second_ans.begin(), second_ans.end());
+
+    Chunking third({1,2,3});
+
+    auto third_res = third.getDimensions();
+    std::vector<hsize_t> third_ans{1,2,3};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(third_res.begin(), third_res.end(),
+                                  third_ans.begin(), third_ans.end());
+}
+
 template <typename T>
 void readWrite2DArrayTest() {
     std::ostringstream filename;

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -129,9 +129,7 @@ BOOST_AUTO_TEST_CASE(HighFiveBasic) {
     BOOST_CHECK_EQUAL(file.getName(), FILE_NAME);
 
     // Create the data space for the dataset.
-    std::vector<size_t> dims;
-    dims.push_back(4);
-    dims.push_back(6);
+    std::vector<size_t> dims = {4,6};
 
     DataSpace dataspace(dims);
 
@@ -577,11 +575,7 @@ BOOST_AUTO_TEST_CASE(DataSpaceTest) {
     File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
     // Create the data space for the dataset.
-    std::vector<size_t> dims;
-    dims.push_back(10);
-    dims.push_back(1);
-
-    DataSpace dataspace(dims);
+    DataSpace dataspace{std::vector<size_t>{10, 1}};
 
     // Create a dataset with size_t type
     DataSet dataset = file.createDataSet<size_t>(DATASET_NAME, dataspace);
@@ -596,6 +590,63 @@ BOOST_AUTO_TEST_CASE(DataSpaceTest) {
     BOOST_CHECK_EQUAL(space.getDimensions().size(), 2);
     BOOST_CHECK_EQUAL(space.getDimensions()[0], 10);
     BOOST_CHECK_EQUAL(space.getDimensions()[1], 1);
+}
+
+BOOST_AUTO_TEST_CASE(DataSpaceVectorTest) {
+    using namespace HighFive;
+
+    // Create 1D shortcut dataspace
+    DataSpace space(7);
+
+    BOOST_CHECK_EQUAL(space.getDimensions().size(), 1);
+    BOOST_CHECK_EQUAL(space.getDimensions()[0], 7);
+
+    // Initializer list (explicit)
+    DataSpace space3({8, 9, 10});
+
+    BOOST_CHECK_EQUAL(space3.getDimensions().size(), 3);
+    BOOST_CHECK_EQUAL(space3.getDimensions()[0], 8);
+    BOOST_CHECK_EQUAL(space3.getDimensions()[1], 9);
+    BOOST_CHECK_EQUAL(space3.getDimensions()[2], 10);
+
+    // Verify 2D works (note that without the {}, this matches the iterator constructor)
+    DataSpace space2(std::vector<size_t>{3, 4});
+
+    BOOST_CHECK_EQUAL(space2.getDimensions().size(), 2);
+    BOOST_CHECK_EQUAL(space2.getDimensions()[0], 3);
+    BOOST_CHECK_EQUAL(space2.getDimensions()[1], 4);
+}
+
+BOOST_AUTO_TEST_CASE(DataSpaceVariadicTest) {
+    using namespace HighFive;
+
+    // Create 1D shortcut dataspace
+    DataSpace space {7};
+
+    BOOST_CHECK_EQUAL(space.getDimensions().size(), 1);
+    BOOST_CHECK_EQUAL(space.getDimensions()[0], 7);
+
+    // Initializer list (explicit)
+    DataSpace space3{8, 9, 10};
+
+    BOOST_CHECK_EQUAL(space3.getDimensions().size(), 3);
+    BOOST_CHECK_EQUAL(space3.getDimensions()[0], 8);
+    BOOST_CHECK_EQUAL(space3.getDimensions()[1], 9);
+    BOOST_CHECK_EQUAL(space3.getDimensions()[2], 10);
+
+    // Verify 2D works using explicit syntax
+    DataSpace space2{3, 4};
+
+    BOOST_CHECK_EQUAL(space2.getDimensions().size(), 2);
+    BOOST_CHECK_EQUAL(space2.getDimensions()[0], 3);
+    BOOST_CHECK_EQUAL(space2.getDimensions()[1], 4);
+    
+    // Verify 2D works using old syntax (this used to match the iterator!)
+    DataSpace space2b(3, 4);
+
+    BOOST_CHECK_EQUAL(space2b.getDimensions().size(), 2);
+    BOOST_CHECK_EQUAL(space2b.getDimensions()[0], 3);
+    BOOST_CHECK_EQUAL(space2b.getDimensions()[1], 4);
 }
 
 template <typename T>

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(HighFiveBasic) {
     BOOST_CHECK_EQUAL(file.getName(), FILE_NAME);
 
     // Create the data space for the dataset.
-    std::vector<size_t> dims = {4,6};
+    std::vector<size_t> dims{4,6};
 
     DataSpace dataspace(dims);
 
@@ -251,9 +251,7 @@ BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSet) {
         Group nested = g1.createGroup(GROUP_NESTED_NAME);
 
         // Create the data space for the dataset.
-        std::vector<size_t> dims;
-        dims.push_back(4);
-        dims.push_back(6);
+        std::vector<size_t> dims{4, 6};
 
         DataSpace dataspace(dims);
 
@@ -548,9 +546,7 @@ BOOST_AUTO_TEST_CASE(DataTypeEqualTakeBack) {
     File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
     // Create the data space for the dataset.
-    std::vector<size_t> dims;
-    dims.push_back(10);
-    dims.push_back(1);
+    std::vector<size_t> dims{10, 1};
 
     DataSpace dataspace(dims);
 
@@ -603,50 +599,62 @@ BOOST_AUTO_TEST_CASE(DataSpaceVectorTest) {
 
     // Initializer list (explicit)
     DataSpace space3({8, 9, 10});
+    auto space3_res = space3.getDimensions();
+    std::vector<size_t> space3_ans{8, 9, 10};
 
-    BOOST_CHECK_EQUAL(space3.getDimensions().size(), 3);
-    BOOST_CHECK_EQUAL(space3.getDimensions()[0], 8);
-    BOOST_CHECK_EQUAL(space3.getDimensions()[1], 9);
-    BOOST_CHECK_EQUAL(space3.getDimensions()[2], 10);
+    BOOST_CHECK_EQUAL_COLLECTIONS(space3_res.begin(), space3_res.end(),
+                                  space3_ans.begin(), space3_ans.end());
 
     // Verify 2D works (note that without the {}, this matches the iterator constructor)
     DataSpace space2(std::vector<size_t>{3, 4});
 
-    BOOST_CHECK_EQUAL(space2.getDimensions().size(), 2);
-    BOOST_CHECK_EQUAL(space2.getDimensions()[0], 3);
-    BOOST_CHECK_EQUAL(space2.getDimensions()[1], 4);
+    auto space2_res = space2.getDimensions();
+    std::vector<size_t> space2_ans{3, 4};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(space2_res.begin(), space2_res.end(),
+                                  space2_ans.begin(), space2_ans.end());
+
 }
 
 BOOST_AUTO_TEST_CASE(DataSpaceVariadicTest) {
     using namespace HighFive;
 
     // Create 1D shortcut dataspace
-    DataSpace space {7};
+    DataSpace space1 {7};
 
-    BOOST_CHECK_EQUAL(space.getDimensions().size(), 1);
-    BOOST_CHECK_EQUAL(space.getDimensions()[0], 7);
+    auto space1_res = space1.getDimensions();
+    std::vector<size_t> space1_ans{7};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(space1_res.begin(), space1_res.end(),
+                                  space1_ans.begin(), space1_ans.end());
+
 
     // Initializer list (explicit)
     DataSpace space3{8, 9, 10};
 
-    BOOST_CHECK_EQUAL(space3.getDimensions().size(), 3);
-    BOOST_CHECK_EQUAL(space3.getDimensions()[0], 8);
-    BOOST_CHECK_EQUAL(space3.getDimensions()[1], 9);
-    BOOST_CHECK_EQUAL(space3.getDimensions()[2], 10);
+    auto space3_res = space3.getDimensions();
+    std::vector<size_t> space3_ans{8, 9, 10};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(space3_res.begin(), space3_res.end(),
+                                  space3_ans.begin(), space3_ans.end());
 
     // Verify 2D works using explicit syntax
     DataSpace space2{3, 4};
 
-    BOOST_CHECK_EQUAL(space2.getDimensions().size(), 2);
-    BOOST_CHECK_EQUAL(space2.getDimensions()[0], 3);
-    BOOST_CHECK_EQUAL(space2.getDimensions()[1], 4);
+    auto space2_res = space2.getDimensions();
+    std::vector<size_t> space2_ans{3, 4};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(space2_res.begin(), space2_res.end(),
+                                  space2_ans.begin(), space2_ans.end());
     
     // Verify 2D works using old syntax (this used to match the iterator!)
     DataSpace space2b(3, 4);
 
-    BOOST_CHECK_EQUAL(space2b.getDimensions().size(), 2);
-    BOOST_CHECK_EQUAL(space2b.getDimensions()[0], 3);
-    BOOST_CHECK_EQUAL(space2b.getDimensions()[1], 4);
+    auto space2b_res = space2b.getDimensions();
+    std::vector<size_t> space2b_ans{3, 4};
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(space2b_res.begin(), space2b_res.end(),
+                                  space2b_ans.begin(), space2b_ans.end());
 }
 
 template <typename T>
@@ -661,9 +669,7 @@ void readWrite2DArrayTest() {
     File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
 
     // Create the data space for the dataset.
-    std::vector<size_t> dims;
-    dims.push_back(x_size);
-    dims.push_back(y_size);
+    std::vector<size_t> dims{x_size, y_size};
 
     DataSpace dataspace(dims);
 
@@ -1074,10 +1080,8 @@ void selectionArraySimpleTest() {
     {
         // read it back
         Vector result;
-        std::vector<size_t> offset;
-        offset.push_back(offset_x);
-        std::vector<size_t> size;
-        size.push_back(count_x);
+        std::vector<size_t> offset{offset_x};
+        std::vector<size_t> size{count_x};
 
         Selection slice = dataset.select(offset, size);
 
@@ -1097,11 +1101,7 @@ void selectionArraySimpleTest() {
     {
         // read it back
         Vector result;
-        std::vector<size_t> ids;
-        ids.push_back(1);
-        ids.push_back(3);
-        ids.push_back(4);
-        ids.push_back(7);
+        std::vector<size_t> ids{1,3,4,7};
 
         Selection slice = dataset.select(ElementSet(ids));
 
@@ -1142,9 +1142,7 @@ void columnSelectionTest() {
     File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
 
     // Create the data space for the dataset.
-    std::vector<size_t> dims;
-    dims.push_back(x_size);
-    dims.push_back(y_size);
+    std::vector<size_t> dims{x_size, y_size};
 
     DataSpace dataspace(dims);
     // Create a dataset with arbitrary type
@@ -1154,10 +1152,7 @@ void columnSelectionTest() {
 
     file.flush();
 
-    std::vector<size_t> columns;
-    columns.push_back(1);
-    columns.push_back(3);
-    columns.push_back(5);
+    std::vector<size_t> columns{1, 3, 5};
 
     Selection slice = dataset.select(columns);
     T result[x_size][3];
@@ -1263,9 +1258,7 @@ void readWriteShuffleDeflateTest() {
         File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
 
         // Create the data space for the dataset.
-        std::vector<size_t> dims;
-        dims.push_back(x_size);
-        dims.push_back(y_size);
+        std::vector<size_t> dims{x_size, y_size};
 
         DataSpace dataspace(dims);
 


### PR DESCRIPTION
This expands the current shortcut:

DataSpace(3) -> 1D dataspace: [3]

to work with any number of dimensions:

DataSpace(2,3,4) -> 3D dataspace: [2,3,4]

It also fixes the current odd behavior where two integer parameters, DataSpace(1,2) matches against the iterator constructor, which then matches against a different constructor in vector, causing a really odd result. This was done by not allowing an integer-like value through the template for the iterator constructor.

A similar fix was added to Chunking for consistency.