### PR TITLE
Avoid conversion warnings being treated as errors

### DIFF
--- a/CMake/config/CompilerFlagsHelpers.cmake
+++ b/CMake/config/CompilerFlagsHelpers.cmake
@@ -83,7 +83,10 @@ foreach(COMPILER_LANGUAGE ${SUPPORTED_COMPILER_LANGUAGE_LIST})
 
 	## GCC, CLANG, rest of the world
 	else()
-		set(CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL "-Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wcast-align -Wunused -Woverloaded-virtual -Wpedantic -Wdouble-promotion -Wformat=2 -Wconversion -Wsign-conversion")
+		string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL
+			" -Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wcast-align -Wunused -Woverloaded-virtual"
+			" -Wpedantic -Wdouble-promotion -Wformat=2 -Wconversion -Wsign-conversion"
+		    " -Wno-error=conversion -Wno-error=sign-conversion")  # Too common to be considered errors
 
 		set(CMAKE_${COMPILER_LANGUAGE}_DEBUGINFO_FLAGS "-g")
 

--- a/CMake/config/CompilerFlagsHelpers.cmake
+++ b/CMake/config/CompilerFlagsHelpers.cmake
@@ -86,7 +86,7 @@ foreach(COMPILER_LANGUAGE ${SUPPORTED_COMPILER_LANGUAGE_LIST})
 		string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL
 			" -Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wunused -Woverloaded-virtual"
 			" -Wformat=2 -Wconversion -Wsign-conversion"
-		    " -Wno-error=conversion -Wno-error=sign-conversion")  # Too common to be considered errors
+		        " -Wno-error=conversion -Wno-error=sign-conversion")  # Too common to be considered errors
 		if(NOT CMAKE_${COMPILER_LANGUAGE}_COMPILER_IS_ICC)
 			string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL " -Wcast-align -Wpedantic -Wdouble-promotion")
 		endif()

--- a/CMake/config/CompilerFlagsHelpers.cmake
+++ b/CMake/config/CompilerFlagsHelpers.cmake
@@ -86,7 +86,7 @@ foreach(COMPILER_LANGUAGE ${SUPPORTED_COMPILER_LANGUAGE_LIST})
 		string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL
 			" -Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wunused -Woverloaded-virtual"
 			" -Wformat=2 -Wconversion -Wsign-conversion"
-		        " -Wno-error=conversion -Wno-error=sign-conversion")  # Too common to be considered errors
+			" -Wno-error=conversion -Wno-error=sign-conversion")  # Too common to be considered errors
 		if(NOT CMAKE_${COMPILER_LANGUAGE}_COMPILER_IS_ICC)
 			string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL " -Wcast-align -Wpedantic -Wdouble-promotion")
 		endif()

--- a/CMake/config/CompilerFlagsHelpers.cmake
+++ b/CMake/config/CompilerFlagsHelpers.cmake
@@ -84,9 +84,12 @@ foreach(COMPILER_LANGUAGE ${SUPPORTED_COMPILER_LANGUAGE_LIST})
 	## GCC, CLANG, rest of the world
 	else()
 		string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL
-			" -Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wcast-align -Wunused -Woverloaded-virtual"
-			" -Wpedantic -Wdouble-promotion -Wformat=2 -Wconversion -Wsign-conversion"
+			" -Wall -Wextra -Werror -Wshadow -Wnon-virtual-dtor -Wunused -Woverloaded-virtual"
+			" -Wformat=2 -Wconversion -Wsign-conversion"
 		    " -Wno-error=conversion -Wno-error=sign-conversion")  # Too common to be considered errors
+		if(NOT CMAKE_${COMPILER_LANGUAGE}_COMPILER_IS_ICC)
+			string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL "-Wcast-align -Wpedantic -Wdouble-promotion")
+		endif()
 
 		set(CMAKE_${COMPILER_LANGUAGE}_DEBUGINFO_FLAGS "-g")
 

--- a/CMake/config/CompilerFlagsHelpers.cmake
+++ b/CMake/config/CompilerFlagsHelpers.cmake
@@ -88,7 +88,7 @@ foreach(COMPILER_LANGUAGE ${SUPPORTED_COMPILER_LANGUAGE_LIST})
 			" -Wformat=2 -Wconversion -Wsign-conversion"
 		    " -Wno-error=conversion -Wno-error=sign-conversion")  # Too common to be considered errors
 		if(NOT CMAKE_${COMPILER_LANGUAGE}_COMPILER_IS_ICC)
-			string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL "-Wcast-align -Wpedantic -Wdouble-promotion")
+			string(APPEND CMAKE_${COMPILER_LANGUAGE}_WARNING_ALL " -Wcast-align -Wpedantic -Wdouble-promotion")
 		endif()
 
 		set(CMAKE_${COMPILER_LANGUAGE}_DEBUGINFO_FLAGS "-g")


### PR DESCRIPTION
Conversion warnings are too common to be treated as errors (since we use -Werror). Such warnings are even found within boost libraries, so there is no way around.
This patch simply turns them non-errors again. The warnings are still raised.
Also, avoiding passing unknown options to ICC.
Fixes #243 