### PR TITLE
Refactoring property lists

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -52,7 +52,7 @@ class File : public Object,
     ///
     /// Open or create a new HDF5 file
     explicit File(const std::string& filename, int openFlags = ReadOnly,
-                  const Properties& fileAccessProps = FileDriver());
+                  const FileAccessProps& fileAccessProps = FileDriver());
 
     ///
     /// \brief Return the name of the file

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -16,12 +16,7 @@ namespace HighFive {
 ///
 /// \brief file driver base concept
 ///
-class FileDriver : public Properties {
-  public:
-    inline FileDriver();
-
-  private:
-};
+class FileDriver : public FileAccessProps {};
 
 ///
 /// \brief MPIIO Driver for Parallel HDF5
@@ -34,7 +29,7 @@ class MPIOFileDriver : public FileDriver {
   private:
 };
 
-} // HighFive
+}  // namespace HighFive
 
 #include "bits/H5FileDriver_misc.hpp"
 

--- a/include/highfive/bits/H5FileDriver_misc.hpp
+++ b/include/highfive/bits/H5FileDriver_misc.hpp
@@ -42,18 +42,13 @@ private:
   Info _info;
 };
 
-// depecrated, use Properties(Properties::FILE_ACCESS) instead
-class DefaultFileDriver : public FileDriver {
-};
-}
-
-// file access property
-inline FileDriver::FileDriver() : Properties(FILE_ACCESS) {}
+}  //namespace
 
 template <typename Comm, typename Info>
 inline MPIOFileDriver::MPIOFileDriver(Comm comm, Info info) {
     add(MPIOFileAccess<Comm, Info>(comm, info));
 }
-}
+
+} // namespace HighFive
 
 #endif // H5FILEDRIVER_MISC_HPP

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -39,7 +39,7 @@ inline int convert_open_flag(int openFlags) {
 }  // namespace
 
 inline File::File(const std::string& filename, int openFlags,
-                  const Properties& fileAccessProps)
+                  const FileAccessProps& fileAccessProps)
     : _filename(filename) {
 
     openFlags = convert_open_flag(openFlags);

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -93,7 +93,7 @@ NodeTraits<Derivate>::getDataSet(const std::string& dataset_name,
 template <typename Derivate>
 inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name,
                                                bool parents) {
-    RawPropertyList lcpl(Properties::LINK_CREATE);
+    RawPropertyList<PropertyType::LINK_CREATE> lcpl;
     if (parents) {
         lcpl.add(H5Pset_create_intermediate_group, 1);
     }

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -16,39 +16,39 @@
 namespace HighFive {
 
 namespace {
-inline hid_t convert_plist_type(Properties::Type propertyType) {
+inline hid_t convert_plist_type(PropertyType propertyType) {
     // The HP5_XXX are macros with function calls so we can't assign
     // them as the enum values
     switch (propertyType) {
-    case Properties::OBJECT_CREATE:
+    case PropertyType::OBJECT_CREATE:
         return H5P_OBJECT_CREATE;
-    case Properties::FILE_CREATE:
+    case PropertyType::FILE_CREATE:
         return H5P_FILE_CREATE;
-    case Properties::FILE_ACCESS:
+    case PropertyType::FILE_ACCESS:
         return H5P_FILE_ACCESS;
-    case Properties::DATASET_CREATE:
+    case PropertyType::DATASET_CREATE:
         return H5P_DATASET_CREATE;
-    case Properties::DATASET_ACCESS:
+    case PropertyType::DATASET_ACCESS:
         return H5P_DATASET_ACCESS;
-    case Properties::DATASET_XFER:
+    case PropertyType::DATASET_XFER:
         return H5P_DATASET_XFER;
-    case Properties::GROUP_CREATE:
+    case PropertyType::GROUP_CREATE:
         return H5P_GROUP_CREATE;
-    case Properties::GROUP_ACCESS:
+    case PropertyType::GROUP_ACCESS:
         return H5P_GROUP_ACCESS;
-    case Properties::DATATYPE_CREATE:
+    case PropertyType::DATATYPE_CREATE:
         return H5P_DATATYPE_CREATE;
-    case Properties::DATATYPE_ACCESS:
+    case PropertyType::DATATYPE_ACCESS:
         return H5P_DATATYPE_ACCESS;
-    case Properties::STRING_CREATE:
+    case PropertyType::STRING_CREATE:
         return H5P_STRING_CREATE;
-    case Properties::ATTRIBUTE_CREATE:
+    case PropertyType::ATTRIBUTE_CREATE:
         return H5P_ATTRIBUTE_CREATE;
-    case Properties::OBJECT_COPY:
+    case PropertyType::OBJECT_COPY:
         return H5P_OBJECT_COPY;
-    case Properties::LINK_CREATE:
+    case PropertyType::LINK_CREATE:
         return H5P_LINK_CREATE;
-    case Properties::LINK_ACCESS:
+    case PropertyType::LINK_ACCESS:
         return H5P_LINK_ACCESS;
     default:
         HDF5ErrMapper::ToException<PropertyException>(
@@ -59,19 +59,19 @@ inline hid_t convert_plist_type(Properties::Type propertyType) {
 
 }  // namespace
 
-inline Properties::Properties(Type type)
-    : _type(type)
-    , _hid(H5P_DEFAULT) {}
+template <PropertyType T>
+inline PropertyList<T>::PropertyList()
+    : _hid(H5P_DEFAULT) {}
 
 #ifdef H5_USE_CXX11
-inline Properties::Properties(Properties&& other)
-    : _type(other._type)
-    , _hid(other._hid) {
+template <PropertyType T>
+inline PropertyList<T>::PropertyList(PropertyList<T>&& other)
+    : _hid(other._hid) {
     other._hid = H5P_DEFAULT;
 }
 
-inline Properties& Properties::operator=(Properties&& other) {
-    _type = other._type;
+template <PropertyType T>
+inline PropertyList<T>& PropertyList<T>::operator=(PropertyList<T>&& other) {
     // This code handles self-assigment without ifs
     const auto hid = other._hid;
     other._hid = H5P_DEFAULT;
@@ -80,36 +80,37 @@ inline Properties& Properties::operator=(Properties&& other) {
 }
 #endif
 
-inline Properties::~Properties() {
+template <PropertyType T>
+inline PropertyList<T>::~PropertyList() {
     // H5P_DEFAULT and H5I_INVALID_HID are not the same Ensuring that ~Object
     if (_hid != H5P_DEFAULT) {
         H5Pclose(_hid);
     }
 }
 
-inline void Properties::_initializeIfNeeded() {
+template <PropertyType T>
+inline void PropertyList<T>::_initializeIfNeeded() {
     if (_hid != H5P_DEFAULT) {
         return;
     }
-    if ((_hid = H5Pcreate(convert_plist_type(_type))) < 0) {
+    if ((_hid = H5Pcreate(convert_plist_type(T))) < 0) {
         HDF5ErrMapper::ToException<PropertyException>(
             "Unable to create property list");
     }
 }
 
-template <typename Property>
-inline void Properties::add(const Property& property) {
+template <PropertyType T>
+template <typename P>
+inline void PropertyList<T>::add(const P& property) {
     _initializeIfNeeded();
     property.apply(_hid);
 }
 
-inline RawPropertyList::RawPropertyList(Type type)
-    : Properties(type) {}
-
-template <typename T, typename... Args>
-inline void RawPropertyList::add(const T& funct, const Args&... args) {
-    _initializeIfNeeded();
-    if (funct(_hid, args...) < 0) {
+template <PropertyType T>
+template <typename F, typename... Args>
+inline void RawPropertyList<T>::add(const F& funct, const Args&... args) {
+    this->_initializeIfNeeded();
+    if (funct(this->_hid, args...) < 0) {
         HDF5ErrMapper::ToException<PropertyException>(
             "Error setting raw hdf5 property.");
     }


### PR DESCRIPTION
To address requests/issues related to Properly lists (e.g. #112) I am refactoring a bit the Properties code. 
This change is the basis to have easily all propertyList types. 

Eventually we could extend the concept further to group several properlylists in an Options object, so that, e.g. DatasetAccess, Create, Xfer that can go to dataset create together as a single object

@hernando since you implemented this part in the first place, do you foresee any problem with this implementation?