### PR TITLE
Fix another MSVC warnings when building for win32

### DIFF
--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -46,7 +46,7 @@ inline bool is_1D(const std::vector<size_t>& dims)
 
 inline size_t compute_total_size(const std::vector<size_t>& dims)
 {
-    return std::accumulate(dims.begin(), dims.end(), 1u,
+    return std::accumulate(dims.begin(), dims.end(), size_t{1u},
                            std::multiplies<size_t>());
 }
 

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -114,7 +114,8 @@ inline std::vector<size_t> DataSpace::getDimensions() const {
 
 inline size_t DataSpace::getElementCount() const {
     std::vector<size_t> dims = getDimensions();
-    return std::accumulate(dims.begin(), dims.end(), size_t(1), std::multiplies<size_t>());
+    return std::accumulate(dims.begin(), dims.end(), size_t{1u},
+                           std::multiplies<size_t>());
 }
 
 inline std::vector<size_t> DataSpace::getMaxDimensions() const {


### PR DESCRIPTION
After PR #169 there is still a warning remaining when building for win32
where sizeof(size_t) > sizeof(unsigned int). Fix it by using brace
initialization which requires that the value inside is exactly
representable in size_t. This is better than the static_cast used in the
initial version of PR #169.