### PR TITLE
Dropping invalid MSVC C++11 flag. Assume support

### DIFF
--- a/CMake/portability/CheckCXXStandardSupport.cmake
+++ b/CMake/portability/CheckCXXStandardSupport.cmake
@@ -11,7 +11,9 @@ if(${CMAKE_VERSION} VERSION_LESS 3.10)
         set(CMAKE_CXX14_STANDARD_COMPILE_OPTION "-std=c++14")
         set(CMAKE_CXX17_STANDARD_COMPILE_OPTION "-std=c++17")
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        set(CMAKE_CXX11_STANDARD_COMPILE_OPTION "/std:c++11")
+        # MSVC Supports some c++11 features since long time, way before language levels
+        set(CMAKE_CXX11_STANDARD_COMPILE_OPTION "")
+        # VS 2015u3 understands these flags and is the first to support C++14 
         set(CMAKE_CXX14_STANDARD_COMPILE_OPTION "/std:c++14")
         set(CMAKE_CXX17_STANDARD_COMPILE_OPTION "/std:c++17")
     endif()


### PR DESCRIPTION
Since some c++11 features are supported since old MSVC versions,
even before -std flags, we let the compiler attempt to compile.
For C++14 and 17 we depend on the -std flags which is ok since 2015u3
understands them and 2015 is the first with c++14 support

Source: https://en.cppreference.com/w/cpp/compiler_support

Fixes #190 