### PR TITLE
H5Easy: fix compatibility with MSVC

### DIFF
--- a/include/highfive/bits/H5Easy_misc.hpp
+++ b/include/highfive/bits/H5Easy_misc.hpp
@@ -59,7 +59,7 @@ inline void createGroupsToDataSet(File& file, const std::string& path)
 {
     std::string group_name = getParentName(path);
 
-    if (not file.exist(group_name)) {
+    if (!file.exist(group_name)) {
         file.createGroup(group_name);
     }
 }


### PR DESCRIPTION
The file `H5Easy_misc.hpp` is using the alternate form of the not operator, `not` instead of `!`. While this is valid C++, it is not valid C, and requires MSVC to be put into a standards-conforming mode (`/permissive-`) that is not compatible with some Windows headers. (See [here](https://stackoverflow.com/questions/24414124/why-does-vs-not-define-the-alternative-tokens-for-logical-operators) and [there](https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=vs-2019))

To keep to compatibility high, I would therefore suggest to use the traditional form of `not` instead.