### PR TITLE
Fix MSVC issue with 2D Vectors

### DIFF
--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -73,17 +73,17 @@ inline void vectors_to_single_buffer(const std::vector<T>& vec_single_dim,
     buffer.insert(buffer.end(), vec_single_dim.begin(), vec_single_dim.end());
 }
 
-template <typename T>
+template <typename T, typename U = typename type_of_array<T>::type>
 inline void
 vectors_to_single_buffer(const std::vector<T>& vec_multi_dim,
-                         const std::vector<size_t>& dims, size_t current_dim,
-                         std::vector<typename type_of_array<T>::type>& buffer) {
+                         const std::vector<size_t>& dims,
+                         size_t current_dim,
+                         std::vector<U>& buffer) {
 
     check_dimensions_vector(vec_multi_dim.size(), dims[current_dim],
                             current_dim);
-    for (typename std::vector<T>::const_iterator it = vec_multi_dim.begin();
-         it < vec_multi_dim.end(); ++it) {
-        vectors_to_single_buffer(*it, dims, current_dim + 1, buffer);
+    for (const auto& it : vec_multi_dim) {
+        vectors_to_single_buffer(it, dims, current_dim + 1, buffer);
     }
 }
 


### PR DESCRIPTION
Change signature of the functions to force a different name mangling which allows MSVC to compile the code. The issue, according to what I've been able to find, is that MSVC cannot disambiguate between a const vs non const function parameter when doing name mangling. Clang and GCC use a different mangling and are able to tell the difference and as such can disambiguate between the candidates. GCC and Clang have conforming behavior and MSVC does not.

Fixes #171 and #104

I reported the issue to Microsoft here https://developercommunity.visualstudio.com/content/problem/736092/standards-conforming-code-returns-c2668-ambiguous.html
It is highly unlikely that MS will be able to fix this issue as it is core to how their name mangling works and likely would cause ABI issues to make changes.
