### PR TITLE
Getting type info and object kind

### DIFF
--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -13,7 +13,24 @@
 
 namespace HighFive {
 
-struct TypeMapper;
+
+///
+/// \brief Fundamental Type classes
+enum class DataTypeClass {
+    Time,
+    Integer,
+    Float,
+    String,
+    BitField,
+    Opaque,
+    Compound,
+    Reference,
+    Enum,
+    VarLen,
+    Array,
+    Invalid
+};
+
 
 ///
 /// \brief HDF5 Data Type
@@ -25,6 +42,25 @@ class DataType : public Object {
     bool operator==(const DataType& other) const;
 
     bool operator!=(const DataType& other) const;
+
+    ///
+    /// \brief Return the fundamental type.
+    ///
+    DataTypeClass getClass() const;
+
+    ///
+    /// \brief Returns the length (in bytes) of this type elements
+    ///
+    /// Notice that the size of variable length sequences may have limited applicability
+    ///   given that it refers to the size of the control structure. For info see
+    ///   https://support.hdfgroup.org/HDF5/doc/RM/RM_H5T.html#Datatype-GetSize
+    ///
+    size_t getSize() const;
+
+    ///
+    /// \brief string() returns a friendly description of the type (e.g. Float32)
+    ///
+    std::string string() const;
 
   protected:
     friend class Attribute;

--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -10,6 +10,8 @@
 #define H5OBJECT_HPP
 
 #include <H5Ipublic.h>
+#include <H5Opublic.h>
+#include <ctime>
 
 namespace HighFive {
 
@@ -19,6 +21,18 @@ class NodeTraits;
 
 template <typename Derivate>
 class AnnotateTraits;
+
+class ObjectInfo;
+
+enum class ObjectType {
+    Invalid = -1,
+    File,
+    Group,
+    UserDataType,
+    DataSpace,
+    Dataset,
+    Attribute
+};
 
 
 class Object {
@@ -39,6 +53,17 @@ class Object {
     ///
     hid_t getId() const;
 
+    ///
+    /// \brief getInfo
+    /// \return Obtains several infos about the object
+    ///
+    ObjectInfo getInfo() const;
+
+    ///
+    /// \brief Gets the fundamental type of the object (dataset, group,...)
+    ///
+    ObjectType getType() const;
+
   protected:
     // empty constructor
     Object();
@@ -51,12 +76,33 @@ class Object {
     hid_t _hid;
 
   private:
+    // Init with an low-level object id
+    Object(hid_t);
+
     template <typename Derivate>
     friend class NodeTraits;
     template <typename Derivate>
     friend class AnnotateTraits;
 };
-}
+
+
+class ObjectInfo  {
+  public:
+    haddr_t getAddress() const noexcept;
+
+    size_t referenceCount() const noexcept;
+
+    std::time_t creationTime() const noexcept;
+
+    std::time_t modificationTime() const noexcept;
+
+  protected:
+    H5O_info_t raw_info;
+
+    friend class Object;
+};
+
+}  // namespace HighFive
 
 #include "bits/H5Object_misc.hpp"
 

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -17,9 +17,24 @@
 
 #include <H5Tpublic.h>
 
+
 namespace HighFive {
 
+namespace {  // unnamed
+inline DataTypeClass convert_type_class(const H5T_class_t& tclass);
+inline std::string type_class_string(DataTypeClass);
+}
+
+
 inline DataType::DataType() {}
+
+inline DataTypeClass DataType::getClass() const {
+    return convert_type_class(H5Tget_class(_hid));
+}
+
+inline size_t DataType::getSize() const {
+    return H5Tget_size(_hid);
+}
 
 inline bool DataType::operator==(const DataType& other) const {
     return (H5Tequal(_hid, other._hid) > 0);
@@ -28,6 +43,11 @@ inline bool DataType::operator==(const DataType& other) const {
 inline bool DataType::operator!=(const DataType& other) const {
     return !(*this == other);
 }
+
+inline std::string DataType::string() const {
+    return type_class_string(getClass()) + std::to_string(getSize() * 8);
+}
+
 
 // char mapping
 template <>
@@ -134,8 +154,74 @@ inline AtomicType<std::complex<double> >::AtomicType()
     _hid = H5Tcopy(complexType.getId());
 }
 
+
+namespace {
+
+inline DataTypeClass convert_type_class(const H5T_class_t& tclass) {
+    switch(tclass) {
+        case H5T_TIME:
+            return DataTypeClass::Time;
+        case H5T_INTEGER:
+            return DataTypeClass::Integer;
+        case H5T_FLOAT:
+            return DataTypeClass::Float;
+        case H5T_STRING:
+            return DataTypeClass::String;
+        case H5T_BITFIELD:
+            return DataTypeClass::BitField;
+        case H5T_OPAQUE:
+            return DataTypeClass::Opaque;
+        case H5T_COMPOUND:
+            return DataTypeClass::Compound;
+        case H5T_REFERENCE:
+            return DataTypeClass::Reference;
+        case H5T_ENUM:
+            return DataTypeClass::Enum;
+        case H5T_VLEN:
+            return DataTypeClass::VarLen;
+        case H5T_ARRAY:
+            return DataTypeClass::Array;
+        case H5T_NO_CLASS:
+        case H5T_NCLASSES:
+        default:
+            return DataTypeClass::Invalid;
+    }
 }
 
+
+inline std::string type_class_string(DataTypeClass tclass) {
+    switch(tclass) {
+        case DataTypeClass::Time:
+            return "Time";
+        case DataTypeClass::Integer:
+            return "Integer";
+        case DataTypeClass::Float:
+            return "Float";
+        case DataTypeClass::String:
+            return "String";
+        case DataTypeClass::BitField:
+            return "BitField";
+        case DataTypeClass::Opaque:
+            return "Opaque";
+        case DataTypeClass::Compound:
+            return "Compound";
+        case DataTypeClass::Reference:
+            return "Reference";
+        case DataTypeClass::Enum:
+            return "Enum";
+        case DataTypeClass::VarLen:
+            return "Varlen";
+        case DataTypeClass::Array:
+            return "Array";
+        case DataTypeClass::Invalid:
+            return "(Invalid)";
+    }
+}
+
+}  // namespace
+
+
+}  // namespace HighFive
 
 
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -19,6 +19,9 @@ class Group;
 class DataSpace;
 class DataType;
 
+enum class LinkType;
+
+
 template <typename Derivate>
 class NodeTraits {
   public:
@@ -114,12 +117,31 @@ class NodeTraits {
     /// false
     bool exist(const std::string& node_name) const;
 
+    /// \brief Returns the kind of link of the given name (soft, hard...)
+    LinkType getLinkType(const std::string& node_name) const;
+
+    /// \brief A shorthand to get the kind of object pointed to (group, dataset, type...)
+    inline ObjectType getObjectType(const std::string& node_name) const;
+
+
   private:
     typedef Derivate derivate_type;
 
     // A wrapper over the low-level H5Lexist
     bool _exist(const std::string& node_name) const;
+
+    // Opens an arbitrary object to obtain info
+    Object _open(const std::string& node_name,
+                 const DataSetAccessProps& accessProps=DataSetAccessProps()) const;
 };
+
+
+enum class LinkType {
+    Hard,
+    Soft,
+    External
+};
+
 
 }  // namespace HighFive
 

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -30,7 +30,10 @@
 #include <H5Ppublic.h>
 #include <H5Tpublic.h>
 
+
+
 namespace HighFive {
+
 
 template <typename Derivate>
 inline DataSet
@@ -197,6 +200,57 @@ inline bool NodeTraits<Derivate>::exist(const std::string& group_path) const {
     }
     return _exist(group_path);
 }
+
+
+static inline LinkType _convert_link_type(const H5L_type_t& ltype) {
+    switch (ltype) {
+        case H5L_TYPE_HARD:
+            return LinkType::Hard;
+        case H5L_TYPE_SOFT:
+            return LinkType::Hard;
+        case H5L_TYPE_EXTERNAL:
+            return LinkType::Hard;
+        default:
+            throw std::invalid_argument("Invalid Link type ");
+    }
+}
+
+template <typename Derivate>
+inline LinkType NodeTraits<Derivate>::getLinkType(const std::string& node_name) const {
+    H5L_info_t linkinfo;
+    H5Lget_info(static_cast<const Derivate*>(this)->getId(),
+                node_name.c_str(),
+                &linkinfo,
+                H5P_DEFAULT);
+    if (linkinfo.type == H5L_TYPE_ERROR) {
+        HDF5ErrMapper::ToException<GroupException>(
+            std::string("Unable to obtain info for link ") + node_name);
+    }
+    return _convert_link_type(linkinfo.type);
+}
+
+template <typename Derivate>
+inline ObjectType NodeTraits<Derivate>::getObjectType(const std::string& node_name) const {
+    return _open(node_name).getType();
+}
+
+
+template <typename Derivate>
+inline Object NodeTraits<Derivate>::_open(const std::string& node_name,
+                                          const DataSetAccessProps& accessProps) const {
+    hid_t id = H5Oopen(static_cast<const Derivate*>(this)->getId(),
+                       node_name.c_str(),
+                       accessProps.getId());
+    if (id < 0) {
+        HDF5ErrMapper::ToException<GroupException>(
+            std::string("Unable to open \"") + node_name + "\":");
+    }
+    return Object(id);
+}
+
+
+
+
 
 }  // namespace HighFive
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1072,3 +1072,31 @@ BOOST_AUTO_TEST_CASE(HighFiveRecursiveGroups) {
     // Using root slash
     BOOST_CHECK(file.exist(std::string("/") + DS_PATH));
 }
+
+
+BOOST_AUTO_TEST_CASE(HighFiveInspect) {
+    const std::string FILE_NAME("group_info.h5");
+    const std::string GROUP_1("group1");
+    const std::string DS_NAME = "ds";
+
+    // Create a new file using the default property lists.
+    File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+    Group g = file.createGroup(GROUP_1);
+
+    std::vector<double> some_data{5.0, 6.0, 7.0};
+    g.createDataSet(DS_NAME, some_data);
+
+    BOOST_CHECK(file.getLinkType("group1") == LinkType::Hard);
+    BOOST_CHECK(file.getObjectType("group1") == ObjectType::Group);
+    BOOST_CHECK(file.getObjectType("group1/ds") == ObjectType::Dataset);
+    BOOST_CHECK(g.getObjectType("ds") == ObjectType::Dataset);
+
+    BOOST_CHECK_THROW(file.getObjectType("ds"), HighFive::GroupException);
+
+    // Data type
+    auto dt = g.getDataSet("ds").getDataType();
+    BOOST_CHECK(dt.getClass() == DataTypeClass::Float);
+    BOOST_CHECK(dt.getSize() == 8);
+    BOOST_CHECK(dt.string() == "Float64");
+
+}


### PR DESCRIPTION
This PR implements some inspection mechanisms, namely for 
- the type of objects in a "Node"
- The data type of a 

### Type of objects
hdf5, since version 1.8 deprecates treating link types and object types together and makes a clear distinction of the two concepts. Therefore a "name" can be described in two ways:
- What kind of link it is (hard, soft, external)
- What kind of object it addresses (a group, dataset, user type...)

As so, two API functions were created for Nodes:
 - `getLinkType(string)`
 - `getObjectType(string)`

**Example**
```
BOOST_CHECK(file.getLinkType("group1") == LinkType::Hard);
BOOST_CHECK(file.getObjectType("group1") == ObjectType::Group);
```
As aux private API, a `getType()` was added to Object to help obtaining the object type from any hdf5 object addressed with an hid

### Data Type
To obtain data types, only a few functions were added to `H5DataType`, namely:
- `DataTypeClass getClass();` // fundamental type
- `size_t getSize() const;`  // byte size
- `std::string string() const;`  // string representation

**Example**
```
auto dt = g.getDataSet("ds").getDataType();
BOOST_CHECK(dt.getClass() == DataTypeClass::Float);
BOOST_CHECK(dt.getSize() == 8);
BOOST_CHECK(dt.string() == "Float64");
```
Fixes #178 
Fixes #209