### PR TITLE
Adding Eigen::Ref to H5Easy (and simplifying Eigen overload)

### DIFF
--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -110,6 +110,24 @@ inline DataSet dump(File& file,
 #endif
 
 ///
+/// \brief Write an Eigen::Map object to a new DataSet in an open HDF5 file.
+///
+/// \param file Writeable opened file
+/// \param path Path of the DataSet
+/// \param data eigen matrix to write
+/// \param mode Write mode
+///
+/// \return the newly created DataSet
+///
+#ifdef H5_USE_EIGEN
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const Eigen::Map<T>& data,
+                    DumpMode mode = DumpMode::Create);
+#endif
+
+///
 /// \brief Write "xt::xarray<T>" to a new DataSet in an open HDF5 file.
 ///
 /// \param file A writeable opened HDF5 file

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -92,6 +92,24 @@ inline DataSet dump(File& file,
 #endif
 
 ///
+/// \brief Write an Eigen::Ref object to a new DataSet in an open HDF5 file.
+///
+/// \param file Writeable opened file
+/// \param path Path of the DataSet
+/// \param data eigen matrix to write
+/// \param mode Write mode
+///
+/// \return the newly created DataSet
+///
+#ifdef H5_USE_EIGEN
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const Eigen::Ref<T>& data,
+                    DumpMode mode = DumpMode::Create);
+#endif
+
+///
 /// \brief Write "xt::xarray<T>" to a new DataSet in an open HDF5 file.
 ///
 /// \param file A writeable opened HDF5 file

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -137,6 +137,22 @@ struct load_impl
     }
 };
 
+// universal front-end (to minimise double code)
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    DumpMode mode)
+{
+    if (!file.exist(path)) {
+        return detail::eigen::dump_impl(file, path, data);
+    } else if (mode == DumpMode::Overwrite) {
+        return detail::eigen::overwrite_impl(file, path, data);
+    } else {
+        throw detail::error(file, path, "H5Easy: path already exists");
+    }
+}
+
 }  // namespace eigen
 
 // front-end
@@ -161,13 +177,7 @@ inline DataSet dump(File& file,
                     const Eigen::Matrix<T,Rows,Cols,Options,MaxRows,MaxCols>& data,
                     DumpMode mode)
 {
-    if (!file.exist(path)) {
-        return detail::eigen::dump_impl(file, path, data);
-    } else if (mode == DumpMode::Overwrite) {
-        return detail::eigen::overwrite_impl(file, path, data);
-    } else {
-        throw detail::error(file, path, "H5Easy: path already exists");
-    }
+    return detail::eigen::dump(file, path, data, mode);
 }
 
 // front-end
@@ -177,13 +187,7 @@ inline DataSet dump(File& file,
                     const Eigen::Ref<T>& data,
                     DumpMode mode)
 {
-    if (!file.exist(path)) {
-        return detail::eigen::dump_impl(file, path, data);
-    } else if (mode == DumpMode::Overwrite) {
-        return detail::eigen::overwrite_impl(file, path, data);
-    } else {
-        throw detail::error(file, path, "H5Easy: path already exists");
-    }
+    return detail::eigen::dump(file, path, data, mode);
 }
 
 // front-end
@@ -193,13 +197,7 @@ inline DataSet dump(File& file,
                     const Eigen::Map<T>& data,
                     DumpMode mode)
 {
-    if (!file.exist(path)) {
-        return detail::eigen::dump_impl(file, path, data);
-    } else if (mode == DumpMode::Overwrite) {
-        return detail::eigen::overwrite_impl(file, path, data);
-    } else {
-        throw detail::error(file, path, "H5Easy: path already exists");
-    }
+    return detail::eigen::dump(file, path, data, mode);
 }
 
 }  // namespace H5Easy

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -269,4 +269,18 @@ BOOST_AUTO_TEST_CASE(H5Easy_Eigen_VectorXRowMajor)
     BOOST_CHECK_EQUAL(A.isApprox(A_r), true);
     BOOST_CHECK_EQUAL(B.isApprox(B_r), true);
 }
+
+BOOST_AUTO_TEST_CASE(H5Easy_Eigen_Map)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    std::vector<int> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    Eigen::Map<Eigen::VectorXi> mapped_vector(A.data(), static_cast<int>(A.size()));
+
+    H5Easy::dump(file, "/path/to/A", mapped_vector);
+
+    std::vector<int> A_r = H5Easy::load<std::vector<int>>(file, "/path/to/A");
+
+    BOOST_CHECK_EQUAL(A == A_r, true);
+}
 #endif


### PR DESCRIPTION
Fixes #286 

It needed to be verified if the CRTP is satisfied. In any case the implementation offers a significant simplification in the internal implementation.
