### PR TITLE
CMake/PackageConfig.cmake: added support for package version

### DIFF
--- a/CMake/PackageConfig.cmake
+++ b/CMake/PackageConfig.cmake
@@ -11,14 +11,22 @@ if(USE_BOOST)
 endif()
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/highfive
-		DESTINATION ${INCLUDE_INSTALL_DIR})
+  DESTINATION ${INCLUDE_INSTALL_DIR})
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/HighFiveConfig.cmake.in
   ${PROJECT_BINARY_DIR}/HighFiveConfig.cmake
   INSTALL_DESTINATION share/${PROJECT_NAME}/CMake
   )
-install(FILES ${PROJECT_BINARY_DIR}/HighFiveConfig.cmake
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
   DESTINATION share/${PROJECT_NAME}/CMake)
 
 # Generate ${PROJECT_NAME}Targets.cmake; is written after the CMake run

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
-project(HighFive)
 cmake_minimum_required(VERSION 3.0)
+project(HighFive VERSION 2.0)
 
 enable_testing()
-
-set(HIGHFIVE_VERSION_MAJOR 2)
-set(HIGHFIVE_VERSION_MINOR 0)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
   ${PROJECT_SOURCE_DIR}/CMake/portability

--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ HighFive does not require an additional library and supports both HDF5 thread sa
 - (optional) boost >= 1.41
 
 
+### CMake integration
+
+HighFive can easily be used by other C++ CMake projects.
+Below is a very simple *foo* project creating a *bar* C++ program
+using HighFive library:
+
+```cmake
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(foo)
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(HighFive 2.0 REQUIRED)
+add_executable(bar bar.cpp)
+target_include_directories(
+  bar
+  PUBLIC $<TARGET_PROPERTY:HighFive,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(
+  bar
+  PUBLIC $<TARGET_PROPERTY:HighFive,INTERFACE_LINK_LIBRARIES>)
+```
+
 ### Usage
 
 #### Write a std::vector<int> to 1D HDF5 dataset and read it back
@@ -112,7 +133,3 @@ make test
 
 ### License
 Boost Software License 1.0
-
-
-
-


### PR DESCRIPTION
This PR adds support for cmake package version.
The befit is that downstream projects can request a specific version, like
```
find_package(HighFive 2.0.0 REQUIRED)
```