### PR TITLE
Support for Fixed-length strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if(NOT COMPILER_SUPPORTS_CXX11)
   message(FATAL_ERROR "HighFive version >= 2.0 requires c++ standard >= c++11")
 endif()
 
-
 # Compat within Highfive 2.x series
 set(USE_BOOST ON CACHE BOOL "Enable Boost Support")
 set(USE_EIGEN OFF CACHE BOOL "Enable Eigen testing")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ if(NOT COMPILER_SUPPORTS_CXX11)
   message(FATAL_ERROR "HighFive version >= 2.0 requires c++ standard >= c++11")
 endif()
 
+add_definitions("-ferror-limit=1")
+
 # Compat within Highfive 2.x series
 set(USE_BOOST ON CACHE BOOL "Enable Boost Support")
 set(USE_EIGEN OFF CACHE BOOL "Enable Eigen testing")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ if(NOT COMPILER_SUPPORTS_CXX11)
   message(FATAL_ERROR "HighFive version >= 2.0 requires c++ standard >= c++11")
 endif()
 
-add_definitions("-ferror-limit=1")
 
 # Compat within Highfive 2.x series
 set(USE_BOOST ON CACHE BOOL "Enable Boost Support")

--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -122,6 +122,9 @@ class DataSpace : public Object {
     template <typename Value, std::size_t N>
     static DataSpace From(const std::array<Value, N>&);
 
+    template <typename ValueT, std::size_t N>
+    static DataSpace From(const ValueT(&container)[N]);
+
 
 #ifdef H5_USE_BOOST
     template <typename Value, std::size_t Dims>

--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -125,6 +125,8 @@ class DataSpace : public Object {
     template <typename ValueT, std::size_t N>
     static DataSpace From(const ValueT(&container)[N]);
 
+    template <std::size_t N, std::size_t Width>
+    static DataSpace FromCharArrayStrings(const char(&)[N][Width]);
 
 #ifdef H5_USE_BOOST
     template <typename Value, std::size_t Dims>

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -132,15 +132,24 @@ class FixedLenStringArray {
     std::string getString(std::size_t index) const;
 
     // Container interface
-    inline const char* operator[](std::size_t i) const { return datavec[i].data(); }
+    inline const char* operator[](std::size_t i) const noexcept { return datavec[i].data(); }
     inline const char* at(std::size_t i) const { return datavec.at(i).data(); }
     inline bool empty() const noexcept { return datavec.empty(); }
     inline std::size_t size() const noexcept { return datavec.size(); }
-    inline void resize(std::size_t i) { datavec.resize(i); }
+    inline void resize(std::size_t n) { datavec.resize(n); }
     inline const char* front() const { return datavec.front().data(); }
     inline const char* back() const { return datavec.back().data(); }
     inline char* data() noexcept { return datavec[0].data(); }
     inline const char* data() const noexcept { return datavec[0].data(); }
+    // Use the underlying iterator
+    typedef typename std::vector<std::array<char, N>>::iterator iterator;
+    typedef typename std::vector<std::array<char, N>>::const_iterator const_iterator;
+    inline iterator begin() noexcept { return datavec.begin(); }
+    inline iterator end() noexcept { return datavec.end(); }
+    inline const_iterator begin() const noexcept { return datavec.begin(); }
+    inline const_iterator cbegin() const noexcept { return datavec.cbegin(); }
+    inline const_iterator end() const noexcept { return datavec.end(); }
+    inline const_iterator cend() const noexcept { return datavec.cend(); }
 
   private:
     typedef typename std::vector<std::array<char, N>> vector_t;

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -92,7 +92,58 @@ class AtomicType : public DataType {
 
     typedef T basic_type;
 };
-}
+
+
+///
+/// \brief A structure representing a set of fixed-length strings
+///
+/// Although fixed-len arrays can be created 'raw' without the need for
+/// this structure, to retrieve results efficiently it must be used.
+///
+template <std::size_t N>
+class FixedLenStringArray {
+  public:
+    inline FixedLenStringArray() {};
+
+    ///
+    /// \brief Create a FixedStringArray from a raw contiguous buffer
+    ///
+    FixedLenStringArray(const char array[][N], std::size_t length);
+
+    ///
+    /// \brief Create a FixedStringArray from a sequence of strings.
+    ///
+    /// Such conversion involves a copy, original vector is not modified
+    ///
+    FixedLenStringArray(const std::string* iter_begin, const std::string* iter_end);
+
+    FixedLenStringArray(const std::vector<std::string> & vec);
+
+    FixedLenStringArray(const std::initializer_list<std::string> &);
+
+    ///
+    /// \brief Append an std::string to buffer structure
+    ///
+    void push_back(const std::string&);
+
+    ///
+    /// \brief Retrieve a string from the structure as std::string
+    ///
+    std::string operator[](std::size_t index) const;
+
+
+    // Container API
+    inline std::size_t size() const { return datavec.size(); }
+    inline const char* data() const { return datavec[0].data(); }
+    void resize(const std::size_t& new_size) { datavec.resize(new_size); }
+
+  private:
+    typedef std::vector<std::array<char, N>> vector_t;
+    vector_t datavec;
+};
+
+
+}  // namespace HighFive
 
 #include "bits/H5DataType_misc.hpp"
 

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -126,6 +126,8 @@ class FixedLenStringArray {
     ///
     void push_back(const std::string&);
 
+    void push_back(const std::array<char, N>&);
+
     ///
     /// \brief Retrieve a string from the structure as std::string
     ///
@@ -152,7 +154,44 @@ class FixedLenStringArray {
     inline const_iterator cend() const noexcept { return datavec.cend(); }
 
   private:
-    typedef typename std::vector<std::array<char, N>> vector_t;
+    using vector_t = typename std::vector<std::array<char, N>>;
+
+  public:
+    using iterator = typename vector_t::iterator;
+    using const_iterator = typename vector_t::const_iterator;
+    using reverse_iterator = typename vector_t::reverse_iterator;
+    using const_reverse_iterator = typename vector_t::const_reverse_iterator;
+    using value_type = typename vector_t::value_type;
+
+    iterator begin() noexcept {
+        return datavec.begin();
+    }
+    iterator end() noexcept {
+        return datavec.end();
+    }
+
+    const_iterator begin() const noexcept {
+        return datavec.begin();
+    }
+    const_iterator end() const noexcept {
+        return datavec.end();
+    }
+
+    reverse_iterator rbegin() noexcept {
+        return datavec.rbegin();
+    }
+    reverse_iterator rend() noexcept {
+        return datavec.rend();
+    }
+
+    const_reverse_iterator rbegin() const noexcept {
+        return datavec.rbegin();
+    }
+    const_reverse_iterator rend() const noexcept {
+        return datavec.rend();
+    }
+
+  private:
     vector_t datavec;
 };
 

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -66,6 +66,8 @@ class DataType : public Object {
     friend class Attribute;
     friend class File;
     friend class DataSet;
+
+    DataType(hid_t type_hid);
 };
 
 ///

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -134,7 +134,7 @@ class FixedLenStringArray {
 
     // Container API
     inline std::size_t size() const { return datavec.size(); }
-    inline const char* data() const { return datavec[0].data(); }
+    inline char* data() const { return const_cast<char*>(datavec[0].data()); }
     void resize(const std::size_t& new_size) { datavec.resize(new_size); }
 
   private:

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -172,6 +172,7 @@ class FixedLenStringArray {
     using reverse_iterator = typename vector_t::reverse_iterator;
     using const_reverse_iterator = typename vector_t::const_reverse_iterator;
     using value_type = typename vector_t::value_type;
+
     inline iterator begin() noexcept {
         return datavec.begin();
     }
@@ -190,16 +191,16 @@ class FixedLenStringArray {
     inline const_iterator cend() const noexcept {
         return datavec.cend();
     }
-    reverse_iterator rbegin() noexcept {
+    inline reverse_iterator rbegin() noexcept {
         return datavec.rbegin();
     }
-    reverse_iterator rend() noexcept {
+    inline reverse_iterator rend() noexcept {
         return datavec.rend();
     }
-    const_reverse_iterator rbegin() const noexcept {
+    inline const_reverse_iterator rbegin() const noexcept {
         return datavec.rbegin();
     }
-    const_reverse_iterator rend() const noexcept {
+    inline const_reverse_iterator rend() const noexcept {
         return datavec.rend();
     }
 

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -62,6 +62,16 @@ class DataType : public Object {
     ///
     std::string string() const;
 
+    ///
+    /// \brief Returns whether the type is a variable-length string
+    ///
+    bool isVariableString() const;
+
+    ///
+    /// \brief Returns whether the type is a fixed-length string
+    ///
+    bool isFixedLengthString() const;
+
   protected:
     friend class Attribute;
     friend class File;

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -103,7 +103,7 @@ class AtomicType : public DataType {
 template <std::size_t N>
 class FixedLenStringArray {
   public:
-    inline FixedLenStringArray() {};
+    FixedLenStringArray() = default;
 
     ///
     /// \brief Create a FixedStringArray from a raw contiguous buffer
@@ -117,7 +117,7 @@ class FixedLenStringArray {
     ///
     FixedLenStringArray(const std::string* iter_begin, const std::string* iter_end);
 
-    FixedLenStringArray(const std::vector<std::string> & vec);
+    explicit FixedLenStringArray(const std::vector<std::string> & vec);
 
     FixedLenStringArray(const std::initializer_list<std::string> &);
 
@@ -133,9 +133,9 @@ class FixedLenStringArray {
 
 
     // Container API
-    inline std::size_t size() const { return datavec.size(); }
+    inline std::size_t size() const noexcept { return datavec.size(); }
     inline char* data() const { return const_cast<char*>(datavec[0].data()); }
-    void resize(const std::size_t& new_size) { datavec.resize(new_size); }
+    void resize(std::size_t new_size) { datavec.resize(new_size); }
 
   private:
     typedef std::vector<std::array<char, N>> vector_t;

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -134,56 +134,68 @@ class FixedLenStringArray {
     std::string getString(std::size_t index) const;
 
     // Container interface
-    inline const char* operator[](std::size_t i) const noexcept { return datavec[i].data(); }
-    inline const char* at(std::size_t i) const { return datavec.at(i).data(); }
-    inline bool empty() const noexcept { return datavec.empty(); }
-    inline std::size_t size() const noexcept { return datavec.size(); }
-    inline void resize(std::size_t n) { datavec.resize(n); }
-    inline const char* front() const { return datavec.front().data(); }
-    inline const char* back() const { return datavec.back().data(); }
-    inline char* data() noexcept { return datavec[0].data(); }
-    inline const char* data() const noexcept { return datavec[0].data(); }
-    // Use the underlying iterator
-    typedef typename std::vector<std::array<char, N>>::iterator iterator;
-    typedef typename std::vector<std::array<char, N>>::const_iterator const_iterator;
-    inline iterator begin() noexcept { return datavec.begin(); }
-    inline iterator end() noexcept { return datavec.end(); }
-    inline const_iterator begin() const noexcept { return datavec.begin(); }
-    inline const_iterator cbegin() const noexcept { return datavec.cbegin(); }
-    inline const_iterator end() const noexcept { return datavec.end(); }
-    inline const_iterator cend() const noexcept { return datavec.cend(); }
+    inline const char* operator[](std::size_t i) const noexcept {
+        return datavec[i].data();
+    }
+    inline const char* at(std::size_t i) const {
+        return datavec.at(i).data();
+    }
+    inline bool empty() const noexcept {
+        return datavec.empty();
+    }
+    inline std::size_t size() const noexcept {
+        return datavec.size();
+    }
+    inline void resize(std::size_t n) {
+        datavec.resize(n);
+    }
+    inline const char* front() const {
+        return datavec.front().data();
+    }
+    inline const char* back() const {
+        return datavec.back().data();
+    }
+    inline char* data() noexcept {
+        return datavec[0].data();
+    }
+    inline const char* data() const noexcept {
+        return datavec[0].data();
+    }
 
   private:
     using vector_t = typename std::vector<std::array<char, N>>;
 
   public:
+    // Use the underlying iterator
     using iterator = typename vector_t::iterator;
     using const_iterator = typename vector_t::const_iterator;
     using reverse_iterator = typename vector_t::reverse_iterator;
     using const_reverse_iterator = typename vector_t::const_reverse_iterator;
     using value_type = typename vector_t::value_type;
-
-    iterator begin() noexcept {
+    inline iterator begin() noexcept {
         return datavec.begin();
     }
-    iterator end() noexcept {
+    inline iterator end() noexcept {
         return datavec.end();
     }
-
-    const_iterator begin() const noexcept {
+    inline const_iterator begin() const noexcept {
         return datavec.begin();
     }
-    const_iterator end() const noexcept {
+    inline const_iterator cbegin() const noexcept {
+        return datavec.cbegin();
+    }
+    inline const_iterator end() const noexcept {
         return datavec.end();
     }
-
+    inline const_iterator cend() const noexcept {
+        return datavec.cend();
+    }
     reverse_iterator rbegin() noexcept {
         return datavec.rbegin();
     }
     reverse_iterator rend() noexcept {
         return datavec.rend();
     }
-
     const_reverse_iterator rbegin() const noexcept {
         return datavec.rbegin();
     }
@@ -195,9 +207,8 @@ class FixedLenStringArray {
     vector_t datavec;
 };
 
-
 }  // namespace HighFive
 
 #include "bits/H5DataType_misc.hpp"
 
-#endif // H5DATATYPE_HPP
+#endif  // H5DATATYPE_HPP

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -120,7 +120,7 @@ public:
     CompoundType(const CompoundType& other) = default;
 
     ///
-    /// \brief Initializes a compound type from a vector of member difinitions
+    /// \brief Initializes a compound type from a vector of member definitions
     /// \param t_members
     /// \param size
     inline CompoundType(const std::vector<member_def>& t_members, size_t size = 0)

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -115,30 +115,35 @@ class FixedLenStringArray {
     ///
     /// Such conversion involves a copy, original vector is not modified
     ///
-    FixedLenStringArray(const std::string* iter_begin, const std::string* iter_end);
-
     explicit FixedLenStringArray(const std::vector<std::string> & vec);
+
+    FixedLenStringArray(const std::string* iter_begin, const std::string* iter_end);
 
     FixedLenStringArray(const std::initializer_list<std::string> &);
 
     ///
-    /// \brief Append an std::string to buffer structure
+    /// \brief Append an std::string to the buffer structure
     ///
     void push_back(const std::string&);
 
     ///
     /// \brief Retrieve a string from the structure as std::string
     ///
-    std::string operator[](std::size_t index) const;
+    std::string getString(std::size_t index) const;
 
-
-    // Container API
+    // Container interface
+    inline const char* operator[](std::size_t i) const { return datavec[i].data(); }
+    inline const char* at(std::size_t i) const { return datavec.at(i).data(); }
+    inline bool empty() const noexcept { return datavec.empty(); }
     inline std::size_t size() const noexcept { return datavec.size(); }
-    inline char* data() const { return const_cast<char*>(datavec[0].data()); }
-    void resize(std::size_t new_size) { datavec.resize(new_size); }
+    inline void resize(std::size_t i) { datavec.resize(i); }
+    inline const char* front() const { return datavec.front().data(); }
+    inline const char* back() const { return datavec.back().data(); }
+    inline char* data() noexcept { return datavec[0].data(); }
+    inline const char* data() const noexcept { return datavec[0].data(); }
 
   private:
-    typedef std::vector<std::array<char, N>> vector_t;
+    typedef typename std::vector<std::array<char, N>> vector_t;
     vector_t datavec;
 };
 

--- a/include/highfive/H5Selection.hpp
+++ b/include/highfive/H5Selection.hpp
@@ -42,6 +42,11 @@ class Selection : public SliceTraits<Selection> {
     DataSet& getDataset();
     const DataSet& getDataset() const;
 
+    ///
+    /// \brief return the datatype of the selection
+    /// \return return the datatype of the selection
+    const DataType getDataType() const;
+
   private:
     Selection(const DataSpace& memspace, const DataSpace& file_space,
               const DataSet& set);
@@ -53,7 +58,8 @@ class Selection : public SliceTraits<Selection> {
     friend class ::HighFive::SliceTraits;
     // absolute namespace naming due to GCC bug 52625
 };
-}
+
+}  // namespace HighFive
 
 #include "bits/H5Slice_traits_misc.hpp"
 #include "bits/H5Selection_misc.hpp"

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -73,7 +73,7 @@ inline void Attribute::read(T& array) const {
         array_datatype;
 
     // Apply pre read conversions
-    details::data_converter<type_no_const> converter(nocv_array, mem_space);
+    details::data_converter<type_no_const> converter(mem_space);
 
     if (H5Aread(getId(), array_datatype.getId(),
                 static_cast<void*>(converter.transform_read(nocv_array))) < 0) {
@@ -107,7 +107,7 @@ inline void Attribute::write(const T& buffer) {
         array_datatype;
 
     // Apply pre write conversions
-    details::data_converter<type_no_const> converter(nocv_buffer, mem_space);
+    details::data_converter<type_no_const> converter(mem_space);
 
     if (H5Awrite(getId(), array_datatype.getId(),
                  static_cast<const void*>(

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -67,7 +67,6 @@ inline void Attribute::read(T& array) const {
         throw DataSpaceException(ss.str());
     }
 
-    // Create mem datatype
     const DataType mem_datatype = create_and_check_datatype<element_type>();
 
     // Apply pre read conversions
@@ -99,8 +98,6 @@ inline void Attribute::write(const T& buffer) {
     }
 
     const DataType mem_datatype = create_and_check_datatype<element_type>();
-
-    // Apply pre write conversions
     details::data_converter<T> converter(mem_space);
 
     if (H5Awrite(getId(), mem_datatype.getId(),
@@ -109,6 +106,7 @@ inline void Attribute::write(const T& buffer) {
             "Error during HDF5 Write: ");
     }
 }
-}
+
+}  // namespace HighFive
 
 #endif // H5ATTRIBUTE_MISC_HPP

--- a/include/highfive/bits/H5ConverterEigen_misc.hpp
+++ b/include/highfive/bits/H5ConverterEigen_misc.hpp
@@ -1,0 +1,209 @@
+/*
+ *  Copyright (c), 2020, EPFL - Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#pragma once
+
+namespace HighFive {
+
+namespace details {
+
+
+#ifdef H5_USE_EIGEN
+//compute size for single Eigen Matrix
+template <typename T, int M, int N>
+inline size_t compute_total_size(const Eigen::Matrix<T,M,N>& matrix)
+{
+    return matrix.rows() * matrix.cols();
+}
+
+//compute size for  std::vector of Eigens
+template <typename T, int M, int N>
+inline size_t compute_total_size(const std::vector<Eigen::Matrix<T,M,N>>& vec)
+{
+    return std::accumulate(vec.begin(), vec.end(), size_t{0u}, [](size_t so_far, const auto& v) {
+        return so_far + static_cast<size_t>(v.rows()) * static_cast<size_t>(v.cols());
+    });
+}
+
+#ifdef H5_USE_BOOST
+// compute size for  boost::multi_array of Eigens
+template <typename T, size_t Dims>
+inline size_t compute_total_size(const boost::multi_array<T, Dims>& vec) {
+    return std::accumulate(vec.origin(),
+                           vec.origin() + vec.num_elements(),
+                           size_t{0u},
+                           [](size_t so_far, const auto& v) {
+                               return so_far +
+                                      static_cast<size_t>(v.rows()) * static_cast<size_t>(v.cols());
+                           });
+}
+#endif
+
+//compute total row size for std::vector of Eigens
+template <typename T, int M, int N>
+inline size_t compute_total_row_size(const std::vector<Eigen::Matrix<T,M,N>>& vec)
+{
+    return std::accumulate(vec.begin(), vec.end(), size_t{0u}, [](size_t so_far, const auto& v) {
+        return so_far + static_cast<size_t>(v.rows());
+    });
+}
+
+
+// apply conversion to eigen matrix
+template <typename T, int M, int N>
+struct data_converter<Eigen::Matrix<T, M, N>, void> {
+
+    typedef typename Eigen::Matrix<T, M, N> MatrixTMN;
+
+    inline data_converter(const DataSpace& space)
+        : _dims(space.getDimensions()) {
+        assert(_dims.size() == 2);
+    }
+
+    inline auto* transform_read(MatrixTMN& array) {
+        if (_dims[0] != static_cast<size_t>(array.rows()) ||
+            _dims[1] != static_cast<size_t>(array.cols())) {
+            array.resize(static_cast<Eigen::Index>(_dims[0]), static_cast<Eigen::Index>(_dims[1]));
+        }
+        return array.data();
+    }
+
+    inline const auto* transform_write(const MatrixTMN& array) {
+        return array.data();
+    }
+
+    inline void process_result(MatrixTMN&) {}
+
+    std::vector<size_t> _dims;
+};
+
+
+template <typename T, int M, int N>
+inline void vectors_to_single_buffer(const std::vector<Eigen::Matrix<T,M,N>>& vec,
+                                     const std::vector<size_t>& dims,
+                                     const size_t current_dim,
+                                     std::vector<T>& buffer) {
+
+    check_dimensions_vector(compute_total_row_size(vec), dims[current_dim], current_dim);
+    for (const auto& k : vec) {
+        std::copy(k.data(), k.data()+k.size(), std::back_inserter(buffer));
+    }
+}
+
+// apply conversion to std::vector of eigen matrix
+template <typename T, int M, int N>
+struct data_converter<std::vector<Eigen::Matrix<T,M,N>>, void> {
+
+    typedef typename Eigen::Matrix<T, M, N> MatrixTMN;
+
+    inline data_converter(const DataSpace& space)
+        : _dims(space.getDimensions()), _space(space) {
+        assert(_dims.size() == 2);
+    }
+
+    inline auto * transform_read(std::vector<MatrixTMN>& /* vec */) {
+        _vec_align.resize(compute_total_size(_space.getDimensions()));
+        return _vec_align.data();
+    }
+
+    inline const auto* transform_write(const std::vector<MatrixTMN>& vec) {
+        _vec_align.reserve(compute_total_size(vec));
+        vectors_to_single_buffer<T, M, N>(vec, _dims, 0, _vec_align);
+        return _vec_align.data();
+    }
+
+    inline void process_result(std::vector<MatrixTMN>& vec) {
+        T* start = _vec_align.data();
+        if(vec.size() > 0) {
+            for(auto& v : vec){
+                v = Eigen::Map<MatrixTMN>(start, v.rows(), v.cols());
+                start += v.rows()*v.cols();
+            }
+        }
+        else {
+            if(M == -1 || N == -1) {
+                std::ostringstream ss;
+                ss << "Dynamic size(-1) used without pre-defined vector data layout.\n"
+                   << "Initiliaze vector elements using Zero, i.e.:\n"
+                   << "\t vector<MatrixXd> vec(5, MatrixXd::Zero(20,5))";
+                throw DataSetException(ss.str());
+            }
+            else
+            {
+                for (size_t i = 0; i < _dims[0] / static_cast<size_t>(M); ++i) {
+                    vec.emplace_back(Eigen::Map<MatrixTMN>(start, M, N));
+                    start += M * N;
+                }
+            }
+        }
+    }
+
+    std::vector<size_t> _dims;
+    std::vector<typename type_of_array<T>::type> _vec_align;
+    const DataSpace& _space;
+};
+
+#ifdef H5_USE_BOOST
+template <typename T, int M, int N, std::size_t Dims>
+struct data_converter<boost::multi_array<Eigen::Matrix<T, M, N>, Dims>, void> {
+    typedef typename boost::multi_array<Eigen::Matrix<T, M, N>, Dims> MultiArrayEigen;
+
+    inline data_converter(const DataSpace& space)
+        : _dims(space.getDimensions())
+        , _space(space) {
+        assert(_dims.size() == Dims);
+    }
+
+    inline auto* transform_read(const MultiArrayEigen& /*array*/) {
+        _vec_align.resize(compute_total_size(_space.getDimensions()));
+        return _vec_align.data();
+    }
+
+    inline const auto* transform_write(const MultiArrayEigen& array) {
+        _vec_align.reserve(compute_total_size(array));
+        for (auto e = array.origin(); e < array.origin() + array.num_elements(); ++e) {
+            std::copy(e->data(), e->data() + e->size(), std::back_inserter(_vec_align));
+        }
+        return _vec_align.data();
+    }
+
+    inline void process_result(MultiArrayEigen& vec) {
+        T* start = _vec_align.data();
+        if (M != -1 && N != -1) {
+            for (auto v = vec.origin(); v < vec.origin() + vec.num_elements(); ++v) {
+                *v = Eigen::Map<Eigen::Matrix<T, M, N>>(start, v->rows(), v->cols());
+                start += v->rows() * v->cols();
+            }
+        } else {
+            if (vec.origin()->rows() > 0 && vec.origin()->cols() > 0) {
+                const auto VEC_M = vec.origin()->rows(), VEC_N = vec.origin()->cols();
+                for (auto v = vec.origin(); v < vec.origin() + vec.num_elements(); ++v) {
+                    assert(v->rows() == VEC_M && v->cols() == VEC_N);
+                    *v = Eigen::Map<Eigen::Matrix<T, M, N>>(start, VEC_M, VEC_N);
+                    start += VEC_M * VEC_N;
+                }
+            } else {
+                throw DataSetException(
+                    "Dynamic size(-1) used without pre-defined multi_array data layout.\n"
+                    "Initialize vector elements using  MatrixXd::Zero");
+            }
+        }
+    }
+
+    std::vector<size_t> _dims;
+    const DataSpace& _space;
+    std::vector<typename type_of_array<T>::type> _vec_align;
+};
+#endif
+
+#endif
+
+
+}  // namespace details
+
+}  // namespace HighFive

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -112,6 +112,9 @@ single_buffer_to_vectors(typename std::vector<U>::iterator begin_buffer,
     return begin_buffer;
 }
 
+// DATA CONVERTERS
+// ---------------
+
 // apply conversion operations to basic scalar type
 template <typename Scalar, class Enable = void>
 struct data_converter {
@@ -537,7 +540,7 @@ struct data_converter<std::vector<std::string>, void> {
     inline char** transform_read(std::vector<std::string>& vec) {
         (void)vec;
         _c_vec.resize(_space.getDimensions()[0], NULL);
-        return (&_c_vec[0]);
+        return _c_vec.data();
     }
 
     static inline char* char_converter(const std::string& str) {
@@ -547,7 +550,7 @@ struct data_converter<std::vector<std::string>, void> {
     inline char** transform_write(std::vector<std::string>& vec) {
         _c_vec.resize(vec.size() + 1, NULL);
         std::transform(vec.begin(), vec.end(), _c_vec.begin(), &char_converter);
-        return (&_c_vec[0]);
+        return _c_vec.data();
     }
 
     inline void process_result(std::vector<std::string>& vec) {

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -358,7 +358,7 @@ struct data_converter<std::vector<Eigen::Matrix<T,M,N>>, void> {
         assert(_dims.size() == 2);
     }
 
-    inline tauto * transform_read(std::vector<MatrixTMN>& /* vec */) {
+    inline auto * transform_read(std::vector<MatrixTMN>& /* vec */) {
         _vec_align.resize(compute_total_size(_space.getDimensions()));
         return _vec_align.data();
     }

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -557,7 +557,35 @@ struct data_converter<std::vector<std::string>, void> {
     std::vector<const char*> _c_vec;
     const DataSpace& _space;
 };
-}
-}
+
+
+
+
+// apply conversion for fixed-string
+template <std::size_t N>
+struct data_converter<FixedLenStringArray<N>, void> {
+    inline data_converter(const DataSpace& space)
+        : _space(space) {
+        assert(is_1D(_space.getDimensions()));
+    }
+
+    inline auto* transform_read(FixedLenStringArray<N>& vec) {
+        vec.resize(_space.getDimensions()[0]);
+        return const_cast<char*>(vec.data());
+    }
+
+    inline const auto* transform_write(const FixedLenStringArray<N>& vec) {
+        return vec.data();
+    }
+
+    inline void process_result(FixedLenStringArray<N>&) {}
+
+    const DataSpace& _space;
+};
+
+
+}  // namespace details
+
+}  // namespace HighFive
 
 #endif // H5CONVERTER_MISC_HPP

--- a/include/highfive/bits/H5DataSet_misc.hpp
+++ b/include/highfive/bits/H5DataSet_misc.hpp
@@ -33,9 +33,7 @@ inline uint64_t DataSet::getStorageSize() const {
 }
 
 inline DataType DataSet::getDataType() const {
-    DataType res;
-    res._hid = H5Dget_type(_hid);
-    return res;
+    return DataType(H5Dget_type(_hid));
 }
 
 inline DataSpace DataSet::getSpace() const {

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -230,10 +230,17 @@ inline void FixedLenStringArray<N>::push_back(const std::string& src) {
 }
 
 template <std::size_t N>
+inline void FixedLenStringArray<N>::push_back(const std::array<char, N>& src) {
+    datavec.emplace_back();
+    const size_t length = std::min(N - 1, src.length());
+    std::memcpy(datavec.back().data(), src.data(), length);
+    datavec.back()[length] = 0;
+}
+
+template <std::size_t N>
 inline std::string FixedLenStringArray<N>::getString(std::size_t i) const {
     return std::string(datavec[i].data());
 }
-
 
 // Internal
 

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -260,7 +260,6 @@ inline std::string type_class_string(DataTypeClass tclass) {
 
 }  // unnamed namespace
 
-
 }  // namespace HighFive
 
 

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <complex>
+#include <cstring>
 
 #include <H5Tpublic.h>
 
@@ -203,7 +204,7 @@ inline FixedLenStringArray<N>
     datavec.resize(static_cast<std::size_t>(iter_end - iter_begin));
     for (auto& dst_array : datavec) {
         const char* src = (iter_begin++)->c_str();
-        const size_t length = std::min(N - 1 , strlen(src));
+        const size_t length = std::min(N - 1 , std::strlen(src));
         std::memcpy(dst_array.data(), src, length);
         dst_array[length] = 0;
     }

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -232,9 +232,7 @@ inline void FixedLenStringArray<N>::push_back(const std::string& src) {
 template <std::size_t N>
 inline void FixedLenStringArray<N>::push_back(const std::array<char, N>& src) {
     datavec.emplace_back();
-    const size_t length = std::min(N - 1, src.length());
-    std::memcpy(datavec.back().data(), src.data(), length);
-    datavec.back()[length] = 0;
+    std::copy(src.begin(), src.end(), datavec.back().data());
 }
 
 template <std::size_t N>

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -50,6 +50,18 @@ inline std::string DataType::string() const {
     return type_class_string(getClass()) + std::to_string(getSize() * 8);
 }
 
+inline bool DataType::isVariableString() const {
+    auto var_value = H5Tis_variable_str(_hid);
+    if (var_value < 0) {
+         HDF5ErrMapper::ToException<DataTypeException>(
+            "Unable to define datatype size to variable");
+    }
+    return static_cast<bool>(var_value);
+}
+
+inline bool DataType::isFixedLengthString() const {
+    return getClass() == DataTypeClass::String && !isVariableString();
+}
 
 // char mapping
 template <>

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -229,7 +229,7 @@ inline void FixedLenStringArray<N>::push_back(const std::string& src) {
 }
 
 template <std::size_t N>
-inline std::string FixedLenStringArray<N>::operator[](std::size_t i) const {
+inline std::string FixedLenStringArray<N>::getString(std::size_t i) const {
     return std::string(datavec[i].data());
 }
 

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -190,6 +190,7 @@ AtomicType<T>::AtomicType() {
 }
 
 
+// class FixedLenStringArray<N>
 
 template <std::size_t N>
 inline FixedLenStringArray<N>

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -171,12 +171,9 @@ class AtomicType<FixedLenStringArray<StrLen>> : public DataType {
 };
 
 template <>
-inline AtomicType<std::complex<double> >::AtomicType()
-{
-    static struct ComplexType : public Object
-    {
-        ComplexType()
-        {
+inline AtomicType<std::complex<double> >::AtomicType() {
+    static struct ComplexType : public Object {
+        ComplexType() {
             _hid = H5Tcreate(H5T_COMPOUND, sizeof(std::complex<double>));
             // h5py/numpy compatible datatype
             H5Tinsert(_hid, "r", 0, H5T_NATIVE_DOUBLE);

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -156,6 +156,14 @@ class AtomicType<char[StrLen]> : public DataType {
     }
 };
 
+template <size_t StrLen>
+class AtomicType<FixedLenStringArray<StrLen>> : public DataType {
+  public:
+    inline AtomicType() {
+        _hid = create_string(StrLen);
+    }
+};
+
 template <>
 inline AtomicType<std::complex<double> >::AtomicType()
 {
@@ -178,6 +186,50 @@ AtomicType<T>::AtomicType() {
     static_assert(details::array_dims<T>::value == 0,
                   "Atomic types cant be arrays, except for char[] (fixed-len strings)");
     static_assert(details::array_dims<T>::value > 0, "Type not supported");
+}
+
+
+
+template <std::size_t N>
+inline FixedLenStringArray<N>
+::FixedLenStringArray(const char array[][N], std::size_t length) {
+    datavec.resize(length);
+    std::memcpy(datavec[0].data(), array[0].data(), N * length);
+}
+
+template <std::size_t N>
+inline FixedLenStringArray<N>
+::FixedLenStringArray(const std::string* iter_begin, const std::string* iter_end) {
+    datavec.resize(static_cast<std::size_t>(iter_end - iter_begin));
+    for (auto& dst_array : datavec) {
+        const char* src = (iter_begin++)->c_str();
+        const size_t length = std::min(N - 1 , strlen(src));
+        std::memcpy(dst_array.data(), src, length);
+        dst_array[length] = 0;
+    }
+}
+
+template <std::size_t N>
+inline FixedLenStringArray<N>
+::FixedLenStringArray(const std::vector<std::string> & vec)
+    : FixedLenStringArray(&vec.front(), &vec.back()) {}
+
+template <std::size_t N>
+inline FixedLenStringArray<N>
+::FixedLenStringArray(const std::initializer_list<std::string>& init_list)
+    : FixedLenStringArray(init_list.begin(), init_list.end()) {}
+
+template <std::size_t N>
+inline void FixedLenStringArray<N>::push_back(const std::string& src) {
+    datavec.emplace_back();
+    const size_t length = std::min(N - 1 , src.length());
+    std::memcpy(datavec.back().data(), src.c_str(), length);
+    datavec.back()[length] = 0;
+}
+
+template <std::size_t N>
+inline std::string FixedLenStringArray<N>::operator[](std::size_t i) const {
+    return std::string(datavec[i].data());
 }
 
 

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -156,6 +156,11 @@ inline DataSpace DataSpace::From(const std::vector<Value>& container) {
     return DataSpace(details::get_dim_vector<Value>(container));
 }
 
+template <typename ValueT, std::size_t N>
+inline DataSpace DataSpace::From(const ValueT(&container)[N]) {
+    return DataSpace(details::get_dim_vector(container));
+}
+
 /// Currently only supports 1D std::array
 template <typename Value, std::size_t N>
 inline DataSpace DataSpace::From(const std::array<Value, N>& ) {

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -160,6 +160,11 @@ inline DataSpace DataSpace::From(const ValueT(&container)[N]) {
     return DataSpace(details::get_dim_vector(container));
 }
 
+template <std::size_t N, std::size_t Width>
+inline DataSpace DataSpace::FromCharArrayStrings(const char(&)[N][Width]) {
+    return DataSpace(N);
+}
+
 /// Currently only supports 1D std::array
 template <typename Value, std::size_t N>
 inline DataSpace DataSpace::From(const std::array<Value, N>& ) {

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -28,7 +28,7 @@ inline DataSpace::DataSpace(const std::initializer_list<size_t>& items)
 
 template<typename... Args>
     inline DataSpace::DataSpace(size_t dim1, Args... dims)
-    : DataSpace(std::vector<size_t>{dim1, static_cast<size_t>(dims)...}){}
+    : DataSpace(std::vector<size_t>{dim1, static_cast<size_t>(dims)...}) {}
 
 template <class IT, typename>
 inline DataSpace::DataSpace(const IT begin, const IT end) {
@@ -230,14 +230,14 @@ inline bool checkDimensions(const DataSpace& mem_space, size_t input_dims) {
         return true;
 
     const std::vector<size_t>& dims = mem_space.getDimensions();
-    for (auto i = dims.crbegin(); i != --dims.rend() && *i == 1; ++i)
+    for (auto i = dims.crbegin(); i != --dims.crend() && *i == 1; ++i)
         --dataset_dims;
 
     if (input_dims == dataset_dims)
         return true;
 
     dataset_dims = dims.size();
-    for (auto i = dims.cbegin(); i != --dims.end() && *i == 1; ++i)
+    for (auto i = dims.cbegin(); i != --dims.cend() && *i == 1; ++i)
         --dataset_dims;
 
     if (input_dims == dataset_dims)

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -28,8 +28,7 @@ inline DataSpace::DataSpace(std::initializer_list<size_t> items)
 
 template<typename... Args>
     inline DataSpace::DataSpace(size_t dim1, Args... dims)
-    : DataSpace(std::vector<size_t>{static_cast<size_t>(dim1),
-                                    static_cast<size_t>(dims)...}){}
+    : DataSpace(std::vector<size_t>{dim1, static_cast<size_t>(dims)...}){}
 
 template <class IT, typename>
 inline DataSpace::DataSpace(const IT begin, const IT end) {
@@ -164,9 +163,7 @@ inline DataSpace DataSpace::From(const ValueT(&container)[N]) {
 /// Currently only supports 1D std::array
 template <typename Value, std::size_t N>
 inline DataSpace DataSpace::From(const std::array<Value, N>& ) {
-    std::vector<size_t> dims;
-    dims.push_back(N);
-    return DataSpace(dims);
+    return DataSpace(N);
 }
 
 #ifdef H5_USE_BOOST

--- a/include/highfive/bits/H5Iterables_misc.hpp
+++ b/include/highfive/bits/H5Iterables_misc.hpp
@@ -36,11 +36,8 @@ struct HighFiveIterateData {
 };
 
 template <typename InfoType>
-inline herr_t internal_high_five_iterate(hid_t id, const char* name,
-                                         const InfoType* info, void* op_data) {
-    (void)id;
-    (void)info;
-
+inline herr_t internal_high_five_iterate(
+		hid_t /*id*/, const char* name, const InfoType* /*info*/, void* op_data) {
     auto* data = static_cast<HighFiveIterateData*>(op_data);
     try {
         data->names.emplace_back(name);

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -21,6 +21,8 @@ class DataSpace;
 class DataType;
 class Group;
 
+template <std::size_t N>
+class FixedLenStringArray;
 
 enum class LinkType;
 
@@ -74,6 +76,14 @@ class NodeTraits {
     DataSet
     createDataSet(const std::string& dataset_name,
                   const T& data,
+                  const DataSetCreateProps& createProps = DataSetCreateProps(),
+                  const DataSetAccessProps& accessProps = DataSetAccessProps());
+
+
+    template <std::size_t N>
+    DataSet
+    createDataSet(const std::string& dataset_name,
+                  const FixedLenStringArray<N>& data,
                   const DataSetCreateProps& createProps = DataSetCreateProps(),
                   const DataSetAccessProps& accessProps = DataSetAccessProps());
 

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -75,6 +75,19 @@ NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
 }
 
 template <typename Derivate>
+template <std::size_t N>
+inline DataSet
+NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
+                                    const FixedLenStringArray<N>& data,
+                                    const DataSetCreateProps& createProps,
+                                    const DataSetAccessProps& accessProps) {
+    DataSet ds = createDataSet<char[N]>(
+        dataset_name, DataSpace(data.size()), createProps, accessProps);
+    ds.write(data);
+    return ds;
+}
+
+template <typename Derivate>
 inline DataSet
 NodeTraits<Derivate>::getDataSet(const std::string& dataset_name,
                                  const DataSetAccessProps& accessProps) const {

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -66,8 +66,10 @@ NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                     const DataSetAccessProps& accessProps) {
     DataSet ds = createDataSet(
         dataset_name, DataSpace::From(data),
-        AtomicType<typename details::type_of_array<T>::type>(), createProps,
-        accessProps);
+        AtomicType<typename details::type_of_array<T>::type>(),
+        createProps,
+        accessProps
+    );
     ds.write(data);
     return ds;
 }

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2020 Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#pragma once
+
+#include "H5Utils.hpp"
+
+namespace HighFive {
+
+namespace details {
+
+
+template <typename T>
+struct BufferInfo {
+    typedef typename std::remove_const<T>::type type_no_const;
+    typedef typename details::type_of_array<type_no_const>::type elem_type;
+    typedef typename details::type_char_array<type_no_const>::type char_array_t;
+    static constexpr bool is_char_array = !std::is_same<char_array_t, void>::value;
+
+    BufferInfo(const DataType& dtype);
+
+    // member data which depends on the destination dataset type
+    const bool is_fixed_len_string;
+    const size_t n_dimensions;
+    const DataType data_type;
+};
+
+
+
+// details implementation
+template <typename SrcStrT>
+struct string_type_checker {
+    static DataType getDataType(const DataType&, bool);
+};
+
+template<>
+struct string_type_checker<void> {
+inline static DataType getDataType(const DataType& element_type, bool) {
+    return element_type;
+}};
+
+template<std::size_t FixedLen>
+struct string_type_checker<char[FixedLen]> {
+inline static DataType getDataType(const DataType& element_type, bool ds_fixed_str) {
+    return ds_fixed_str ? AtomicType<char[FixedLen]>() : element_type;
+}};
+
+template<>
+struct string_type_checker<char*> {
+inline static DataType getDataType(const DataType&, bool ds_fixed_str) {
+    if (ds_fixed_str) throw DataSetException(
+        "Can't output variable-length to fixed-length strings");
+    return AtomicType<std::string>();
+}};
+
+
+template <typename T>
+BufferInfo<T>::BufferInfo(const DataType& dtype)
+    : is_fixed_len_string(dtype.isFixedLengthString())
+    , n_dimensions(details::array_dims<type_no_const>::value
+                   - ((is_fixed_len_string && is_char_array)? 1 : 0))
+    , data_type(string_type_checker<char_array_t>
+                ::getDataType(AtomicType<elem_type>(), is_fixed_len_string))
+{
+    if (is_fixed_len_string && std::is_same<elem_type, std::string>::value) {
+        throw DataSetException("Can't output std::string as fixed-length.");
+    }
+    if (dtype.getClass() != data_type.getClass()) {
+        std::cerr << "WARNING: src data and hdf5 dataset have different types: "
+                  << data_type.string() << " -> " << dtype.string() << std::endl;
+    }
+}
+
+
+}  // namespace details
+
+}  // namespace HighFive

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -14,7 +14,6 @@ namespace HighFive {
 
 namespace details {
 
-
 template <typename T>
 struct BufferInfo {
     typedef typename std::remove_const<T>::type type_no_const;
@@ -30,52 +29,43 @@ struct BufferInfo {
     const DataType data_type;
 };
 
-
-
 // details implementation
 template <typename SrcStrT>
 struct string_type_checker {
     static DataType getDataType(const DataType&, bool);
 };
 
-template<>
+template <>
 struct string_type_checker<void> {
 inline static DataType getDataType(const DataType& element_type, bool) {
     return element_type;
 }};
 
-template<std::size_t FixedLen>
+template <std::size_t FixedLen>
 struct string_type_checker<char[FixedLen]> {
 inline static DataType getDataType(const DataType& element_type, bool ds_fixed_str) {
     return ds_fixed_str ? AtomicType<char[FixedLen]>() : element_type;
 }};
 
-template<>
+template <>
 struct string_type_checker<char*> {
 inline static DataType getDataType(const DataType&, bool ds_fixed_str) {
-    if (ds_fixed_str) throw DataSetException(
-        "Can't output variable-length to fixed-length strings");
+    if (ds_fixed_str)
+        throw DataSetException("Can't output variable-length to fixed-length strings");
     return AtomicType<std::string>();
 }};
-
 
 template <typename T>
 BufferInfo<T>::BufferInfo(const DataType& dtype)
     : is_fixed_len_string(dtype.isFixedLengthString())
-    , n_dimensions(details::array_dims<type_no_const>::value
-                   - ((is_fixed_len_string && is_char_array)? 1 : 0))
-    , data_type(string_type_checker<char_array_t>
-                ::getDataType(AtomicType<elem_type>(), is_fixed_len_string))
-{
+    , n_dimensions(details::array_dims<type_no_const>::value -
+                   ((is_fixed_len_string && is_char_array) ? 1 : 0))
+    , data_type(string_type_checker<char_array_t>::getDataType(AtomicType<elem_type>(),
+                                                               is_fixed_len_string)) {
     if (is_fixed_len_string && std::is_same<elem_type, std::string>::value) {
         throw DataSetException("Can't output std::string as fixed-length.");
     }
-    if (dtype.getClass() != data_type.getClass()) {
-        std::cerr << "WARNING: src data and hdf5 dataset have different types: "
-                  << data_type.string() << " -> " << dtype.string() << std::endl;
-    }
 }
-
 
 }  // namespace details
 

--- a/include/highfive/bits/H5Selection_misc.hpp
+++ b/include/highfive/bits/H5Selection_misc.hpp
@@ -32,6 +32,12 @@ inline DataSet& Selection::getDataset() {
 inline const DataSet& Selection::getDataset() const {
     return _set;
 }
+
+// Not only a shortcut but also for templated compat with H5Dataset
+inline const DataType Selection::getDataType() const {
+    return _set.getDataType();
 }
+
+}  // namespace HighFive
 
 #endif // H5SELECTION_MISC_HPP

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -119,7 +119,7 @@ class SliceTraits {
     /// elements. For n-dimensional matrices the buffer layout follows H5
     /// default conventions.
     template <typename T>
-    void write(const T* buffer);
+    void write_raw(const T* const buffer);
 
   private:
     typedef Derivate derivate_type;

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -101,7 +101,7 @@ class SliceTraits {
     /// \param array: A buffer containing enough space for the data
     /// \param dtype: The type of the data, in case it cannot be automatically guessed
     template <typename T>
-    void read(T* array, const DataType &dtype = DataType()) const;
+    void read(T* array, const DataType& dtype = DataType()) const;
 
     ///
     /// Write the integrality N-dimension buffer to this dataset
@@ -123,7 +123,7 @@ class SliceTraits {
     /// \param array: A buffer containing the data to be written
     /// \param dtype: The type of the data, in case it cannot be automatically guessed
     template <typename T>
-    void write_raw(const T* buffer, const DataType &dtype = DataType());
+    void write_raw(const T* buffer, const DataType& dtype = DataType());
 
 };
 

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -109,8 +109,10 @@ inline Selection SliceTraits<Derivate>::select(const std::vector<size_t>& column
     std::vector<hsize_t> offsets(dims.size(), 0);
 
     H5Sselect_none(space.getId());
-    for (const auto& i : columns) {
-        offsets[offsets.size() - 1] = i;
+
+    for (const auto& column: columns) {
+        offsets[offsets.size() - 1] = column;
+
         if (H5Sselect_hyperslab(space.getId(), H5S_SELECT_OR, offsets.data(), 0,
                                 counts.data(), 0) < 0) {
             HDF5ErrMapper::ToException<DataSpaceException>("Unable to select hyperslap");

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -108,7 +108,7 @@ inline Selection SliceTraits<Derivate>::select(const std::vector<size_t>& column
 
     H5Sselect_none(space.getId());
 
-    for (const auto& column: columns) {
+    for (const auto& column : columns) {
         offsets[offsets.size() - 1] = column;
 
         if (H5Sselect_hyperslab(space.getId(), H5S_SELECT_OR, offsets.data(), 0,
@@ -131,7 +131,6 @@ inline Selection SliceTraits<Derivate>::select(const ElementSet& elements) const
         throw DataSpaceException("Number of coordinates in elements picking "
                                  "should be a multiple of the dimensions.");
     }
-
     const std::size_t num_elements = length / space.getNumberDimensions();
     std::vector<hsize_t> raw_elements;
 
@@ -168,10 +167,7 @@ inline void SliceTraits<Derivate>::read(T& array) const {
            << buffer_info.n_dimensions;
         throw DataSpaceException(ss.str());
     }
-
-    // Apply pre read conversions
     details::data_converter<T> converter(mem_space);
-
     read(converter.transform_read(array), buffer_info.data_type);
     // re-arrange results
     converter.process_result(array);
@@ -180,14 +176,13 @@ inline void SliceTraits<Derivate>::read(T& array) const {
 
 template <typename Derivate>
 template <typename T>
-inline void SliceTraits<Derivate>::read(T* array, const DataType& dtype)
-const {
+inline void SliceTraits<Derivate>::read(T* array, const DataType& dtype) const {
     static_assert(!std::is_const<T>::value,
                   "read() requires a non-const structure to read data into");
     const auto& slice = static_cast<const Derivate&>(*this);
     using element_type = typename details::type_of_array<T>::type;
 
-    // Create mem datatype
+    // Auto-detect mem datatype if not provided
     const DataType& mem_datatype =
             dtype.empty() ? create_and_check_datatype<element_type>() : dtype;
 
@@ -213,10 +208,7 @@ inline void SliceTraits<Derivate>::write(const T& buffer) {
            << " into dataset of dimensions " << mem_space.getNumberDimensions();
         throw DataSpaceException(ss.str());
     }
-
-    // Apply pre write conversions
     details::data_converter<T> converter(mem_space);
-
     write_raw(converter.transform_write(buffer), buffer_info.data_type);
 }
 
@@ -226,8 +218,7 @@ template <typename T>
 inline void SliceTraits<Derivate>::write_raw(const T* buffer, const DataType& dtype) {
     using element_type = typename details::type_of_array<T>::type;
     const auto& slice = static_cast<const Derivate&>(*this);
-
-    const auto& mem_datatype =  // Create mem datatype if not specified
+    const auto& mem_datatype =
         dtype.empty() ? create_and_check_datatype<element_type>() : dtype;
 
     if (H5Dwrite(details::get_dataset(slice).getId(),
@@ -238,7 +229,6 @@ inline void SliceTraits<Derivate>::write_raw(const T* buffer, const DataType& dt
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Write: ");
     }
 }
-
 
 }  // namespace HighFive
 

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -99,10 +99,9 @@ SliceTraits<Derivate>::select(const std::vector<size_t>& offset,
 template <typename Derivate>
 inline Selection
 SliceTraits<Derivate>::select(const std::vector<size_t>& columns) const {
-
-    const DataSpace& space = static_cast<const Derivate*>(this)->getSpace();
-    const DataSet& dataset =
-        details::get_dataset(static_cast<const Derivate*>(this));
+    const auto* slice = static_cast<const Derivate*>(this);
+    const DataSpace& space = slice->getSpace();
+    const DataSet& dataset = details::get_dataset(slice);
     std::vector<size_t> dims = space.getDimensions();
     std::vector<hsize_t> counts(dims.size());
     std::copy(dims.begin(), dims.end(), counts.begin());

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -242,6 +242,26 @@ inline void SliceTraits<Derivate>::write(const T& buffer) {
     }
 }
 
+
+template <typename Derivate>
+template <typename T>
+inline void SliceTraits<Derivate>::write_raw(const T* buffer) {
+    DataSpace space = static_cast<const Derivate*>(this)->getSpace();
+    DataSpace mem_space = static_cast<const Derivate*>(this)->getMemSpace();
+
+    const AtomicType<typename details::type_of_array<T>::type> array_datatype;
+
+    if (H5Dwrite(details::get_dataset(static_cast<Derivate*>(this)).getId(),
+                 array_datatype.getId(),
+                 details::get_memspace_id((static_cast<Derivate*>(this))),
+                 space.getId(), H5P_DEFAULT,
+                 static_cast<const void*>(buffer)) < 0) {
+        HDF5ErrMapper::ToException<DataSetException>(
+            "Error during HDF5 Write: ");
+    }
+}
+
+
 }  // namespace HighFive
 
 #endif  // H5SLICE_TRAITS_MISC_HPP

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -220,23 +220,63 @@ inline void SliceTraits<Derivate>::read(T* array) const {
     }
 }
 
-inline static size_t
-adjust_mem_datatype(DataType&, const DataType&, const DataType&) {
-    return 0;
+
+
+template <typename SrcStrT>
+struct string_type_checker {
+    static DataType getDataType(const DataType&, bool);
+};
+
+template<>
+inline DataType
+string_type_checker<void>::getDataType(const DataType& element_type, bool) {
+    return element_type;
 }
 
-template<std::size_t N>
-inline static size_t
-adjust_mem_datatype(AtomicType<char>& out_mem_datatype,
-                    const AtomicType<char[N]>& in_mem_datatype,
-                    const DataType& ds_datatype) {
-    if(ds_datatype.getClass() != DataTypeClass::String) {
-        // Dont convert if destination didnt request string
-        return 0;
-    }
-    static_cast<DataType&>(out_mem_datatype) = static_cast<const DataType&>(in_mem_datatype);
-    return 1;
-}
+template<std::size_t FixedLen>
+struct string_type_checker<char[FixedLen]> {
+inline static DataType getDataType(const DataType& element_type, bool ds_fixed_str) {
+    return ds_fixed_str ? AtomicType<char[FixedLen]>() : element_type;
+}};
+
+template<>
+struct string_type_checker<char*> {
+inline static DataType getDataType(const DataType&, bool) {
+    return AtomicType<std::string>();
+}};
+
+
+// inline static size_t
+// adjust_mem_datatype(DataType&, const DataType&) {
+//     return 0;
+// }
+
+// size_t _check_replace_datatype(DataType& out_mem_datatype,
+//                              const DataType& in_mem_datatype,
+//                              const DataType& ds_datatype) {
+//     // Dont convert if destination didnt request string
+//     if(ds_datatype.getClass() == DataTypeClass::String) {
+//         out_mem_datatype = in_mem_datatype;
+//         return 1;
+//     }
+//     return 0;
+// }
+
+// inline static size_t
+// adjust_mem_datatype(AtomicType<char>& out_mem_datatype,
+//                     const AtomicType<char*>& in_mem_datatype,
+//                     const DataType& ds_datatype) {
+//     return _check_replace_datatype(out_mem_datatype, in_mem_datatype, ds_datatype);
+// }
+
+// template<std::size_t N>
+// inline static size_t
+// adjust_mem_datatype(AtomicType<char>& out_mem_datatype,
+//                     const AtomicType<char[N]>& in_mem_datatype,
+//                     const DataType& ds_datatype) {
+//     return _check_replace_datatype(out_mem_datatype, in_mem_datatype, ds_datatype);
+// }
+
 
 
 template <typename Derivate>
@@ -244,20 +284,35 @@ template <typename T>
 inline void SliceTraits<Derivate>::write(const T& buffer) {
     typedef typename std::remove_const<T>::type type_no_const;
     typedef typename details::type_of_array<type_no_const>::type elem_type;
-    typedef typename details::type_of_array_storage<type_no_const>::type type_maybe_array;
+    typedef typename details::type_char_array<type_no_const>::type char_array_t;
+
+    std::cout << typeid(char_array_t).name() << std::endl;
 
     type_no_const& nocv_buffer = const_cast<type_no_const&>(buffer);
     const auto& self = static_cast<const Derivate&>(*this);
-    const DataSpace space = self.getSpace();
-    DataSpace mem_space = self.getMemSpace();
+    const auto& dst_type = self.getDataType();
+    const auto& mem_space = self.getMemSpace();
+    bool is_fixed_len_string = dst_type.isFixedLengthString();
+    size_t buffer_dims = details::array_dims<type_no_const>::value;
+    const auto buffer_type = string_type_checker<char_array_t>::getDataType(
+        AtomicType<elem_type>(),
+        is_fixed_len_string
+    );
 
-    AtomicType<elem_type> mem_data_type;
-    const size_t dim_buffer = details::array_dims<type_no_const>::value
-        - adjust_mem_datatype(mem_data_type, AtomicType<type_maybe_array>(), self.getDataType());
+    std::cout  << "Fied len? " << is_fixed_len_string
+               << "is char*" << std::is_same<char_array_t, char*>::value << std::endl;
 
-    if (!details::checkDimensions(mem_space, dim_buffer)) {
+    if (is_fixed_len_string) {
+        if (std::is_same<elem_type, std::string>::value
+                or std::is_same<char_array_t, char*>::value) {
+            throw DataSetException("Can't output variable-length to fixed-length strings");
+        }
+        if (std::is_same<elem_type, char>::value) buffer_dims--;
+    }
+
+    if (!details::checkDimensions(mem_space, buffer_dims)) {
         std::ostringstream ss;
-        ss << "Impossible to write buffer of dimensions " << dim_buffer
+        ss << "Impossible to write buffer of dimensions " << buffer_dims
            << " into dataset of dimensions " << mem_space.getNumberDimensions();
         throw DataSpaceException(ss.str());
     }
@@ -266,37 +321,76 @@ inline void SliceTraits<Derivate>::write(const T& buffer) {
     details::data_converter<type_no_const> converter(nocv_buffer, mem_space);
 
     if (H5Dwrite(details::get_dataset(static_cast<Derivate*>(this)).getId(),
-                 mem_data_type.getId(),
+                 buffer_type.getId(),
                  details::get_memspace_id((static_cast<Derivate*>(this))),
-                 space.getId(), H5P_DEFAULT,
-                 static_cast<const void*>(
-                     converter.transform_write(nocv_buffer))) < 0) {
+                 self.getSpace().getId(), H5P_DEFAULT,
+                 static_cast<const void*>(converter.transform_write(nocv_buffer))
+            ) < 0) {
         HDF5ErrMapper::ToException<DataSetException>(
             "Error during HDF5 Write: ");
     }
 }
 
-template <typename Derivate>
-template <typename T>
-inline void SliceTraits<Derivate>::write_raw(const T* const buffer) {
-    const auto& self = static_cast<const Derivate&>(*this);
-    const DataSpace& space = self.getSpace();
-    DataSpace mem_space = self.getMemSpace();
 
-    AtomicType<typename details::type_of_array<T>::type> array_datatype;
-    adjust_mem_datatype(array_datatype,
-                        AtomicType<typename details::type_of_array_storage<T>::type>(),
-                        self.getDataType());
+// template <typename Derivate>
+// template <typename T>
+// inline void SliceTraits<Derivate>::write(const T& buffer) {
+//     typedef typename std::remove_const<T>::type type_no_const;
+//     typedef typename details::type_of_array<type_no_const>::type elem_type;
+//     typedef typename details::type_of_wide_array<type_no_const>::type type_maybe_array;
 
-    if (H5Dwrite(details::get_dataset(static_cast<Derivate*>(this)).getId(),
-                 array_datatype.getId(),
-                 details::get_memspace_id((static_cast<Derivate*>(this))),
-                 space.getId(), H5P_DEFAULT,
-                 static_cast<const void*>(buffer)) < 0) {
-        HDF5ErrMapper::ToException<DataSetException>(
-            "Error during HDF5 Write: ");
-    }
-}
-}
+//     type_no_const& nocv_buffer = const_cast<type_no_const&>(buffer);
+//     const auto& self = static_cast<const Derivate&>(*this);
+//     DataSpace mem_space = self.getMemSpace();
+
+//     AtomicType<elem_type> mem_data_type;
+//     const size_t dim_buffer = details::array_dims<type_no_const>::value
+//         - adjust_mem_datatype(mem_data_type, AtomicType<type_maybe_array>(), self.getDataType());
+
+//     if (!details::checkDimensions(mem_space, dim_buffer)) {
+//         std::ostringstream ss;
+//         ss << "Impossible to write buffer of dimensions " << dim_buffer
+//            << " into dataset of dimensions " << mem_space.getNumberDimensions();
+//         throw DataSpaceException(ss.str());
+//     }
+
+//     // Apply pre write conversions
+//     details::data_converter<type_no_const> converter(nocv_buffer, mem_space);
+
+//     if (H5Dwrite(details::get_dataset(static_cast<Derivate*>(this)).getId(),
+//                  mem_data_type.getId(),
+//                  details::get_memspace_id((static_cast<Derivate*>(this))),
+//                  self.getSpace().getId(), H5P_DEFAULT,
+//                  static_cast<const void*>(
+//                      converter.transform_write(nocv_buffer))) < 0) {
+//         HDF5ErrMapper::ToException<DataSetException>(
+//             "Error during HDF5 Write: ");
+//     }
+// }
+
+// template <typename Derivate>
+// template <typename T>
+// inline void SliceTraits<Derivate>::write_raw(const T* const buffer) {
+//     typedef std::remove_const<typename details::type_of_array<T>::type>::type elem_type;
+//     const auto& self = static_cast<const Derivate&>(*this);
+//     const DataSpace& space = self.getSpace();
+//     DataSpace mem_space = self.getMemSpace();
+
+//     AtomicType<elem_type> array_datatype;
+//     adjust_mem_datatype(array_datatype,
+//                         AtomicType<typename type_of_wide_array<T>::type>(),
+//                         self.getDataType());
+
+//     if (H5Dwrite(details::get_dataset(static_cast<Derivate*>(this)).getId(),
+//                  array_datatype.getId(),
+//                  details::get_memspace_id((static_cast<Derivate*>(this))),
+//                  space.getId(), H5P_DEFAULT,
+//                  static_cast<const void*>(buffer)) < 0) {
+//         HDF5ErrMapper::ToException<DataSetException>(
+//             "Error during HDF5 Write: ");
+//     }
+// }
+
+}  // namespace HighFive
 
 #endif // H5SLICE_TRAITS_MISC_HPP

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -109,10 +109,8 @@ inline Selection SliceTraits<Derivate>::select(const std::vector<size_t>& column
     std::vector<hsize_t> offsets(dims.size(), 0);
 
     H5Sselect_none(space.getId());
-    for (std::vector<size_t>::const_iterator i = columns.begin(); i != columns.end();
-         ++i) {
-
-        offsets[offsets.size() - 1] = *i;
+    for (const auto& i : columns) {
+        offsets[offsets.size() - 1] = i;
         if (H5Sselect_hyperslab(space.getId(), H5S_SELECT_OR, offsets.data(), 0,
                                 counts.data(), 0) < 0) {
             HDF5ErrMapper::ToException<DataSpaceException>("Unable to select hyperslap");

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -31,12 +31,22 @@
 
 namespace HighFive {
 
+// If ever used, recognize dimensions of FixedLenStringArray
+template <std::size_t N>
+class FixedLenStringArray;
+
+
 namespace details {
 
 // determine at compile time number of dimensions of in memory datasets
 template <typename T>
 struct array_dims {
     static constexpr size_t value = 0;
+};
+
+template <std::size_t N>
+struct array_dims<FixedLenStringArray<N>> {
+    static constexpr size_t value = 1;
 };
 
 template <typename T>

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -86,13 +86,13 @@ struct array_dims<std::vector<Eigen::Matrix<T, M, N>>> {
 
 // determine recursively the size of each dimension of a N dimension vector
 template <typename T>
-void get_dim_vector_rec(const T& vec, std::vector<size_t>& dims) {
+inline void get_dim_vector_rec(const T& vec, std::vector<size_t>& dims) {
     (void)dims;
     (void)vec;
 }
 
 template <typename T>
-void get_dim_vector_rec(const std::vector<T>& vec, std::vector<size_t>& dims) {
+inline void get_dim_vector_rec(const std::vector<T>& vec, std::vector<size_t>& dims) {
     dims.push_back(vec.size());
     get_dim_vector_rec(vec[0], dims);
 }
@@ -106,7 +106,7 @@ std::vector<size_t> get_dim_vector(const std::vector<T>& vec) {
 
 // determine recursively the size of each dimension of a N dimension vector
 template <typename T, std::size_t N>
-void get_dim_vector_rec(const T(&vec)[N], std::vector<size_t>& dims) {
+inline void get_dim_vector_rec(const T(&vec)[N], std::vector<size_t>& dims) {
     dims.push_back(N);
     get_dim_vector_rec(vec[0], dims);
 }

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -164,6 +164,21 @@ struct type_of_array<T[N]> {
     typedef typename type_of_array<T>::type type;
 };
 
+template <typename T>
+struct type_of_array_storage {
+    typedef typename type_of_array<T>::type type;
+};
+
+template <typename T, std::size_t N>
+struct type_of_array_storage<T[N]> {
+    typedef typename type_of_array_storage<T>::type type;
+};
+
+template <std::size_t N>
+struct type_of_array_storage<char[N]> {
+    typedef char type[N];
+};
+
 // check if the type is a container ( only vector supported for now )
 template <typename>
 struct is_container {

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -165,6 +165,7 @@ struct type_of_array<T[N]> {
 };
 
 
+// Find the type of an eventual char array, otherwise void
 template <typename>
 struct type_char_array {
     typedef void type;
@@ -201,7 +202,6 @@ struct is_container<std::vector<T> > {
 };
 
 // check if the type is a basic C-Array
-// check if the type is a container ( only vector supported for now )
 template <typename>
 struct is_c_array {
     static const bool value = false;

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -122,7 +122,7 @@ std::vector<size_t> get_dim_vector(const T(&vec)[N]) {
 // determine at compile time recursively the basic type of the data
 template <typename T>
 struct type_of_array {
-    typedef T type;
+    typedef typename std::remove_const<T>::type type;
 };
 
 template <typename T>
@@ -164,20 +164,42 @@ struct type_of_array<T[N]> {
     typedef typename type_of_array<T>::type type;
 };
 
+
+template <typename>
+struct type_char_array {
+    typedef void type;
+};
+
+template <>
+struct type_char_array<char*> {
+    typedef char* type;
+};
+
+template <>
+struct type_char_array<const char*> {
+    typedef char* type;
+};
+
 template <typename T>
-struct type_of_array_storage {
-    typedef typename type_of_array<T>::type type;
+struct type_char_array<T*> {
+    typedef typename type_char_array<T>::type type;
 };
 
 template <typename T, std::size_t N>
-struct type_of_array_storage<T[N]> {
-    typedef typename type_of_array_storage<T>::type type;
+struct type_char_array<T[N]> {
+    typedef typename type_char_array<T>::type type;
 };
 
 template <std::size_t N>
-struct type_of_array_storage<char[N]> {
+struct type_char_array<char[N]> {
     typedef char type[N];
 };
+
+template <std::size_t N>
+struct type_char_array<const char[N]> {
+    typedef char type[N];
+};
+
 
 // check if the type is a container ( only vector supported for now )
 template <typename>

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -170,34 +170,22 @@ struct type_char_array {
     typedef void type;
 };
 
-template <>
-struct type_char_array<char*> {
-    typedef char* type;
-};
-
-template <>
-struct type_char_array<const char*> {
-    typedef char* type;
-};
-
 template <typename T>
 struct type_char_array<T*> {
-    typedef typename type_char_array<T>::type type;
+    typedef typename std::conditional<
+        std::is_same<typename std::remove_const<T>::type, char>::value,
+        char*,
+        typename type_char_array<T>::type
+    >::type type;
 };
 
 template <typename T, std::size_t N>
 struct type_char_array<T[N]> {
-    typedef typename type_char_array<T>::type type;
-};
-
-template <std::size_t N>
-struct type_char_array<char[N]> {
-    typedef char type[N];
-};
-
-template <std::size_t N>
-struct type_char_array<const char[N]> {
-    typedef char type[N];
+    typedef typename std::conditional<
+        std::is_same<typename std::remove_const<T>::type, char>::value,
+        char[N],
+        typename type_char_array<T>::type
+    >::type type;
 };
 
 

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -104,6 +104,21 @@ std::vector<size_t> get_dim_vector(const std::vector<T>& vec) {
     return dims;
 }
 
+// determine recursively the size of each dimension of a N dimension vector
+template <typename T, std::size_t N>
+void get_dim_vector_rec(const T(&vec)[N], std::vector<size_t>& dims) {
+    dims.push_back(N);
+    get_dim_vector_rec(vec[0], dims);
+}
+
+template <typename T, std::size_t N>
+std::vector<size_t> get_dim_vector(const T(&vec)[N]) {
+    std::vector<size_t> dims;
+    get_dim_vector_rec(vec, dims);
+    return dims;
+}
+
+
 // determine at compile time recursively the basic type of the data
 template <typename T>
 struct type_of_array {

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -96,10 +96,7 @@ struct array_dims<std::vector<Eigen::Matrix<T, M, N>>> {
 
 // determine recursively the size of each dimension of a N dimension vector
 template <typename T>
-inline void get_dim_vector_rec(const T& vec, std::vector<size_t>& dims) {
-    (void)dims;
-    (void)vec;
-}
+inline void get_dim_vector_rec(const T& /*vec*/, std::vector<size_t>& /*dims*/) {}
 
 template <typename T>
 inline void get_dim_vector_rec(const std::vector<T>& vec, std::vector<size_t>& dims) {
@@ -108,7 +105,7 @@ inline void get_dim_vector_rec(const std::vector<T>& vec, std::vector<size_t>& d
 }
 
 template <typename T>
-std::vector<size_t> get_dim_vector(const std::vector<T>& vec) {
+inline std::vector<size_t> get_dim_vector(const std::vector<T>& vec) {
     std::vector<size_t> dims;
     get_dim_vector_rec(vec, dims);
     return dims;
@@ -122,7 +119,7 @@ inline void get_dim_vector_rec(const T(&vec)[N], std::vector<size_t>& dims) {
 }
 
 template <typename T, std::size_t N>
-std::vector<size_t> get_dim_vector(const T(&vec)[N]) {
+inline std::vector<size_t> get_dim_vector(const T(&vec)[N]) {
     std::vector<size_t> dims;
     get_dim_vector_rec(vec, dims);
     return dims;
@@ -232,13 +229,15 @@ struct is_c_array<T[N]> {
 };
 
 
-
 // converter function for hsize_t -> size_t when hsize_t != size_t
 template <typename Size>
 inline std::vector<std::size_t> to_vector_size_t(const std::vector<Size>& vec) {
-    static_assert(std::is_same<Size, std::size_t>::value == false, " hsize_t != size_t mandatory here");
+    static_assert(std::is_same<Size, std::size_t>::value == false,
+                  " hsize_t != size_t mandatory here");
     std::vector<size_t> res(vec.size());
-    std::transform(vec.begin(), vec.end(), res.begin(), [](Size e) { return static_cast<size_t>(e); });
+    std::transform(vec.cbegin(), vec.cend(), res.begin(), [](Size e) {
+        return static_cast<size_t>(e);
+    });
     return res;
 }
 

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -80,7 +80,7 @@ inline void write(DataSet& dataset,
         0,
         Eigen::InnerStride<1>> row_major(data);
 
-    dataset.write(row_major.data());
+    dataset.write_raw(row_major.data());
 }
 
 // create DataSet and write data

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -38,7 +38,7 @@ struct dump_impl
         detail::createGroupsToDataSet(file, path);
         DataSet dataset =
             file.createDataSet<typename C::value_type>(path, DataSpace(shape(data)));
-        dataset.write(data.begin());
+        dataset.write_raw(data.data());
         file.flush();
         return dataset;
     }
@@ -55,7 +55,7 @@ struct overwrite_impl
         if (dataset.getDimensions() != shape(data)) {
             throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
         }
-        dataset.write(data.begin());
+        dataset.write_raw(data.data());
         file.flush();
         return dataset;
     }

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -22,10 +22,8 @@ function(compile_example exemple_source)
 
 endfunction()
 
-compile_example("read_write_fixedlen_string.cpp")
+file(GLOB list_example "*.cpp")
 
-# file(GLOB list_example "*.cpp")
-
-# foreach(example_src ${list_example})
-#     compile_example(${example_src})
-# endforeach()
+foreach(example_src ${list_example})
+    compile_example(${example_src})
+endforeach()

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -22,9 +22,10 @@ function(compile_example exemple_source)
 
 endfunction()
 
+compile_example("read_write_fixedlen_string.cpp")
 
-file(GLOB list_example "*.cpp")
+# file(GLOB list_example "*.cpp")
 
-foreach(example_src ${list_example})
-    compile_example(${example_src})
-endforeach()
+# foreach(example_src ${list_example})
+#     compile_example(${example_src})
+# endforeach()

--- a/src/examples/create_attribute_string_integer.cpp
+++ b/src/examples/create_attribute_string_integer.cpp
@@ -59,7 +59,7 @@ int main(void) {
         // let's list the keys of all attributes now
         std::vector<std::string> all_attributes_keys =
             dataset.listAttributeNames();
-        for (const auto& attr: all_attributes_keys) {
+        for (const auto& attr : all_attributes_keys) {
             std::cout << "attribute: " << attr << std::endl;
         }
 

--- a/src/examples/create_attribute_string_integer.cpp
+++ b/src/examples/create_attribute_string_integer.cpp
@@ -59,10 +59,8 @@ int main(void) {
         // let's list the keys of all attributes now
         std::vector<std::string> all_attributes_keys =
             dataset.listAttributeNames();
-        for (std::vector<std::string>::const_iterator it =
-                 all_attributes_keys.begin();
-             it < all_attributes_keys.end(); ++it) {
-            std::cout << "attribute: " << *it << std::endl;
+        for (const auto& attr: all_attributes_keys) {
+            std::cout << "attribute: " << attr << std::endl;
         }
 
     } catch (Exception& err) {

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -28,13 +28,16 @@ int main(void) {
         File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
         //std::vector<std::string> strings_fixed = {"one", "two", "three", "four", "five"};
-        char strings_fixed[][4] = {"abc", "123"};
+        const char strings_fixed[][16] = {"abcabcabcabcabc", "123123123123123"};
 
         // create a dataset ready to contains strings of the size of the vector
         // string_list
         //DataSet dataset = file.createDataSet<int>(DATASET_NAME, DataSpace(10));
+
+        // This will crate an int8 dataset
         DataSet dataset = file.createDataSet(DATASET_NAME, strings_fixed);
 
+        // This shall create a string dataset
         DataSet dataset2 = file.createDataSet<char[10]>("ds2", DataSpace(2));
         dataset2.write(strings_fixed);
 

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -34,10 +34,10 @@ int main(void) {
         file.createDataSet("ds2", strings_fixed);
 
         // Now test the new interface type
-        //FixedLenStringArray<10> arr(std::vector<std::string>{"0000000", "1111111"});
-        FixedLenStringArray<10> arr{"0000000", "1111111"};
+        FixedLenStringArray<10> arr{"0000000", "1111111"};  // also accepts std::vector
         auto ds = file.createDataSet("ds3", arr);
 
+        // Read back truncating to 4 chars
         FixedLenStringArray<4> array_back;
         ds.read(array_back);
         std::cout << "First item is '" << array_back[0] << "'" << std::endl

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -17,7 +17,6 @@
 using namespace HighFive;
 
 const std::string FILE_NAME("create_dataset_string_example.h5");
-const std::string DATASET_NAME("story");
 
 // create a dataset from a vector of string
 // read it back and print it
@@ -26,29 +25,24 @@ int main(void) {
     try {
         // Create a new file using the default property lists.
         File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
-
-        //std::vector<std::string> strings_fixed = {"one", "two", "three", "four", "five"};
         const char strings_fixed[][16] = {"abcabcabcabcabc", "123123123123123"};
 
         // create a dataset ready to contains strings of the size of the vector
-        // string_list
-        //DataSet dataset = file.createDataSet<int>(DATASET_NAME, DataSpace(10));
+        file.createDataSet<char[10]>("ds1", DataSpace(2)).write(strings_fixed);
 
-        // This will crate an int8 dataset
-        const char (*strings_fixed2)[16] = strings_fixed;
-        //DataSet dataset = file.createDataSet(DATASET_NAME, strings_fixed2);
+        // Without specific type info this will crate an int8 dataset
+        file.createDataSet("ds2", strings_fixed);
 
-        // This shall create a string dataset
-        DataSet dataset2 = file.createDataSet<char[10]>("ds2", DataSpace(2));
-        dataset2.write(strings_fixed2);
+        // Now test the new interface type
+        //FixedLenStringArray<10> arr(std::vector<std::string>{"0000000", "1111111"});
+        FixedLenStringArray<10> arr{"0000000", "1111111"};
+        auto ds = file.createDataSet("ds3", arr);
 
-        // // now we read it back
-        // std::vector<std::string> result_string_list;
-        // dataset.read(result_string_list);
+        FixedLenStringArray<4> array_back;
+        ds.read(array_back);
+        std::cout << "First item is '" << array_back[0] << "'" << std::endl
+                  << "Second item is '" << array_back[1] << "'" << std::endl;
 
-        // for (size_t i = 0; i < result_string_list.size(); ++i) {
-        //     std::cout << ":" << i << " " << result_string_list[i] << "\n";
-        // }
 
     } catch (Exception& err) {
         // catch and print any HDF5 error

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -16,7 +16,7 @@
 
 using namespace HighFive;
 
-const std::string FILE_NAME("create_dataset_string_example.h5");
+static const std::string FILE_NAME("create_dataset_string_example.h5");
 
 // create a dataset from a vector of string
 // read it back and print it
@@ -30,7 +30,7 @@ int main(void) {
         // create a dataset ready to contains strings of the size of the vector
         file.createDataSet<char[10]>("ds1", DataSpace(2)).write(strings_fixed);
 
-        // Without specific type info this will crate an int8 dataset
+        // Without specific type info this will create an int8 dataset
         file.createDataSet("ds2", strings_fixed);
 
         // Now test the new interface type
@@ -44,7 +44,7 @@ int main(void) {
                   << "Second item is '" << array_back[1] << "'" << std::endl;
 
 
-    } catch (Exception& err) {
+    } catch (const Exception& err) {
         // catch and print any HDF5 error
         std::cerr << err.what() << std::endl;
     }

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -35,11 +35,12 @@ int main(void) {
         //DataSet dataset = file.createDataSet<int>(DATASET_NAME, DataSpace(10));
 
         // This will crate an int8 dataset
-        DataSet dataset = file.createDataSet(DATASET_NAME, strings_fixed);
+        const char (*strings_fixed2)[16] = strings_fixed;
+        //DataSet dataset = file.createDataSet(DATASET_NAME, strings_fixed2);
 
         // This shall create a string dataset
         DataSet dataset2 = file.createDataSet<char[10]>("ds2", DataSpace(2));
-        dataset2.write(strings_fixed);
+        dataset2.write(strings_fixed2);
 
         // // now we read it back
         // std::vector<std::string> result_string_list;

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c), 2020, Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <highfive/H5File.hpp>
+#include <highfive/H5DataSet.hpp>
+#include <highfive/H5DataSpace.hpp>
+
+using namespace HighFive;
+
+const std::string FILE_NAME("create_dataset_string_example.h5");
+const std::string DATASET_NAME("story");
+
+// create a dataset from a vector of string
+// read it back and print it
+int main(void) {
+
+    try {
+        // Create a new file using the default property lists.
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+
+        //std::vector<std::string> strings_fixed = {"one", "two", "three", "four", "five"};
+        char strings_fixed[][4] = {"abc", "123"};
+
+        // create a dataset ready to contains strings of the size of the vector
+        // string_list
+        //DataSet dataset = file.createDataSet<int>(DATASET_NAME, DataSpace(10));
+        DataSet dataset = file.createDataSet(DATASET_NAME, strings_fixed);
+
+        DataSet dataset2 = file.createDataSet<char[10]>("ds2", DataSpace(2));
+        dataset2.write(strings_fixed);
+
+        // // now we read it back
+        // std::vector<std::string> result_string_list;
+        // dataset.read(result_string_list);
+
+        // for (size_t i = 0; i < result_string_list.size(); ++i) {
+        //     std::cout << ":" << i << " " << result_string_list[i] << "\n";
+        // }
+
+    } catch (Exception& err) {
+        // catch and print any HDF5 error
+        std::cerr << err.what() << std::endl;
+    }
+
+    return 0; // successfully terminated
+}

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -34,7 +34,6 @@ typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, 
     dataset_test_types;
 
 
-
 template <typename T, typename Func>
 void fillVec(std::vector<std::vector<T>>& v, std::vector<size_t> dims, const Func& f) {
     v.resize(dims[0]);

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -25,16 +25,13 @@ using complex = std::complex<double>;
 
 typedef boost::mpl::list<float, double> floating_numerics_test_types;
 
-// typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
-//                          float, double, long long, unsigned long long, complex>
-//     numerical_test_types;
+typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
+                         float, double, long long, unsigned long long, complex>
+    numerical_test_types;
 
-// typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
-//                          float, double>
-//     dataset_test_types;
-
-typedef boost::mpl::list<int, float, char> numerical_test_types;
-typedef boost::mpl::list<int, float, char> dataset_test_types;
+typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
+                         float, double>
+    dataset_test_types;
 
 
 

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -25,13 +25,17 @@ using complex = std::complex<double>;
 
 typedef boost::mpl::list<float, double> floating_numerics_test_types;
 
-typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
-                         float, double, long long, unsigned long long, complex>
-    numerical_test_types;
+// typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
+//                          float, double, long long, unsigned long long, complex>
+//     numerical_test_types;
 
-typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
-                         float, double>
-    dataset_test_types;
+// typedef boost::mpl::list<int, unsigned int, long, unsigned long, unsigned char, char,
+//                          float, double>
+//     dataset_test_types;
+
+typedef boost::mpl::list<int, float, char> numerical_test_types;
+typedef boost::mpl::list<int, float, char> dataset_test_types;
+
 
 
 template <typename T, typename Func>

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1191,7 +1191,7 @@ BOOST_AUTO_TEST_CASE(HighFiveInspect) {
 }
 
 
-BOOST_AUTO_TEST_CASE(HighFiveCharArray) {
+BOOST_AUTO_TEST_CASE(HighFiveFixedString) {
     const std::string FILE_NAME("array_atomic_types.h5");
     const std::string GROUP_1("group1");
 
@@ -1235,9 +1235,22 @@ BOOST_AUTO_TEST_CASE(HighFiveCharArray) {
         file.createDataSet<char[10]>("ds6", DataSpace(1)).write(buffer);
     }
 
-    { // TODO: vector of char[]
-        //const std::vector<std::array<char, 10>> buffer = {"abcd", "1234"};
-        //file.createDataSet<char[10]>("ds7", DataSpace(2)).write(buffer);
+    { // Dedicated FixedLenStringArray
+        FixedLenStringArray<10> arr{"0000000", "1111111"};
+        // For completeness, test also the other constructor
+        FixedLenStringArray<10> arrx(std::vector<std::string>{"0000", "1111"});
+
+        // More API: test inserting something
+        arr.push_back("2222");
+        auto ds = file.createDataSet("ds7", arr);  // Short syntax ok
+
+        // Recover truncating
+        FixedLenStringArray<4> array_back;
+        ds.read(array_back);
+        BOOST_CHECK(array_back.size() == 3);
+        BOOST_CHECK(array_back[0] == std::string("000"));
+        BOOST_CHECK(array_back[1] == std::string("111"));
+        BOOST_CHECK(array_back[2] == std::string("222"));
     }
 }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -626,6 +626,32 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
             BOOST_CHECK_EQUAL(my_nested[i][j], out_nested[i][j]);
         }
     }
+
+    // Plain c arrays. 1D
+    {
+        int int_c_array[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        DataSet ds_int2 = file.createDataSet("/TmpCArrayInt", int_c_array);
+
+        decltype(int_c_array) int_c_array_out;
+        ds_int2.read(int_c_array_out);
+        for (size_t i = 0; i < 10; ++i) {
+            BOOST_CHECK_EQUAL(int_c_array[i], int_c_array_out[i]);
+        }
+    }
+
+    // Plain c arrays. 2D
+    {
+        char char_c_2darray[][3] = {"aa", "bb", "cc", "12"};
+        DataSet ds_char2 = file.createDataSet("/TmpCArray2dchar", char_c_2darray);
+
+        decltype(char_c_2darray) char_c_2darray_out;
+        ds_char2.read(char_c_2darray_out);
+        for (size_t i = 0; i < 4; ++i) {
+            for (size_t j = 0; j < 3; ++j) {
+                BOOST_CHECK_EQUAL(char_c_2darray[i][j], char_c_2darray_out[i][j]);
+            }
+        }
+    }
 }
 
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1199,7 +1199,7 @@ BOOST_AUTO_TEST_CASE(HighFiveCharArray) {
     File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
     char raw_strings[][10] = {"abcd", "1234"};
 
-    /// This will not compile, hits static_assert with a nice error
+    /// This will not compile - only char arrays - hits static_assert with a nice error
     // file.createDataSet<int[10]>(DS_NAME, DataSpace(2)));
 
     { // But char should be fine
@@ -1233,6 +1233,11 @@ BOOST_AUTO_TEST_CASE(HighFiveCharArray) {
     { // scalar char strings
         const char buffer[] = "abcd";
         file.createDataSet<char[10]>("ds6", DataSpace(1)).write(buffer);
+    }
+
+    { // TODO: vector of char[]
+        //const std::vector<std::array<char, 10>> buffer = {"abcd", "1234"};
+        //file.createDataSet<char[10]>("ds7", DataSpace(2)).write(buffer);
     }
 }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -668,19 +668,26 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
         BOOST_CHECK_EQUAL(arr2.size(), 4);
     }
 
+    using array_t = FixedLenStringArray<10>;
+    // increment the characters of a string written in a std::array
+    auto increment_string = [](const array_t::value_type arr) {
+        array_t::value_type result(arr);
+        for (auto& c : result) {
+            if (c == 0) {
+                break;
+            }
+            ++c;
+        }
+        return result;
+    };
+
     // manipulate FixedLenStringArray with std::transform
     {
-        using array_t = FixedLenStringArray<10>;
         array_t arr;
         {
             const array_t arr1{"0000000", "1111111"};
-            auto increment_string = [](const array_t::value_type arr) {
-                array_t::value_type result;
-                std::transform(arr.begin(), arr.end(), result.begin(),
-                               [](char c) { return c + 1; });
-                return result;
-            };
-            std::transform(arr1.begin(), arr1.begin(), arr.begin(), increment_string);
+            std::transform(arr1.begin(), arr1.end(), std::back_inserter(arr),
+                           increment_string);
         }
         BOOST_CHECK_EQUAL(arr.size(), 2);
         BOOST_CHECK_EQUAL(arr[0], std::string("1111111"));
@@ -689,30 +696,22 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
 
     // manipulate FixedLenStringArray with std::transform and reverse iterator
     {
-        using array_t = FixedLenStringArray<10>;
         array_t arr;
         {
             const array_t arr1{"0000000", "1111111"};
-            auto increment_string = [](const array_t::value_type arr) {
-                array_t::value_type result;
-                std::transform(arr.begin(), arr.end(), result.begin(),
-                               [](char c) { return c + 1; });
-                return result;
-            };
-            std::transform(arr1.rbegin(), arr1.rbegin(), arr.begin(), increment_string);
+            std::copy(arr1.rbegin(), arr1.rend(), std::back_inserter(arr));
         }
         BOOST_CHECK_EQUAL(arr.size(), 2);
-        BOOST_CHECK_EQUAL(arr[0], std::string("2222222"));
-        BOOST_CHECK_EQUAL(arr[1], std::string("1111111"));
+        BOOST_CHECK_EQUAL(arr[0], std::string("1111111"));
+        BOOST_CHECK_EQUAL(arr[1], std::string("0000000"));
     }
 
     // manipulate FixedLenStringArray with std::remove_copy_if
     {
-        using array_t = FixedLenStringArray<10>;
         array_t arr2;
         {
             const array_t arr1{"0000000", "1111111"};
-            std::remove_copy_if(arr1.begin(), arr1.end(), arr2.begin(),
+            std::remove_copy_if(arr1.begin(), arr1.end(), std::back_inserter(arr2),
                                 [](const array_t::value_type& s) {
                                     return std::strncmp(s.data(), "1111111", 7) == 0;
                                 });

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -659,33 +659,36 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
             }
         }
     }
+}
 
-    // manipulate FixedLenStringArray with std::copy
-    {
-        const FixedLenStringArray<10> arr1{"0000000", "1111111"};
-        FixedLenStringArray<10> arr2{"0000000", "1111111"};
-        std::copy(arr1.begin(), arr1.end(), std::back_inserter(arr2));
-        BOOST_CHECK_EQUAL(arr2.size(), 4);
-    }
+BOOST_AUTO_TEST_CASE(HighFiveFixedLenStringArrayStructure) {
 
-    using array_t = FixedLenStringArray<10>;
+    using fixed_array_t = FixedLenStringArray<10>;
     // increment the characters of a string written in a std::array
-    auto increment_string = [](const array_t::value_type arr) {
-        array_t::value_type result(arr);
-        for (auto& c : result) {
+    auto increment_string = [](const fixed_array_t::value_type arr) {
+        fixed_array_t::value_type output(arr);
+        for (auto& c : output) {
             if (c == 0) {
                 break;
             }
             ++c;
         }
-        return result;
+        return output;
     };
+
+    // manipulate FixedLenStringArray with std::copy
+    {
+        const fixed_array_t arr1{"0000000", "1111111"};
+        fixed_array_t arr2{"0000000", "1111111"};
+        std::copy(arr1.begin(), arr1.end(), std::back_inserter(arr2));
+        BOOST_CHECK_EQUAL(arr2.size(), 4);
+    }
 
     // manipulate FixedLenStringArray with std::transform
     {
-        array_t arr;
+        fixed_array_t arr;
         {
-            const array_t arr1{"0000000", "1111111"};
+            const fixed_array_t arr1{"0000000", "1111111"};
             std::transform(arr1.begin(), arr1.end(), std::back_inserter(arr),
                            increment_string);
         }
@@ -696,9 +699,9 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
 
     // manipulate FixedLenStringArray with std::transform and reverse iterator
     {
-        array_t arr;
+        fixed_array_t arr;
         {
-            const array_t arr1{"0000000", "1111111"};
+            const fixed_array_t arr1{"0000000", "1111111"};
             std::copy(arr1.rbegin(), arr1.rend(), std::back_inserter(arr));
         }
         BOOST_CHECK_EQUAL(arr.size(), 2);
@@ -708,11 +711,11 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
 
     // manipulate FixedLenStringArray with std::remove_copy_if
     {
-        array_t arr2;
+        fixed_array_t arr2;
         {
-            const array_t arr1{"0000000", "1111111"};
+            const fixed_array_t arr1{"0000000", "1111111"};
             std::remove_copy_if(arr1.begin(), arr1.end(), std::back_inserter(arr2),
-                                [](const array_t::value_type& s) {
+                                [](const fixed_array_t::value_type& s) {
                                     return std::strncmp(s.data(), "1111111", 7) == 0;
                                 });
         }

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1078,7 +1078,7 @@ void readWriteShuffleDeflateTest() {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteShuffleDeflate, T, numerical_test_types) {
-    //readWriteShuffleDeflateTest<T>();
+    readWriteShuffleDeflateTest<T>();
 }
 
 // Broadcasting is supported
@@ -1270,6 +1270,14 @@ BOOST_AUTO_TEST_CASE(HighFiveFixedString) {
         BOOST_CHECK(array_back.data() == std::string("000"));
         array_back.data()[0] = 'x';
         BOOST_CHECK(array_back.data() == std::string("x00"));
+
+        for (auto& raw_elem : array_back) {
+            raw_elem[1] = 'y';
+        }
+        BOOST_CHECK(array_back.getString(1) == "1y1");
+        for (auto iter = array_back.cbegin(); iter != array_back.cend(); ++iter) {
+            BOOST_CHECK((*iter)[1] == 'y');
+        }
     }
 }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1264,6 +1264,12 @@ BOOST_AUTO_TEST_CASE(HighFiveFixedString) {
         BOOST_CHECK(array_back[0] == std::string("000"));
         BOOST_CHECK(array_back[1] == std::string("111"));
         BOOST_CHECK(array_back[2] == std::string("222"));
+        BOOST_CHECK(array_back.getString(1) == "111");
+        BOOST_CHECK(array_back.front() == std::string("000"));
+        BOOST_CHECK(array_back.back() == std::string("222"));
+        BOOST_CHECK(array_back.data() == std::string("000"));
+        array_back.data()[0] = 'x';
+        BOOST_CHECK(array_back.data() == std::string("x00"));
     }
 }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -189,14 +189,14 @@ BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSet) {
         {
             SilenceHDF5 silencer;
             BOOST_CHECK_THROW(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
-                                             AtomicType<double>(),
-                                             badChunking0),
-                          DataSetException);
+                                                 AtomicType<double>(),
+                                                 badChunking0),
+                              DataSetException);
 
             BOOST_CHECK_THROW(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
-                                             AtomicType<double>(),
-                                             badChunking1),
-                          DataSetException);
+                                                 AtomicType<double>(),
+                                                 badChunking1),
+                              DataSetException);
         }
 
         // here we use the other signature

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1069,7 +1069,7 @@ void readWriteShuffleDeflateTest() {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteShuffleDeflate, T, numerical_test_types) {
-    readWriteShuffleDeflateTest<T>();
+    //readWriteShuffleDeflateTest<T>();
 }
 
 // Broadcasting is supported
@@ -1182,6 +1182,28 @@ BOOST_AUTO_TEST_CASE(HighFiveInspect) {
     BOOST_CHECK(ds.getType() == ObjectType::Dataset);  // internal
     BOOST_CHECK(ds.getInfo().getRefCount() == 1);
 }
+
+
+BOOST_AUTO_TEST_CASE(HighFiveAtomicCharArray) {
+    const std::string FILE_NAME("array_atomic_types.h5");
+    const std::string GROUP_1("group1");
+    const std::string DS_NAME = "ds";
+
+    // Create a new file using the default property lists.
+    File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+
+    /// This will not compile, hits static_assert with a nice error
+    // file.createDataSet<int[10]>(DS_NAME, DataSpace(2)));
+
+    // But char should be fine
+    auto ds = file.createDataSet<char[10]>(DS_NAME, DataSpace(2));
+    BOOST_CHECK(ds.getDataType().getClass() == DataTypeClass::String);
+
+    char raw_strings[][10] = {"abcd", "1234"};
+    ds.write(raw_strings);
+}
+
+
 
 #ifdef H5_USE_EIGEN
 BOOST_AUTO_TEST_CASE(HighFiveEigen) {


### PR DESCRIPTION
## This PR
* Adds core support and API for fixed length strings
* Change `write(const T*)` to `write_raw(const T*, const DataType& dtype = DataType())`.
 The change of the name is intended to fix #275, while the introduction of the optional dtype allows users to raw write data structures whose type is ambiguous (e.g. char[] is fixed-string or int8 array?)

## Rationale
The type `char[N]` is now considered a valid Atomic type. The user can therefore
```c++
// create  a dataset for fixed length strings as 
ds = file.createDataSet<char[10]>("ds1", dataspace);
// write raw data
char my_strings[][10] = {"abc", "def"};
ds.write(my_strings);
```

While the previous API is great for performance, a high level API was also introduced, compatible with the short-circuit syntax:
```c++
// Have FixedLenStringArray initialised from std::string containers
FixedLenStringArray<10> arr{"abcde", "010101"};
// create DS and write in single step
file.createDataSet("ds3", arr);
```
Data is internally stored as `vector<array<char,N>>`, as returned by Hdf5 directly. As so operator returns char*, but the user may request an `std::string` using `getString()`

### Extras
* Simplifies internal converters / Improves const-correctness
* Introduces `BufferInfo` in ReadWrite_misc to help detecting a buffer type with the help of the DataSet type. 
* Spins-off Eigen Converter routines t its own source

fixes #94 
fixes #275 