### PR TITLE
Fix broadcasting on read

### DIFF
--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1329,3 +1329,46 @@ void readWriteShuffleDeflateTest() {
 BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteShuffleDeflate, T, numerical_test_types) {
     readWriteShuffleDeflateTest<T>();
 }
+
+// Broadcasting is supported
+BOOST_AUTO_TEST_CASE(ReadInBroadcastDims) {
+
+    const std::string FILE_NAME("h5_missmatch1_dset.h5");
+    const std::string DATASET_NAME("dset");
+
+    // Create a new file using the default property lists.
+    File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+
+    // Create the data space for the dataset.
+    std::vector<size_t> dims_a{1,3};
+    std::vector<size_t> dims_b{3,1};
+
+    // 1D input / output vectors
+    std::vector<double> some_data{5.0, 6.0, 7.0};
+    std::vector<double> data_a;
+    std::vector<double> data_b;
+
+    DataSpace dataspace_a(dims_a);
+    DataSpace dataspace_b(dims_b);
+
+    // Create a dataset with double precision floating points
+    DataSet dataset_a = file.createDataSet(DATASET_NAME + "_a", dataspace_a, AtomicType<double>());
+    DataSet dataset_b = file.createDataSet(DATASET_NAME + "_b", dataspace_b, AtomicType<double>());
+
+    dataset_a.write(some_data);
+    dataset_b.write(some_data);
+
+    DataSet out_a = file.getDataSet(DATASET_NAME + "_a");
+    DataSet out_b = file.getDataSet(DATASET_NAME + "_b");
+
+    out_a.read(data_a);
+    out_b.read(data_b);
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            data_a.begin(), data_a.end(),
+            some_data.begin(), some_data.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            data_b.begin(), data_b.end(),
+            some_data.begin(), some_data.end());
+}

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -646,7 +646,7 @@ BOOST_AUTO_TEST_CASE(DataSpaceVariadicTest) {
 
     BOOST_CHECK_EQUAL_COLLECTIONS(space2_res.begin(), space2_res.end(),
                                   space2_ans.begin(), space2_ans.end());
-    
+
     // Verify 2D works using old syntax (this used to match the iterator!)
     DataSpace space2b(3, 4);
 
@@ -754,7 +754,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
     dataset.read(result);
     BOOST_CHECK_EQUAL_COLLECTIONS(vec.begin(), vec.end(),
                                   result.begin(), result.end());
-    
+
     std::string read_in;
     dataset.getAttribute("str").read(read_in);
     BOOST_CHECK_EQUAL(read_in, at_contents);
@@ -763,7 +763,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
     ds_int.read(out_int);
     BOOST_CHECK_EQUAL(my_int, out_int);
 
-    decltype(my_nested) out_nested; 
+    decltype(my_nested) out_nested;
     ds_nested.read(out_nested);
 
     for (size_t i = 0; i < 2; ++i) {
@@ -1352,8 +1352,10 @@ BOOST_AUTO_TEST_CASE(ReadInBroadcastDims) {
     DataSpace dataspace_b(dims_b);
 
     // Create a dataset with double precision floating points
-    DataSet dataset_a = file.createDataSet(DATASET_NAME + "_a", dataspace_a, AtomicType<double>());
-    DataSet dataset_b = file.createDataSet(DATASET_NAME + "_b", dataspace_b, AtomicType<double>());
+    DataSet dataset_a = file.createDataSet(DATASET_NAME + "_a", dataspace_a,
+                                           AtomicType<double>());
+    DataSet dataset_b = file.createDataSet(DATASET_NAME + "_b", dataspace_b,
+                                           AtomicType<double>());
 
     dataset_a.write(some_data);
     dataset_b.write(some_data);


### PR DESCRIPTION
This is the test mentioned in #135, and a possible fix. Only fixes 1D vectors and arrays at the moment.

It works by giving the unnested vector and array converters a filtered version of the dimensions array, where all the 1s have been removed unless it is all 1s, in which case a single 1 is kept.

Higher dimensional arrays may still have issues where they don’t throw an error, but miss the correct non-1 dimensions.