### PR TITLE
Added missing default constructor HighFive::File

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -40,9 +40,11 @@ class File : public Object,
     static const int Create = 0x10;
     /// Derived open flag: common write mode (=ReadWrite | Create | Truncate)
     static const int Overwrite = Truncate;
-    /// Derived open flag: Opens RW or exclusivelly creates
+    /// Derived open flag: Opens RW or exclusively creates
     static const int OpenOrCreate = ReadWrite | Create;
 
+    // Default constructor
+    explicit File() = default;
 
     ///
     /// \brief File


### PR DESCRIPTION
This constructor is needed for example to use `HighFive::File` as a class variable. E.g.

```cpp
class Foo
{
private:

    HighFive::File data;

public:

    Foo(const std::string &fname)
    {
        data = HighFive::File(fname, HighFive::File::ReadOnly);
    }
};