### PR TITLE
Remove old "using namespace"

### DIFF
--- a/include/highfive/H5Exception.hpp
+++ b/include/highfive/H5Exception.hpp
@@ -9,6 +9,7 @@
 #ifndef H5EXCEPTION_HPP
 #define H5EXCEPTION_HPP
 
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -64,7 +65,7 @@ class Exception : public std::exception {
 
   protected:
     std::string _errmsg;
-    details::Mem::shared_ptr<Exception> _next;
+    std::shared_ptr<Exception> _next;
     hid_t _err_major, _err_minor;
 
     friend struct HDF5ErrMapper;

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -14,7 +14,6 @@
 #include <array>
 #include <cstddef> // __GLIBCXX__
 #include <exception>
-#include <memory>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -193,12 +192,6 @@ inline std::vector<std::size_t> to_vector_size_t(std::vector<Size> vec){
 inline std::vector<std::size_t> to_vector_size_t(std::vector<std::size_t> vec){
     return vec;
 }
-
-// shared ptr portability
-// was used pre-C++11, kept for compatibility
-namespace Mem {
-    using namespace std;
-} // end Mem
 
 } // end details
 }


### PR DESCRIPTION
It is written "kept for compatibility" but it's use only in a private part and declare in "details" namespace.