### PR TITLE
Proposal: Add Attributes to H5Easy

### DIFF
--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -68,7 +68,7 @@ inline size_t getSize(const File& file, const std::string& path);
 ///
 /// \brief Get the shape of an existing DataSet in an readable file.
 ///
-/// \param file Readable opened HDF5 file
+/// \param file Open HDF5 file, readable
 /// \param path Path of the DataSet
 ///
 /// \return the shape of the DataSet

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -39,6 +39,7 @@
 
 namespace H5Easy {
 
+using HighFive::Attribute;
 using HighFive::AtomicType;
 using HighFive::Chunking;
 using HighFive::DataSet;
@@ -74,7 +75,7 @@ inline size_t getSize(const File& file, const std::string& path);
 inline std::vector<size_t> getShape(const File& file, const std::string& path);
 
 ///
-/// \brief Write an Eigen matrix to a new DataSet in an open HDF5 file.
+/// \brief Write an Eigen matrix to a DataSet in an open HDF5 file.
 ///
 /// \param file Writeable opened file
 /// \param path Path of the DataSet
@@ -92,7 +93,7 @@ inline DataSet dump(File& file,
 #endif
 
 ///
-/// \brief Write "xt::xarray<T>" to a new DataSet in an open HDF5 file.
+/// \brief Write "xt::xarray<T>" to a DataSet in an open HDF5 file.
 ///
 /// \param file A writeable opened HDF5 file
 /// \param path Path of the DataSet
@@ -110,7 +111,7 @@ inline DataSet dump(File& file,
 #endif
 
 ///
-/// \brief Write "xt::xtensor<T,rank>" to a new DataSet in an open HDF5 file.
+/// \brief Write "xt::xtensor<T,rank>" to a DataSet in an open HDF5 file.
 ///
 /// \param file opened File (has to be writeable)
 /// \param path path of the DataSet
@@ -128,7 +129,7 @@ inline DataSet dump(File& file,
 #endif
 
 ///
-/// \brief Write "std::vector<T>" to a new DataSet in an open HDF5 file.
+/// \brief Write "std::vector<T>" to a DataSet in an open HDF5 file.
 ///
 /// \param file opened File (has to be writeable)
 /// \param path path of the DataSet
@@ -144,7 +145,7 @@ inline DataSet dump(File& file,
                     DumpMode mode = DumpMode::Create);
 
 ///
-/// \brief Write scalar/string to a new DataSet in an open HDF5 file.
+/// \brief Write scalar/string to a DataSet in an open HDF5 file.
 ///
 /// \param file Writeable opened file
 /// \param path Path of the DataSet
@@ -199,6 +200,66 @@ inline T load(const File& file,
 ///
 template <class T>
 inline T load(const File& file, const std::string& path);
+
+///
+/// \brief Write to an Attribute of an existing DataSet in an open HDF5 file.
+///
+/// \param file Writeable opened file
+/// \param path Path to the DataSet
+/// \param key Path of the Attribute
+/// \param data Data to write
+/// \param mode Write mode
+///
+/// \return the newly created Attribute
+///
+template <class T>
+inline Attribute dump_attribute(File& file,
+                                const std::string& path,
+                                const std::string& key,
+                                const T& data,
+                                DumpMode mode = DumpMode::Create);
+
+///
+/// \brief Write scalar/string to an Attribute of an existing DataSet in an open HDF5 file.
+///
+/// \param file Writeable opened file
+/// \param dataset Opened DataSet
+/// \param key Path of the Attribute
+/// \param data Data to write
+/// \param mode Write mode
+///
+/// \return the newly created Attribute
+///
+template <class T>
+inline Attribute dump_attribute(File& file,
+                                DataSet& dataset,
+                                const std::string& key,
+                                const T& data,
+                                DumpMode mode = DumpMode::Create);
+
+///
+/// \brief Load an Attribute in an open HDF5 file to an object (templated).
+///
+/// \param file opened File (has to be writeable)
+/// \param path Path to the DataSet
+/// \param key Path of the Attribute
+///
+/// \return the read data
+///
+template <class T>
+inline T load_attribute(const File& file, const std::string& path, const std::string &key);
+
+///
+/// \brief Load an Attribute in an open HDF5 file to an object (templated).
+///
+/// \param file opened File (has to be writeable)
+/// \param dataset Opened DataSet
+/// \param key Path of the Attribute
+///
+/// \return the read data
+///
+template <class T>
+inline T load_attribute(const File& file, const DataSet& dataset, const std::string &key);
 
 }  // namespace H5Easy
 

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -59,7 +59,7 @@ enum class DumpMode
 ///
 /// \brief Get the size of an existing DataSet in an open HDF5 file.
 ///
-/// \param file Readable opened HDF5 file
+/// \param file Open HDF5 file, readable
 /// \param path Path of the DataSet
 ///
 /// \return Size of the DataSet

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -95,7 +95,7 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write "xt::xarray<T>" to a DataSet in an open HDF5 file.
 ///
-/// \param file Writeable opened HDF5 file
+/// \param file Open HDF5 file, writable
 /// \param path Path of the DataSet
 /// \param data xtensor array to write
 /// \param mode Write mode

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -113,7 +113,7 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write "xt::xtensor<T,rank>" to a DataSet in an open HDF5 file.
 ///
-/// \param file Writeable opened HDF5 file
+/// \param file Open HDF5 file, writable
 /// \param path Path of the DataSet
 /// \param data The data to write
 /// \param mode Write mode

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -59,7 +59,7 @@ enum class DumpMode
 ///
 /// \brief Get the size of an existing DataSet in an open HDF5 file.
 ///
-/// \param file A readable opened file
+/// \param file Readable opened HDF5 file
 /// \param path Path of the DataSet
 ///
 /// \return Size of the DataSet
@@ -68,7 +68,7 @@ inline size_t getSize(const File& file, const std::string& path);
 ///
 /// \brief Get the shape of an existing DataSet in an readable file.
 ///
-/// \param file A readable opened file
+/// \param file Readable opened HDF5 file
 /// \param path Path of the DataSet
 ///
 /// \return the shape of the DataSet
@@ -77,12 +77,12 @@ inline std::vector<size_t> getShape(const File& file, const std::string& path);
 ///
 /// \brief Write an Eigen matrix to a DataSet in an open HDF5 file.
 ///
-/// \param file Writeable opened file
+/// \param file Writeable opened HDF5 file
 /// \param path Path of the DataSet
 /// \param data eigen matrix to write
 /// \param mode Write mode
 ///
-/// \return the newly created DataSet
+/// \return Newly created DataSet
 ///
 #ifdef H5_USE_EIGEN
 template <class T, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
@@ -95,12 +95,12 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write "xt::xarray<T>" to a DataSet in an open HDF5 file.
 ///
-/// \param file A writeable opened HDF5 file
+/// \param file Writeable opened HDF5 file
 /// \param path Path of the DataSet
 /// \param data xtensor array to write
-/// \param mode write mode
+/// \param mode Write mode
 ///
-/// \return the newly created DataSet
+/// \return Newly created DataSet
 ///
 #ifdef H5_USE_XTENSOR
 template <class T>
@@ -113,12 +113,12 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write "xt::xtensor<T,rank>" to a DataSet in an open HDF5 file.
 ///
-/// \param file opened File (has to be writeable)
-/// \param path path of the DataSet
-/// \param data the data to write
-/// \param mode write mode
+/// \param file Writeable opened HDF5 file
+/// \param path Path of the DataSet
+/// \param data The data to write
+/// \param mode Write mode
 ///
-/// \return the newly created DataSet
+/// \return Newly created DataSet
 ///
 #ifdef H5_USE_XTENSOR
 template <class T, size_t rank>
@@ -131,12 +131,12 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write "std::vector<T>" to a DataSet in an open HDF5 file.
 ///
-/// \param file opened File (has to be writeable)
-/// \param path path of the DataSet
-/// \param data the data to write
-/// \param mode write mode
+/// \param file Writeable opened HDF5 file
+/// \param path Path of the DataSet
+/// \param data The data to write
+/// \param mode Write mode
 ///
-/// \return the newly created DataSet
+/// \return Newly created DataSet
 ///
 template <class T>
 inline DataSet dump(File& file,
@@ -147,12 +147,12 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write scalar/string to a DataSet in an open HDF5 file.
 ///
-/// \param file Writeable opened file
+/// \param file Writeable opened HDF5 file
 /// \param path Path of the DataSet
 /// \param data Data to write
 /// \param mode Write mode
 ///
-/// \return The newly created DataSet
+/// \return Newly created DataSet
 ///
 template <class T>
 inline DataSet dump(File& file,
@@ -163,12 +163,12 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write a scalar to a (new, extendible) DataSet in an open HDF5 file.
 ///
-/// \param file opened File (has to be writeable)
-/// \param path path of the DataSet
-/// \param data the data to write
-/// \param idx the indices to which to write
+/// \param file Writeable opened HDF5 file
+/// \param path Path of the DataSet
+/// \param data The data to write
+/// \param idx Indices to which to write
 ///
-/// \return The newly created DataSet
+/// \return Newly created DataSet
 ///
 template <class T>
 inline DataSet dump(File& file,
@@ -179,11 +179,11 @@ inline DataSet dump(File& file,
 ///
 /// \brief Load entry "(i,j)" from a rank-two DataSet in an open HDF5 file to a scalar.
 ///
-/// \param file opened File (has to be writeable)
-/// \param idx the indices to load
-/// \param path path of the DataSet
+/// \param file Readable opened HDF5 file
+/// \param path Path of the DataSet
+/// \param idx Indices to load
 ///
-/// \return the read data
+/// \return Read data
 ///
 template <class T>
 inline T load(const File& file,
@@ -193,10 +193,10 @@ inline T load(const File& file,
 ///
 /// \brief Load a DataSet in an open HDF5 file to an object (templated).
 ///
-/// \param file opened File (has to be writeable)
-/// \param path path of the DataSet
+/// \param file Readable opened HDF5 file
+/// \param path Path of the DataSet
 ///
-/// \return the read data
+/// \return Read data
 ///
 template <class T>
 inline T load(const File& file, const std::string& path);
@@ -204,7 +204,7 @@ inline T load(const File& file, const std::string& path);
 ///
 /// \brief Write to an Attribute of an existing DataSet in an open HDF5 file.
 ///
-/// \param file Writeable opened file
+/// \param file Writeable opened HDF5 file
 /// \param path Path to the DataSet
 /// \param key Path of the Attribute
 /// \param data Data to write
@@ -220,19 +220,87 @@ inline Attribute dump_attribute(File& file,
                                 DumpMode mode = DumpMode::Create);
 
 ///
+/// \brief Write an Eigen matrix to a DataSet in an open HDF5 file.
+///
+/// \param dataset Opened DataSet
+/// \param key Path of the Attribute
+/// \param data eigen matrix to write
+/// \param mode Write mode
+///
+/// \return Newly created Attribute
+///
+#ifdef H5_USE_EIGEN
+template <class T, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+inline Attribute dump_attribute(DataSet& dataset,
+                                const std::string& key,
+                                const Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>& data,
+                                DumpMode mode = DumpMode::Create);
+#endif
+
+///
+/// \brief Write "xt::xarray<T>" to a DataSet in an open HDF5 file.
+///
+/// \param dataset Opened DataSet
+/// \param key Path of the Attribute
+/// \param data xtensor array to write
+/// \param mode Write mode
+///
+/// \return Newly created Attribute
+///
+#ifdef H5_USE_XTENSOR
+template <class T>
+inline Attribute dump_attribute(DataSet& dataset,
+                                const std::string& key,
+                                const xt::xarray<T>& data,
+                                DumpMode mode = DumpMode::Create);
+#endif
+
+///
+/// \brief Write "xt::xtensor<T,rank>" to a DataSet in an open HDF5 file.
+///
+/// \param dataset Opened DataSet
+/// \param key Path of the Attribute
+/// \param data The data to write
+/// \param mode Write mode
+///
+/// \return Newly created Attribute
+///
+#ifdef H5_USE_XTENSOR
+template <class T, size_t rank>
+inline Attribute dump_attribute(DataSet& dataset,
+                                const std::string& key,
+                                const xt::xtensor<T, rank>& data,
+                                DumpMode mode = DumpMode::Create);
+#endif
+
+///
+/// \brief Write "std::vector<T>" to a DataSet in an open HDF5 file.
+///
+/// \param dataset Opened DataSet
+/// \param key Path of the Attribute
+/// \param data The data to write
+/// \param mode Write mode
+///
+/// \return Newly created Attribute
+///
+template <class T>
+inline Attribute dump_attribute(DataSet& dataset,
+                                const std::string& key,
+                                const std::vector<T>& data,
+                                DumpMode mode = DumpMode::Create);
+
+///
 /// \brief Write scalar/string to an Attribute of an existing DataSet in an open HDF5 file.
 ///
-/// \param file Writeable opened file
 /// \param dataset Opened DataSet
 /// \param key Path of the Attribute
 /// \param data Data to write
 /// \param mode Write mode
 ///
-/// \return the newly created Attribute
+/// \return Newly created Attribute
 ///
 template <class T>
-inline Attribute dump_attribute(File& file,
-                                DataSet& dataset,
+inline Attribute dump_attribute(DataSet& dataset,
                                 const std::string& key,
                                 const T& data,
                                 DumpMode mode = DumpMode::Create);
@@ -244,7 +312,7 @@ inline Attribute dump_attribute(File& file,
 /// \param path Path to the DataSet
 /// \param key Path of the Attribute
 ///
-/// \return the read data
+/// \return Read data
 ///
 template <class T>
 inline T load_attribute(const File& file, const std::string& path, const std::string &key);
@@ -256,7 +324,7 @@ inline T load_attribute(const File& file, const std::string& path, const std::st
 /// \param dataset Opened DataSet
 /// \param key Path of the Attribute
 ///
-/// \return the read data
+/// \return Read data
 ///
 template <class T>
 inline T load_attribute(const DataSet& dataset, const std::string &key);

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -259,7 +259,7 @@ inline T load_attribute(const File& file, const std::string& path, const std::st
 /// \return the read data
 ///
 template <class T>
-inline T load_attribute(const File& file, const DataSet& dataset, const std::string &key);
+inline T load_attribute(const DataSet& dataset, const std::string &key);
 
 }  // namespace H5Easy
 

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -77,7 +77,7 @@ inline std::vector<size_t> getShape(const File& file, const std::string& path);
 ///
 /// \brief Write an Eigen matrix to a DataSet in an open HDF5 file.
 ///
-/// \param file Writeable opened HDF5 file
+/// \param file Open HDF5 file, writable
 /// \param path Path of the DataSet
 /// \param data eigen matrix to write
 /// \param mode Write mode

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -27,6 +27,19 @@ inline Exception error(const File& file,
     return Exception(ss.str());
 }
 
+// Generate error-stream and return "Exception" (not yet thrown).
+inline Exception error(const File& file,
+                       const DataSet&,
+                       const std::string& key,
+                       const std::string& message)
+{
+    std::ostringstream ss;
+    ss << message << std::endl
+       << "Key: " << key << std::endl
+       << "Filename: " << file.getName() << std::endl;
+    return Exception(ss.str());
+}
+
 ///
 /// Get the parent of a path.
 /// For example for ``path = "/path/to/dataset"`` this function returns

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -28,15 +28,11 @@ inline Exception error(const File& file,
 }
 
 // Generate error-stream and return "Exception" (not yet thrown).
-inline Exception error(const File& file,
-                       const DataSet&,
-                       const std::string& key,
+inline Exception error(const std::string& key,
                        const std::string& message)
 {
     std::ostringstream ss;
-    ss << message << std::endl
-       << "Key: " << key << std::endl
-       << "Filename: " << file.getName() << std::endl;
+    ss << key << ": " << message << std::endl;
     return Exception(ss.str());
 }
 


### PR DESCRIPTION
This is a proposal for the extension of the H5Easy API. It would allow:

```cpp
#include <Eigen/Eigen>
#include <highfive/H5Easy.hpp>

int main()
{
    Eigen::Vector3d a;
    a(0) = 1.0;
    a(1) = 2.0;
    a(2) = 3.0;

    H5Easy::File data("test.h5", H5Easy::File::Overwrite);

    H5Easy::dump(data, "/a", a);
    H5Easy::dump_attribute(data, "/a", "desc", std::string("Foobar"));
    std::cout << H5Easy::load_attribute<std::string>(data, "/a", "desc") << std::endl;
}
```

Comments would be great!