### PR TITLE
Missing semicolon

### DIFF
--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -13,6 +13,13 @@
 #include <vector>
 #include <boost/mpl/list.hpp>
 
+// Since, 1.59: semicolon has been removed from the end of the BOOST_GLOBAL_FIXTURE
+// https://github.com/boostorg/test/commit/3f7216db3db2e11a768d8d0c8bb18632f106c466
+#if BOOST_VERSION >= 105900
+#define BOOST_GLOBAL_FIXTURE_END ;
+#else
+#define BOOST_GLOBAL_FIXTURE_END
+#endif
 
 using complex = std::complex<double>;
 

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -34,7 +34,7 @@ struct MpiFixture {
     ~MpiFixture() { MPI_Finalize(); }
 };
 
-BOOST_GLOBAL_FIXTURE(MpiFixture)
+BOOST_GLOBAL_FIXTURE(MpiFixture);
 
 
 template <typename T>

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -35,9 +35,7 @@ struct MpiFixture {
 };
 
 BOOST_GLOBAL_FIXTURE(MpiFixture)
-#if BOOST_VERSION >= 105900
-;
-#endif
+BOOST_GLOBAL_FIXTURE_END
 
 template <typename T>
 void selectionArraySimpleTestParallel() {

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -36,7 +36,7 @@ struct MpiFixture {
 
 BOOST_GLOBAL_FIXTURE(MpiFixture)
 #if BOOST_VERSION >= 105900
-#then ;
+;
 #endif
 
 template <typename T>

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -34,8 +34,10 @@ struct MpiFixture {
     ~MpiFixture() { MPI_Finalize(); }
 };
 
-BOOST_GLOBAL_FIXTURE(MpiFixture);
-
+BOOST_GLOBAL_FIXTURE(MpiFixture)
+#if BOOST_VERSION >= 105900
+#then ;
+#endif
 
 template <typename T>
 void selectionArraySimpleTestParallel() {


### PR DESCRIPTION
Without the semicolon building HighFive fails with:
```
HighFive/tests/unit/tests_high_five_parallel.cpp:40:1: error: expected initializer before ‘template’
   40 | template <typename T>
```

Tested with `gcc 9.2.1` and `boost 1.67.0.2`.