### PR TITLE
explicitly override std::exception::what()

### DIFF
--- a/include/highfive/H5Exception.hpp
+++ b/include/highfive/H5Exception.hpp
@@ -31,7 +31,7 @@ class Exception : public std::exception {
     /// \brief get the current exception error message
     /// \return
     ///
-    inline virtual const char* what() const throw() { return _errmsg.c_str(); }
+    inline virtual const char* what() const throw() override { return _errmsg.c_str(); }
 
     ///
     /// \brief define the error message

--- a/include/highfive/H5Exception.hpp
+++ b/include/highfive/H5Exception.hpp
@@ -31,7 +31,7 @@ class Exception : public std::exception {
     /// \brief get the current exception error message
     /// \return
     ///
-    inline virtual const char* what() const throw() override { return _errmsg.c_str(); }
+    inline const char* what() const throw() override { return _errmsg.c_str(); }
 
     ///
     /// \brief define the error message


### PR DESCRIPTION
One line fix: clears the (not enabled) `-Wsuggest-override` warnings.