### PR TITLE
Fix MSVC warnings

### DIFF
--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -22,7 +22,7 @@ class DataSpace;
 
 class Attribute : public Object {
   public:
-    size_t getStorageSize() const;
+    hsize_t getStorageSize() const;
 
     ///
     /// \brief getDataType

--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -22,7 +22,7 @@ class DataSpace;
 
 class Attribute : public Object {
   public:
-    hsize_t getStorageSize() const;
+    size_t getStorageSize() const;
 
     ///
     /// \brief getDataType

--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -28,7 +28,17 @@ class DataSet : public Object,
                 public SliceTraits<DataSet>,
                 public AnnotateTraits<DataSet> {
   public:
-    hsize_t getStorageSize() const;
+    ///
+    /// \brief getStorageSize
+    /// \return returns the amount of storage allocated for a dataset.
+    ///
+    uint64_t getStorageSize() const;
+
+    ///
+    /// \brief getOffset
+    /// \return returns DataSet address in file
+    ///
+    uint64_t getOffset() const;
 
     ///
     /// \brief getDataType
@@ -49,12 +59,6 @@ class DataSet : public Object,
     ///
     DataSpace getMemSpace() const;
 
-    ///
-    /// \brief getOffset
-    /// \return returns DataSet address in file
-    /// class
-    ///
-    haddr_t getOffset() const;
 
     /// \brief Change the size of the dataset
     ///

--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -28,7 +28,7 @@ class DataSet : public Object,
                 public SliceTraits<DataSet>,
                 public AnnotateTraits<DataSet> {
   public:
-    size_t getStorageSize() const;
+    hsize_t getStorageSize() const;
 
     ///
     /// \brief getDataType
@@ -54,7 +54,7 @@ class DataSet : public Object,
     /// \return returns DataSet address in file
     /// class
     ///
-    size_t getOffset() const;
+    haddr_t getOffset() const;
 
     /// \brief Change the size of the dataset
     ///

--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -13,10 +13,13 @@
 
 namespace HighFive {
 
+
 template <typename Derivate>
 class NodeTraits;
+
 template <typename Derivate>
 class AnnotateTraits;
+
 
 class Object {
   public:

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -33,7 +33,9 @@ namespace HighFive {
 
 inline Attribute::Attribute() {}
 
-inline hsize_t Attribute::getStorageSize() const { return H5Aget_storage_size(_hid); }
+inline size_t Attribute::getStorageSize() const {
+    return static_cast<size_t>(H5Aget_storage_size(_hid));
+}
 
 inline DataType Attribute::getDataType() const {
     DataType res;

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -33,9 +33,7 @@ namespace HighFive {
 
 inline Attribute::Attribute() {}
 
-inline size_t Attribute::getStorageSize() const {
-    return H5Aget_storage_size(_hid);
-}
+inline hsize_t Attribute::getStorageSize() const { return H5Aget_storage_size(_hid); }
 
 inline DataType Attribute::getDataType() const {
     DataType res;

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -46,7 +46,7 @@ inline bool is_1D(const std::vector<size_t>& dims)
 
 inline size_t compute_total_size(const std::vector<size_t>& dims)
 {
-    return std::accumulate(dims.begin(), dims.end(), 1ul,
+    return std::accumulate(dims.begin(), dims.end(), static_cast<size_t>(1),
                            std::multiplies<size_t>());
 }
 

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -46,7 +46,7 @@ inline bool is_1D(const std::vector<size_t>& dims)
 
 inline size_t compute_total_size(const std::vector<size_t>& dims)
 {
-    return std::accumulate(dims.begin(), dims.end(), static_cast<size_t>(1),
+    return std::accumulate(dims.begin(), dims.end(), 1u,
                            std::multiplies<size_t>());
 }
 

--- a/include/highfive/bits/H5DataSet_misc.hpp
+++ b/include/highfive/bits/H5DataSet_misc.hpp
@@ -33,9 +33,7 @@ namespace HighFive {
 
 inline DataSet::DataSet() {}
 
-inline size_t DataSet::getStorageSize() const {
-    return H5Dget_storage_size(_hid);
-}
+inline hsize_t DataSet::getStorageSize() const { return H5Dget_storage_size(_hid); }
 
 inline DataType DataSet::getDataType() const {
     DataType res;
@@ -54,7 +52,7 @@ inline DataSpace DataSet::getSpace() const {
 
 inline DataSpace DataSet::getMemSpace() const { return getSpace(); }
 
-inline size_t DataSet::getOffset() const {
+inline haddr_t DataSet::getOffset() const {
     haddr_t addr = H5Dget_offset(_hid);
     if (addr == HADDR_UNDEF) {
         HDF5ErrMapper::ToException<DataSetException>(

--- a/include/highfive/bits/H5DataSet_misc.hpp
+++ b/include/highfive/bits/H5DataSet_misc.hpp
@@ -33,7 +33,9 @@ namespace HighFive {
 
 inline DataSet::DataSet() {}
 
-inline hsize_t DataSet::getStorageSize() const { return H5Dget_storage_size(_hid); }
+inline uint64_t DataSet::getStorageSize() const {
+    return H5Dget_storage_size(_hid);
+}
 
 inline DataType DataSet::getDataType() const {
     DataType res;
@@ -50,10 +52,12 @@ inline DataSpace DataSet::getSpace() const {
     return space;
 }
 
-inline DataSpace DataSet::getMemSpace() const { return getSpace(); }
+inline DataSpace DataSet::getMemSpace() const {
+    return getSpace();
+}
 
-inline haddr_t DataSet::getOffset() const {
-    haddr_t addr = H5Dget_offset(_hid);
+inline uint64_t DataSet::getOffset() const {
+    uint64_t addr = H5Dget_offset(_hid);
     if (addr == HADDR_UNDEF) {
         HDF5ErrMapper::ToException<DataSetException>(
             "Cannot get offset of DataSet.");

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -124,10 +124,9 @@ inline std::vector<size_t> DataSpace::getMaxDimensions() const {
             "Unable to get dataspace dimensions");
     }
 
-    std::vector<size_t> res(maxdims.begin(), maxdims.end());
-    std::replace(maxdims.begin(), maxdims.end(),
-                 static_cast<size_t>(H5S_UNLIMITED), DataSpace::UNLIMITED);
-    return res;
+    std::replace(maxdims.begin(), maxdims.end(), H5S_UNLIMITED,
+                 static_cast<hsize_t>(DataSpace::UNLIMITED));
+    return details::to_vector_size_t(maxdims);
 }
 
 template <typename ScalarValue>

--- a/include/highfive/bits/H5Exception_misc.hpp
+++ b/include/highfive/bits/H5Exception_misc.hpp
@@ -44,7 +44,7 @@ struct HDF5ErrMapper {
     }
 
     template <typename ExceptionType>
-    static inline void ToException(const std::string& prefix_msg) {
+    [[noreturn]] static inline void ToException(const std::string& prefix_msg) {
 
         hid_t err_stack = H5Eget_current_stack();
         if (err_stack >= 0) {

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -126,7 +126,7 @@ inline size_t NodeTraits<Derivate>::getNumberObjects() const {
         HDF5ErrMapper::ToException<GroupException>(
             std::string("Unable to count objects in existing group or file"));
     }
-    return res;
+    return static_cast<size_t>(res);
 }
 
 template <typename Derivate>

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -54,7 +54,6 @@ inline hid_t convert_plist_type(PropertyType propertyType) {
         HDF5ErrMapper::ToException<PropertyException>(
             "Unsupported property list type");
     }
-    return -1;
 }
 
 }  // namespace

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -10,6 +10,7 @@
 #define H5UTILS_HPP
 
 // internal utilities functions
+#include <algorithm>
 #include <cstddef> // __GLIBCXX__
 #include <exception>
 #include <memory>
@@ -168,8 +169,9 @@ struct is_c_array<T[N]> {
 template<typename Size>
 inline std::vector<std::size_t> to_vector_size_t(std::vector<Size> vec){
     static_assert(std::is_same<Size, std::size_t>::value == false, " hsize_t != size_t mandatory here");
-    std::vector<size_t> res(vec.size());
-    std::copy(vec.begin(), vec.end(), res.begin());
+    std::vector<size_t> res;
+    res.reserve(vec.size());
+    std::transform(vec.begin(), vec.end(), std::back_inserter(res), [](hsize_t e) { return static_cast<size_t>(e);  });
     return res;
 }
 

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -169,9 +169,8 @@ struct is_c_array<T[N]> {
 template<typename Size>
 inline std::vector<std::size_t> to_vector_size_t(std::vector<Size> vec){
     static_assert(std::is_same<Size, std::size_t>::value == false, " hsize_t != size_t mandatory here");
-    std::vector<size_t> res;
-    res.reserve(vec.size());
-    std::transform(vec.begin(), vec.end(), std::back_inserter(res), [](hsize_t e) { return static_cast<size_t>(e);  });
+    std::vector<size_t> res(vec.size());
+    std::transform(vec.begin(), vec.end(), res.begin(), [](Size e) { return static_cast<size_t>(e); });
     return res;
 }
 


### PR DESCRIPTION
This fixes all remaining MSVC type conversion warnings (both x64 and x32
build) and one "code unreachable" warning (by marking
HDF5ErrMapper::ToException as [[noreturn]]).
    
Also, in DataSpace::getMaxDimensions it fixes the H5S_UNLIMITED ->
DataSpace::UNLIMITED replacement to work on the correct vector.
    
Fixes #164