### PR TITLE
 workaround for Travis OSX build failures 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,9 +90,9 @@ matrix:
           - hdf5
           - eigen
           - ninja
-        # Temporary workaround to Max OS builds failing 
-        # Same issue seen here: https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798
-        update: true
+          # Temporary workaround to Max OS builds failing
+          # Same issue seen here: https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798
+          update: true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,9 @@ matrix:
           - hdf5
           - eigen
           - ninja
+        # Temporary workaround to Max OS builds failing 
+        # Same issue seen here: https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798
+        update: true
 
 env:
   global:


### PR DESCRIPTION
Travis OSX builds are failing for some reason due to an error from homebrew.

See the following links for people discussing this at the travis community page:
* here: https://travis-ci.community/t/xcode-8-3-homebrew-outdated-error/3798
* https://travis-ci.community/t/issue-brew-formula-installation-fails-due-to-being-outdated/3872
* https://travis-ci.community/t/previously-working-build-failing-with-services-are-not-supported-on-osx/3960/2
* https://travis-ci.community/t/osx-homebrew-addons-module-not-as-reliable-as-claimed/4054