### PR TITLE
Fixing CI - switched to correct Conda channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,10 +111,9 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda install cmake -c conda-forge
-  - conda install xtl -c QuantStack
-  - conda install xsimd -c QuantStack
-  - conda install xtensor -c QuantStack
-  - conda install nlohmann_json -c QuantStack
+  - conda install xtl -c conda-forge
+  - conda install xsimd -c conda-forge
+  - conda install xtensor -c conda-forge
 
 before_script:
   - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi


### PR DESCRIPTION
The QuantStack channel on conda was merged into the conda-forge channel. The QuantStack channel was removed: trying to use it results in an error: https://travis-ci.org/BlueBrain/HighFive