### PR TITLE
Adding some H5Easy support for OpenCV (rough prototype)

### DIFF
--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -207,5 +207,6 @@ inline T load(const File& file, const std::string& path);
 #include "h5easy_bits/H5Easy_vector.hpp"
 #include "h5easy_bits/H5Easy_Eigen.hpp"
 #include "h5easy_bits/H5Easy_xtensor.hpp"
+#include "h5easy_bits/H5Easy_opencv.hpp"
 
 #endif  // H5EASY_HPP

--- a/include/highfive/h5easy_bits/H5Easy_opencv.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_opencv.hpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c), 2017, Adrien Devresse <adrien.devresse@epfl.ch>
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#ifndef H5EASY_BITS_OPENCV_HPP
+#define H5EASY_BITS_OPENCV_HPP
+
+#include "../H5Easy.hpp"
+#include "H5Easy_misc.hpp"
+#include "H5Easy_scalar.hpp"  // to get the basic "load_impl"
+
+////#ifdef H5_USE_OPENCV
+
+namespace H5Easy {
+
+namespace detail {
+
+namespace opencv {
+
+// return the shape of the opencv-object as "std::vector<size_t>"
+template <class T>
+inline std::vector<size_t> shape(const T& data)
+{
+    return std::vector<size_t>(data.shape().cbegin(), data.shape().cend());
+}
+
+
+// load opencv-object from DataSet
+template <class T>
+struct load_impl
+{
+    static T run(const File& file, const std::string& path)
+    {
+        DataSet dataset = file.getDataSet(path);
+        std::vector<size_t> dims = dataset.getDimensions();
+        T data(dims[0], dims[1]);
+        dataset.read(reinterpret_cast<double*>(data.data));
+        //                             ^ ! Shouldn't be explicitly double of course TODO.
+        return data;
+    }
+};
+
+}  // namespace opencv
+
+// front-end
+template <class T>
+struct load_impl<cv::Mat_<T>>
+{
+    static cv::Mat_<T> run(const File& file, const std::string& path)
+    {
+        return detail::opencv::load_impl<cv::Mat_<T>>::run(file, path);
+    }
+};
+
+
+}  // namespace detail
+
+}  // namespace H5Easy
+
+////////#endif  // H5_USE_OPENCV
+
+#endif  // H5EASY_BITS_OPENCV_HPP

--- a/include/highfive/h5easy_bits/H5Easy_opencv.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_opencv.hpp
@@ -28,31 +28,32 @@ inline std::vector<size_t> shape(const T& data)
     return std::vector<size_t>(data.shape().cbegin(), data.shape().cend());
 }
 
-
-// load opencv-object from DataSet
-template <class T>
+template<typename _Tp, template<typename> class T>
 struct load_impl
 {
-    static T run(const File& file, const std::string& path)
+    static T<_Tp> run(const File& file, const std::string& path)
     {
         DataSet dataset = file.getDataSet(path);
         std::vector<size_t> dims = dataset.getDimensions();
-        T data(dims[0], dims[1]);
-        dataset.read(reinterpret_cast<double*>(data.data));
-        //                             ^ ! Shouldn't be explicitly double of course TODO.
+        T<_Tp> data(dims[0], dims[1]);
+        dataset.read(reinterpret_cast<_Tp*>(data.data)); // idem v, choose
+        //dataset.read(data.template ptr<_Tp>()); // idem ^, choose
         return data;
     }
 };
 
+
+
+
 }  // namespace opencv
 
 // front-end
-template <class T>
-struct load_impl<cv::Mat_<T>>
+template <class _Tp>
+struct load_impl<cv::Mat_<_Tp>>
 {
-    static cv::Mat_<T> run(const File& file, const std::string& path)
+    static cv::Mat_<_Tp> run(const File& file, const std::string& path)
     {
-        return detail::opencv::load_impl<cv::Mat_<T>>::run(file, path);
+        return detail::opencv::load_impl<_Tp, cv::Mat_>::run(file, path);
     }
 };
 


### PR DESCRIPTION
See #294. 

##### MWE using `cv::Mat_<double>`
```cpp
#include <iostream>
#include <opencv2/core.hpp>
#include "highfive/H5Easy.hpp"

int main()
{
        H5Easy::File input_hdf("../in.hdf", H5Easy::File::ReadOnly);

        // Works!
        auto data_cv = H5Easy::load<cv::Mat_<double>>(input_hdf, "/data");

        std::cout << data_cv << std::endl;
        std::cout << data_cv.rows << 'x' << data_cv.cols << std::endl;
        std::cout << data_cv.row(2) << std::endl;

        return 0;
}
```

Cheers.