### PR TITLE
Making optional Boost dependency non-default (fixes #196)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,7 @@ script:
   - mkdir -p build && pushd build
   - >
     cmake --warn-uninitialized
+    -DUSE_BOOST=TRUE
     -DUSE_EIGEN:BOOL=ON
     -DEigen3_DIR=/usr/lib/cmake/eigen3
     -DUSE_XTENSOR:BOOL=${USE_XTENSOR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT COMPILER_SUPPORTS_CXX11)
 endif()
 
 option(HIGHFIVE_UNIT_TESTS "enable unit tests" TRUE)
-option(USE_BOOST "enable Boost Support" TRUE)
+option(USE_BOOST "enable Boost Support" FALSE)
 option(USE_EIGEN "enable Eigen testing" FALSE)
 option(USE_XTENSOR "enable xtensor testing" FALSE)
 option(HIGHFIVE_EXAMPLES "Compile examples" TRUE)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ HighFive does not require an additional library and supports both HDF5 thread sa
 
 
 ### Design
+
 - Simple C++-ish minimalist interface
 - No other dependency than libhdf5
 - Zero overhead
@@ -20,9 +21,9 @@ HighFive does not require an additional library and supports both HDF5 thread sa
 
 
 ### Dependencies
-- libhdf5
-- (optional) boost >= 1.41
 
+- libhdf5
+- boost >= 1.41 (optional, enable CMake option `USE_BOOST`)
 
 ### CMake integration
 
@@ -162,6 +163,7 @@ make test
 
 
 ### Contributors
+
 - Adrien Devresse <adrien.devresse@epfl.ch> - Blue Brain Project
 - Ali Can Demiralp <demiralpali@gmail.com> -
 - Fernando Pereira <fernando.pereira@epfl.ch> - Blue Brain Project
@@ -171,4 +173,5 @@ make test
 - Tom de Geus <tom@geus.me> - EPFL
 
 ### License
+
 Boost Software License 1.0


### PR DESCRIPTION
Making optional Boost dependency non-default in CMake test/installation.

Fixes #196 