### PR TITLE
Fix missing include for old versions of BOOST

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -16,6 +16,10 @@
 #include <initializer_list>
 
 #ifdef H5_USE_BOOST
+
+// In some versions of Boost (starting with 1.64), you have to include the serialization header before ublas
+#include <boost/serialization/vector.hpp>
+
 #include <boost/multi_array.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
 #endif

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -18,6 +18,10 @@
 #include <array>
 
 #ifdef H5_USE_BOOST
+
+// In some versions of Boost (starting with 1.64), you have to include the serialization header before ublas
+#include <boost/serialization/vector.hpp>
+
 #include <boost/multi_array.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
 #endif

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -19,6 +19,9 @@
 #include <string>
 
 #ifdef H5_USE_BOOST
+// In some versions of Boost (starting with 1.64), you have to include the serialization header before ublas
+#include <boost/serialization/vector.hpp>
+
 #include <boost/multi_array.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
 #endif

--- a/src/examples/boost_ublas_double.cpp
+++ b/src/examples/boost_ublas_double.cpp
@@ -11,6 +11,9 @@
 #undef H5_USE_BOOST
 #define H5_USE_BOOST
 
+// In some versions of Boost (starting with 1.64), you have to include the serialization header before ublas
+#include <boost/serialization/vector.hpp>
+
 #include <boost/numeric/ublas/io.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
 #include <highfive/H5File.hpp>


### PR DESCRIPTION
On some versions of Boost (1.64, at least), you can't import ublas without a specific header first. See [this issue](https://stackoverflow.com/questions/44534516/error-make-array-is-not-a-member-of-boostserialization). This fixes it by importing the extra required header first in HighFive.

Could it be possible to just add definitions instead of importing the boost headers? And then the imports would only be needed in user code if the user actually used the boost features. Not sure if it would work, but it would be much nicer if it did.

PS: Though the issue I linked didn't mention it, for me it seems to not be necessary on Boost 1.68; I only noticed this when running with 1.64.