### PR TITLE
HDF5 object references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+tests/test_project
 .idea
 
 .vs/

--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -23,6 +23,9 @@ namespace HighFive {
 ///
 class Attribute : public Object {
   public:
+
+    const static ObjectType type = ObjectType::Attribute;
+
     size_t getStorageSize() const;
 
     ///

--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -29,6 +29,9 @@ class DataSet : public Object,
                 public SliceTraits<DataSet>,
                 public AnnotateTraits<DataSet> {
   public:
+
+    const static ObjectType type = ObjectType::Dataset;
+
     ///
     /// \brief getStorageSize
     /// \return returns the amount of storage allocated for a dataset.

--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -85,11 +85,15 @@ class DataSet : public Object,
     inline size_t getElementCount() const {
         return getSpace().getElementCount();
     }
+  protected:
+    explicit DataSet(const Object& o) : Object(o) {};
 
   private:
     DataSet();
     template <typename Derivate>
     friend class ::HighFive::NodeTraits;
+
+    friend class ::HighFive::Reference;
 };
 
 }  // namespace HighFive

--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -35,6 +35,9 @@ class DataSet;
 class DataSpace : public Object {
   public:
 
+    const static ObjectType type = ObjectType::DataSpace;
+
+
     static const size_t UNLIMITED = SIZE_MAX;
 
     /// dataspace type

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -78,6 +78,9 @@ class DataType : public Object {
     ///
     bool empty() const noexcept;
 
+    /// \brief Returns whether the type is a Reference
+    bool isReference() const;
+
   protected:
     friend class Attribute;
     friend class File;

--- a/include/highfive/H5Exception.hpp
+++ b/include/highfive/H5Exception.hpp
@@ -134,6 +134,14 @@ class PropertyException : public Exception {
   public:
     PropertyException(const std::string& err_msg) : Exception(err_msg) {}
 };
+
+///
+/// \brief Exception specific to HighFive Reference interface
+///
+class ReferenceException : public Exception {
+  public:
+    ReferenceException(const std::string& err_msg) : Exception(err_msg) {}
+};
 }
 
 #include "bits/H5Exception_misc.hpp"

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -25,6 +25,9 @@ class File : public Object,
              public NodeTraits<File>,
              public AnnotateTraits<File> {
  public:
+
+    const static ObjectType type = ObjectType::File;
+
     enum : unsigned {
         /// Open flag: Read only access
         ReadOnly = 0x00u,

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -25,7 +25,12 @@ class Group : public Object,
   public:
     Group();
 
+  protected:
+    explicit Group(const Object& o) : Object(o) {};
+
     friend class File;
+
+    friend class ::HighFive::Reference;
 };
 }
 

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -23,6 +23,9 @@ class Group : public Object,
               public NodeTraits<Group>,
               public AnnotateTraits<Group> {
   public:
+
+    const static ObjectType type = ObjectType::Group;
+
     Group();
 
   protected:

--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -27,6 +27,8 @@ class AnnotateTraits;
 
 class ObjectInfo;
 
+class Reference;
+
 
 ///
 /// \brief Enum of the types of objects (H5O api)
@@ -79,18 +81,20 @@ class Object {
     // copy constructor, increase reference counter
     Object(const Object& other);
 
+    // Init with an low-level object id
+    explicit Object(hid_t);
+
     Object& operator=(const Object& other);
 
     hid_t _hid;
 
   private:
-    // Init with an low-level object id
-    explicit Object(hid_t);
 
     template <typename Derivate>
     friend class NodeTraits;
     template <typename Derivate>
     friend class AnnotateTraits;
+    friend class Reference;
 };
 
 

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c), 2020, EPFL - Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#ifndef H5REFERENCE_HPP
+#define H5REFERENCE_HPP
+
+#include <H5Rpublic.h>
+
+
+namespace HighFive {
+
+///
+/// \brief Create an HDF5 (object) reference type
+///
+
+class Reference {
+  public:
+    Reference() = default;
+
+    Reference(const Object& parent, const Object& o);
+
+    explicit Reference(const hobj_ref_t h5_ref)
+        : href(h5_ref){};
+
+    void create_ref(hobj_ref_t* refptr) const;
+
+    template <typename T>
+    T dereference(const Object& loc);
+    // Group dereference(const Object& loc);
+  private:
+    hobj_ref_t href{};
+    std::string obj_name;
+    hid_t parent_id{};
+};
+
+}
+
+#include "H5DataSet.hpp"
+#include "bits/H5Reference_misc.hpp"
+
+#endif // H5REFERENCE_HPP

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -11,6 +11,7 @@
 #define H5REFERENCE_HPP
 
 #include <string>
+#include <vector>
 
 #include <H5Ipublic.h>
 #include <H5Rpublic.h>
@@ -18,8 +19,15 @@
 
 namespace HighFive {
 
+// Forward declarations
 class Object;
 enum class ObjectType;
+
+namespace details {
+// Forward declaration of data_converter with default value of Enable
+template <typename T, typename Enable = void>
+struct data_converter;
+}
 
 ///
 /// \brief An HDF5 (object) reference type
@@ -47,7 +55,7 @@ class Reference {
     template <typename T>
     T dereference(const Object& location) const;
 
-    /// \brief Ge only the type of the referenced Object
+    /// \brief Get only the type of the referenced Object
     ///
     /// \param location the location where the referenced object is to be found (a File)
     /// \return the ObjectType of the referenced object
@@ -60,7 +68,8 @@ class Reference {
 
     /// \brief Create the low-level reference and store it at refptr
     ///
-    /// \param refptr Pointer to a memory location where the created HDF5 reference will be stored
+    /// \param refptr Pointer to a memory location where the created HDF5 reference will
+    /// be stored
     void create_ref(hobj_ref_t* refptr) const;
 
   private:
@@ -68,12 +77,12 @@ class Reference {
     std::string obj_name{};
     hid_t parent_id{};
 
-    friend HighFive::details::data_converter<std::vector<Reference>>;
+    friend details::data_converter<std::vector<Reference>>;
 };
 
-}
+}  // namespace HighFive
 
 #include "H5DataSet.hpp"
 #include "bits/H5Reference_misc.hpp"
 
-#endif // H5REFERENCE_HPP
+#endif  // H5REFERENCE_HPP

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -16,27 +16,54 @@
 namespace HighFive {
 
 ///
-/// \brief Create an HDF5 (object) reference type
+/// \brief An HDF5 (object) reference type
+///
+/// HDF5 object references allow pointing to groups, datasets (and compound types). They
+/// differ from links in their ability to be stored and retrieved as data from the HDF5
+/// file in datasets themselves.
 ///
 
 class Reference {
   public:
+    /// \brief Create an empty Reference to be initialized later
     Reference() = default;
 
-    Reference(const Object& parent, const Object& o);
+    /// \brief Create a Reference to an object residing at a given location
+    ///
+    /// \param location A File or Group where the object being referenced to resides
+    /// \param object A Dataset or Group to be referenced
+    Reference(const Object& location, const Object& object);
 
+    /// \brief Retrieve the Object being referenced by the Reference
+    ///
+    /// \tparam T the appropriate HighFive Container (either DataSet or Group)
+    /// \param location the location where the referenced object is to be found (a File)
+    /// \return the dereferenced Object (either a Group or DataSet)
+    template <typename T>
+    T dereference(const Object& location) const;
+
+    /// \brief Ge only the type of the referenced Object
+    ///
+    /// \param location the location where the referenced object is to be found (a File)
+    /// \return the ObjectType of the referenced object
+    ObjectType getType(const Object& location) const;
+
+  protected:
+    /// \brief Create a Reference from a low-level HDF5 object reference
     explicit Reference(const hobj_ref_t h5_ref)
         : href(h5_ref){};
 
+    /// \brief Create the low-level reference and store it at refptr
+    ///
+    /// \param refptr Pointer to a memory location where the created HDF5 reference will be stored
     void create_ref(hobj_ref_t* refptr) const;
 
-    template <typename T>
-    T dereference(const Object& loc);
-    // Group dereference(const Object& loc);
   private:
     hobj_ref_t href{};
-    std::string obj_name;
+    std::string obj_name{};
     hid_t parent_id{};
+
+    friend HighFive::details::data_converter<std::vector<Reference>>;
 };
 
 }

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -22,6 +22,7 @@ namespace HighFive {
 // Forward declarations
 class Object;
 enum class ObjectType;
+class Group;
 
 namespace details {
 // Forward declaration of data_converter with default value of Enable

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -74,6 +74,9 @@ class Reference {
     void create_ref(hobj_ref_t* refptr) const;
 
   private:
+
+    Object get_ref(const Object& location) const;
+
     hobj_ref_t href{};
     std::string obj_name{};
     hid_t parent_id{};

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -10,10 +10,16 @@
 #ifndef H5REFERENCE_HPP
 #define H5REFERENCE_HPP
 
+#include <string>
+
+#include <H5Ipublic.h>
 #include <H5Rpublic.h>
 
 
 namespace HighFive {
+
+class Object;
+enum class ObjectType;
 
 ///
 /// \brief An HDF5 (object) reference type
@@ -22,7 +28,6 @@ namespace HighFive {
 /// differ from links in their ability to be stored and retrieved as data from the HDF5
 /// file in datasets themselves.
 ///
-
 class Reference {
   public:
     /// \brief Create an empty Reference to be initialized later

--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c), 2020, EPFL - Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#ifndef H5REFERENCE_MISC_HPP
+#define H5REFERENCE_MISC_HPP
+
+#include <string>
+
+namespace HighFive {
+
+inline Reference::Reference(const Object& parent, const Object& o)
+    : parent_id(parent.getId()) {
+
+    const size_t maxLength = 255;
+    char buffer[maxLength + 1];
+    if (H5Iget_name(o.getId(), buffer, maxLength) <= 0) {
+        HDF5ErrMapper::ToException<DataTypeException>("Invalid object or location");
+    }
+    obj_name = std::string(buffer);
+}
+
+
+void Reference::create_ref(hobj_ref_t* refptr) const {
+
+    H5Rcreate(refptr, parent_id, obj_name.c_str(), H5R_OBJECT, -1);
+}
+
+template <typename T>
+T Reference::dereference(const Object& loc) {
+    static_assert(std::is_base_of<Object, T>::value != 0,
+        "Can only return a subtype of HighFive::Object");
+    hid_t res = H5Rdereference(loc.getId(), H5R_OBJECT, &href);
+    auto obj = Object(res);
+    T h5_obj(obj);
+    return h5_obj;
+}
+
+namespace details {
+
+// apply conversion for vectors nested vectors
+template <>
+struct data_converter<std::vector<Reference>> {
+    inline data_converter(const std::vector<Reference>&, const DataSpace& space)
+        : _dims(space.getDimensions()) {
+        if (!is_1D(_dims)) {
+            throw DataSpaceException("Only 1D std::array supported currently.");
+        }
+    }
+
+    inline typename type_of_array<hobj_ref_t>::type*
+    transform_read(std::vector<Reference>&) {
+        _vec_align.resize(compute_total_size(_dims));
+        return _vec_align.data();
+    }
+
+    inline typename type_of_array<hobj_ref_t>::type* transform_write(const std::vector<Reference>& vec) {
+        _vec_align.reserve(compute_total_size(_dims));
+        for (size_t i = 0; i < vec.size(); ++i) {
+            vec[i].create_ref(&_vec_align[i]);
+        }
+        return _vec_align.data();
+    }
+
+    inline void process_result(std::vector<Reference>& vec) const {
+        hobj_ref_t* href = const_cast<hobj_ref_t*>(_vec_align.data());
+        for (auto& ref : vec) {
+            ref = Reference(*(href++));
+        }
+    }
+
+    std::vector<size_t> _dims;
+    std::vector<typename type_of_array<hobj_ref_t>::type> _vec_align;
+};
+
+
+}
+
+}
+
+
+#endif  // H5REFERENCE_MISC_HPP

--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -25,16 +25,14 @@ inline Reference::Reference(const Object& location, const Object& object)
     obj_name = std::string(buffer);
 }
 
-
-void Reference::create_ref(hobj_ref_t* refptr) const {
+inline void Reference::create_ref(hobj_ref_t* refptr) const {
     if (H5Rcreate(refptr, parent_id, obj_name.c_str(), H5R_OBJECT, -1) < 0) {
         HDF5ErrMapper::ToException<ReferenceException>(
-            std::string("Unable to create the reference for \"") + obj_name +
-            "\":");
+            std::string("Unable to create the reference for \"") + obj_name + "\":");
     }
 }
 
-ObjectType Reference::getType(const Object& location) const {
+inline ObjectType Reference::getType(const Object& location) const {
     hid_t res;
     if ((res = H5Rdereference(location.getId(), H5R_OBJECT, &href)) < 0) {
         HDF5ErrMapper::ToException<ReferenceException>("Unable to dereference.");
@@ -43,57 +41,16 @@ ObjectType Reference::getType(const Object& location) const {
 }
 
 template <typename T>
-T Reference::dereference(const Object& location) const {
+inline T Reference::dereference(const Object& location) const {
     static_assert(std::is_base_of<Object, T>::value != 0,
-        "Can only return a subtype of HighFive::Object");
+                  "Can only return a subtype of HighFive::Object");
     hid_t res;
     if ((res = H5Rdereference(location.getId(), H5R_OBJECT, &href)) < 0) {
         HDF5ErrMapper::ToException<ReferenceException>("Unable to dereference.");
     }
-    auto obj = Object(res);
-    T h5_obj(obj);
-    return h5_obj;
+    return T(Object(res));
 }
 
-namespace details {
-
-template <>
-struct data_converter<std::vector<Reference>> {
-    inline data_converter(const DataSpace& space)
-        : _dims(space.getDimensions()) {
-        if (!is_1D(_dims)) {
-            throw DataSpaceException("Only 1D std::array supported currently.");
-        }
-    }
-
-    inline hobj_ref_t* transform_read(std::vector<Reference>& vec) {
-        auto total_size = compute_total_size(_dims);
-        _vec_align.resize(total_size);
-        vec.resize(total_size);
-        return _vec_align.data();
-    }
-
-    inline const hobj_ref_t* transform_write(const std::vector<Reference>& vec) {
-        _vec_align.reserve(compute_total_size(_dims));
-        for (size_t i = 0; i < vec.size(); ++i) {
-            vec[i].create_ref(&_vec_align[i]);
-        }
-        return _vec_align.data();
-    }
-
-    inline void process_result(std::vector<Reference>& vec) const {
-        hobj_ref_t* href = const_cast<hobj_ref_t*>(_vec_align.data());
-        for (auto& ref : vec) {
-            ref = Reference(*(href++));
-        }
-    }
-
-    std::vector<size_t> _dims;
-    std::vector<typename type_of_array<hobj_ref_t>::type> _vec_align;
-};
-
-}
-}
-
+}  // namespace HighFive
 
 #endif  // H5REFERENCE_MISC_HPP

--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -66,8 +66,10 @@ struct data_converter<std::vector<Reference>> {
         }
     }
 
-    inline hobj_ref_t* transform_read(std::vector<Reference>&) {
-        _vec_align.resize(compute_total_size(_dims));
+    inline hobj_ref_t* transform_read(std::vector<Reference>& vec) {
+        auto total_size = compute_total_size(_dims);
+        _vec_align.resize(total_size);
+        vec.resize(total_size);
         return _vec_align.data();
     }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -32,7 +32,6 @@
 
 using namespace HighFive;
 
-
 BOOST_AUTO_TEST_CASE(HighFiveBasic) {
     const std::string FILE_NAME("h5tutr_dset.h5");
     const std::string DATASET_NAME("dset");
@@ -52,8 +51,8 @@ BOOST_AUTO_TEST_CASE(HighFiveBasic) {
     BOOST_CHECK(!dataset_exist);
 
     // Create a dataset with double precision floating points
-    DataSet dataset_double = file.createDataSet(
-        DATASET_NAME + "_double", dataspace, AtomicType<double>());
+    DataSet dataset_double = file.createDataSet(DATASET_NAME + "_double", dataspace,
+                                                AtomicType<double>());
 
     BOOST_CHECK_EQUAL(file.getObjectName(0), DATASET_NAME + "_double");
 
@@ -72,8 +71,8 @@ BOOST_AUTO_TEST_CASE(HighFiveBasic) {
             DataSetException);
     }
 
-    DataSet dataset_size_t = file.createDataSet<size_t>(
-        DATASET_NAME + "_size_t", dataspace);
+    DataSet dataset_size_t = file.createDataSet<size_t>(DATASET_NAME + "_size_t",
+                                                        dataspace);
 }
 
 BOOST_AUTO_TEST_CASE(HighFiveSilence) {
@@ -106,8 +105,7 @@ BOOST_AUTO_TEST_CASE(HighFiveOpenMode) {
     SilenceHDF5 silencer;
 
     // Attempt open file only ReadWrite should fail (wont create)
-    BOOST_CHECK_THROW({ File file(FILE_NAME, File::ReadWrite); },
-                      FileException);
+    BOOST_CHECK_THROW({ File file(FILE_NAME, File::ReadWrite); }, FileException);
 
     // But with Create flag should be fine
     { File file(FILE_NAME, File::ReadWrite | File::Create); }
@@ -168,8 +166,8 @@ BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSet) {
         DataSpace dataspace(dims);
 
         DataSet dataset_absolute = file.createDataSet(
-            GROUP_NAME1 + "/" + GROUP_NESTED_NAME + "/" + DATASET_NAME,
-            dataspace, AtomicType<double>());
+            GROUP_NAME1 + "/" + GROUP_NESTED_NAME + "/" + DATASET_NAME, dataspace,
+            AtomicType<double>());
 
         DataSet dataset_relative = nested.createDataSet(DATASET_NAME, dataspace,
                                                         AtomicType<double>());
@@ -189,13 +187,11 @@ BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSet) {
         {
             SilenceHDF5 silencer;
             BOOST_CHECK_THROW(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
-                                                 AtomicType<double>(),
-                                                 badChunking0),
+                                                 AtomicType<double>(), badChunking0),
                               DataSetException);
 
             BOOST_CHECK_THROW(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
-                                                 AtomicType<double>(),
-                                                 badChunking1),
+                                                 AtomicType<double>(), badChunking1),
                               DataSetException);
         }
 
@@ -216,8 +212,8 @@ BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSet) {
         Group g2 = file.getGroup(GROUP_NAME2);
         Group nested_group2 = g2.getGroup(GROUP_NESTED_NAME);
 
-        DataSet dataset_absolute = file.getDataSet(
-            GROUP_NAME1 + "/" + GROUP_NESTED_NAME + "/" + DATASET_NAME);
+        DataSet dataset_absolute = file.getDataSet(GROUP_NAME1 + "/" + GROUP_NESTED_NAME +
+                                                   "/" + DATASET_NAME);
         BOOST_CHECK_EQUAL(4, dataset_absolute.getSpace().getDimensions()[0]);
 
         DataSet dataset_relative = nested_group2.getDataSet(DATASET_NAME);
@@ -225,14 +221,11 @@ BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSet) {
 
         DataSetAccessProps accessProps;
         accessProps.add(Caching(13, 1024, 0.5));
-        DataSet dataset_chunked = file.getDataSet(CHUNKED_DATASET_NAME,
-                                                  accessProps);
+        DataSet dataset_chunked = file.getDataSet(CHUNKED_DATASET_NAME, accessProps);
         BOOST_CHECK_EQUAL(4, dataset_chunked.getSpace().getDimensions()[0]);
 
-        DataSet dataset_chunked_small = file.getDataSet(
-            CHUNKED_DATASET_SMALL_NAME);
-        BOOST_CHECK_EQUAL(1,
-                          dataset_chunked_small.getSpace().getDimensions()[0]);
+        DataSet dataset_chunked_small = file.getDataSet(CHUNKED_DATASET_SMALL_NAME);
+        BOOST_CHECK_EQUAL(1, dataset_chunked_small.getSpace().getDimensions()[0]);
     }
 }
 
@@ -392,8 +385,7 @@ BOOST_AUTO_TEST_CASE(HighFiveSimpleListing) {
             reference_elems.push_back(ss.str());
         }
 
-        BOOST_CHECK_EQUAL_COLLECTIONS(elems.begin(), elems.end(),
-                                      reference_elems.begin(),
+        BOOST_CHECK_EQUAL_COLLECTIONS(elems.begin(), elems.end(), reference_elems.begin(),
                                       reference_elems.end());
     }
 
@@ -424,8 +416,7 @@ BOOST_AUTO_TEST_CASE(HighFiveSimpleListing) {
         std::sort(elems.begin(), elems.end());
         std::sort(reference_elems.begin(), reference_elems.end());
 
-        BOOST_CHECK_EQUAL_COLLECTIONS(elems.begin(), elems.end(),
-                                      reference_elems.begin(),
+        BOOST_CHECK_EQUAL_COLLECTIONS(elems.begin(), elems.end(), reference_elems.begin(),
                                       reference_elems.end());
     }
 }
@@ -462,8 +453,7 @@ BOOST_AUTO_TEST_CASE(DataTypeEqualTakeBack) {
     DataSpace dataspace(dims);
 
     // Create a dataset with double precision floating points
-    DataSet dataset = file.createDataSet<size_t>(DATASET_NAME + "_double",
-                                                 dataspace);
+    DataSet dataset = file.createDataSet<size_t>(DATASET_NAME + "_double", dataspace);
 
     AtomicType<size_t> s;
     AtomicType<double> d;
@@ -567,8 +557,8 @@ BOOST_AUTO_TEST_CASE(ChunkingConstructorsTest) {
     auto first_res = first.getDimensions();
     std::vector<hsize_t> first_ans{1, 2, 3};
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(first_res.begin(), first_res.end(),
-                                  first_ans.begin(), first_ans.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(first_res.begin(), first_res.end(), first_ans.begin(),
+                                  first_ans.end());
 
     Chunking second{1, 2, 3};
 
@@ -583,10 +573,9 @@ BOOST_AUTO_TEST_CASE(ChunkingConstructorsTest) {
     auto third_res = third.getDimensions();
     std::vector<hsize_t> third_ans{1, 2, 3};
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(third_res.begin(), third_res.end(),
-                                  third_ans.begin(), third_ans.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(third_res.begin(), third_res.end(), third_ans.begin(),
+                                  third_ans.end());
 }
-
 
 BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
     std::ostringstream filename;
@@ -596,7 +585,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
     const std::string DATASET_NAME("dset");
     std::vector<unsigned> vec;
     vec.resize(x_size);
-    for(unsigned i = 0; i < x_size; i++)
+    for (unsigned i = 0; i < x_size; i++)
         vec[i] = i * 2;
     std::string at_contents("Contents of string");
     int my_int = 3;
@@ -614,8 +603,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
 
     std::vector<int> result;
     dataset.read(result);
-    BOOST_CHECK_EQUAL_COLLECTIONS(vec.begin(), vec.end(), result.begin(),
-                                  result.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(vec.begin(), vec.end(), result.begin(), result.end());
 
     std::string read_in;
     dataset.getAttribute("str").read(read_in);
@@ -661,7 +649,6 @@ BOOST_AUTO_TEST_CASE(HighFiveReadWriteShortcut) {
     }
 }
 
-
 template <typename T>
 void readWriteAttributeVectorTest() {
     std::ostringstream filename;
@@ -693,8 +680,7 @@ void readWriteAttributeVectorTest() {
         bool has_attribute = g.hasAttribute("my_attribute");
         BOOST_CHECK_EQUAL(has_attribute, false);
 
-        Attribute a1 = g.createAttribute<T>("my_attribute",
-                                            DataSpace::From(vec));
+        Attribute a1 = g.createAttribute<T>("my_attribute", DataSpace::From(vec));
         a1.write(vec);
 
         // check now that we effectively have an attribute listable
@@ -709,11 +695,9 @@ void readWriteAttributeVectorTest() {
         BOOST_CHECK_EQUAL(all_attribute_names[0], std::string("my_attribute"));
 
         // Create the same attribute on a newly created dataset
-        DataSet s = g.createDataSet("dummy_dataset", DataSpace(1),
-                                    AtomicType<int>());
+        DataSet s = g.createDataSet("dummy_dataset", DataSpace(1), AtomicType<int>());
 
-        Attribute a2 = s.createAttribute<T>("my_attribute_copy",
-                                            DataSpace::From(vec));
+        Attribute a2 = s.createAttribute<T>("my_attribute_copy", DataSpace::From(vec));
         a2.write(vec);
 
         // const data, short-circuit syntax
@@ -724,8 +708,7 @@ void readWriteAttributeVectorTest() {
     {
         typename std::vector<T> result1, result2;
 
-        Attribute a1_read =
-            file.getGroup("dummy_group").getAttribute("my_attribute");
+        Attribute a1_read = file.getGroup("dummy_group").getAttribute("my_attribute");
         a1_read.read(result1);
 
         BOOST_CHECK_EQUAL(vec.size(), x_size);
@@ -774,7 +757,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteAttributeVector, T, dataset_test_types) {
     readWriteAttributeVectorTest<T>();
 }
 
-
 BOOST_AUTO_TEST_CASE(datasetOffset) {
     std::string filename = "datasetOffset.h5";
     std::string dsetname = "dset";
@@ -787,7 +769,6 @@ BOOST_AUTO_TEST_CASE(datasetOffset) {
     DataSet ds_read = file.getDataSet(dsetname);
     BOOST_CHECK(ds_read.getOffset() > 0);
 }
-
 
 template <typename T>
 void selectionArraySimpleTest() {
@@ -809,8 +790,7 @@ void selectionArraySimpleTest() {
     // Create a new file using the default property lists.
     File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
 
-    DataSet dataset = file.createDataSet<T>(DATASET_NAME,
-                                            DataSpace::From(values));
+    DataSet dataset = file.createDataSet<T>(DATASET_NAME, DataSpace::From(values));
 
     dataset.write(values);
 
@@ -871,28 +851,28 @@ BOOST_AUTO_TEST_CASE(selectionByElementMultiDim) {
     const std::string FILE_NAME("h5_test_selection_multi_dim.h5");
     // Create a 2-dim dataset
     File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
-    std::vector<size_t> dims{3,3};
+    std::vector<size_t> dims{3, 3};
 
     auto set = file.createDataSet("test", DataSpace(dims), AtomicType<int>());
-    int values[3][3] = {{1,2,3},{4,5,6},{7,8,9}};
+    int values[3][3] = {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
     set.write(values);
 
     {
         int value;
-        set.select(ElementSet{{1,1}}).read(value);
+        set.select(ElementSet{{1, 1}}).read(value);
         BOOST_CHECK_EQUAL(value, 5);
     }
 
     {
         int value[2];
-        set.select(ElementSet{0,0,2,2}).read(value);
+        set.select(ElementSet{0, 0, 2, 2}).read(value);
         BOOST_CHECK_EQUAL(value[0], 1);
         BOOST_CHECK_EQUAL(value[1], 9);
     }
 
     {
         int value[2];
-        set.select(ElementSet{{0,1},{1,2}}).read(value);
+        set.select(ElementSet{{0, 1}, {1, 2}}).read(value);
         BOOST_CHECK_EQUAL(value[0], 2);
         BOOST_CHECK_EQUAL(value[1], 6);
     }
@@ -955,8 +935,7 @@ void attribute_scalar_rw() {
     std::ostringstream filename;
     filename << "h5_rw_attribute_scalar_rw" << typeNameHelper<T>() << "_test.h5";
 
-    File h5file(filename.str(),
-		File::ReadWrite | File::Create | File::Truncate);
+    File h5file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
 
     ContentGenerate<T> generator;
 
@@ -1039,8 +1018,7 @@ void readWriteShuffleDeflateTest() {
 
     // write a compressed file
     {
-        File file(filename.str(),
-                  File::ReadWrite | File::Create | File::Truncate);
+        File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
 
         // Create the data space for the dataset.
         std::vector<size_t> dims{x_size, y_size};
@@ -1125,11 +1103,11 @@ BOOST_AUTO_TEST_CASE(ReadInBroadcastDims) {
     out_a.read(data_a);
     out_b.read(data_b);
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(data_a.begin(), data_a.end(),
-                                  some_data.begin(), some_data.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(data_a.begin(), data_a.end(), some_data.begin(),
+                                  some_data.end());
 
-    BOOST_CHECK_EQUAL_COLLECTIONS(data_b.begin(), data_b.end(),
-                                  some_data.begin(), some_data.end());
+    BOOST_CHECK_EQUAL_COLLECTIONS(data_b.begin(), data_b.end(), some_data.begin(),
+                                  some_data.end());
 }
 
 BOOST_AUTO_TEST_CASE(HighFiveRecursiveGroups) {
@@ -1179,7 +1157,6 @@ BOOST_AUTO_TEST_CASE(HighFiveRecursiveGroups) {
         BOOST_CHECK_THROW(g1.unlink("x"), HighFive::GroupException);
     }
 }
-
 
 BOOST_AUTO_TEST_CASE(HighFiveInspect) {
     const std::string FILE_NAME("group_info.h5");
@@ -1233,11 +1210,7 @@ typedef struct {
 
 CompoundType create_compound_csl1() {
     auto t2 = AtomicType<int>();
-    CompoundType t1({
-                        {"m1", AtomicType<int>{}},
-                        {"m2", AtomicType<int>{}},
-                        {"m3", t2}
-    });
+    CompoundType t1({{"m1", AtomicType<int>{}}, {"m2", AtomicType<int>{}}, {"m3", t2}});
 
     return t1;
 }
@@ -1245,9 +1218,7 @@ CompoundType create_compound_csl1() {
 CompoundType create_compound_csl2() {
     CompoundType t1 = create_compound_csl1();
 
-    CompoundType t2({
-        {"csl1", t1}
-    });
+    CompoundType t2({{"csl1", t1}});
 
     return t2;
 }
@@ -1269,11 +1240,10 @@ BOOST_AUTO_TEST_CASE(HighFiveCompounds) {
     CompoundType t2 = create_compound_csl2();
     t2.commit(file, "my_type2");
 
-
-    {   // Not nested
+    {  // Not nested
         auto dataset = file.createDataSet(DATASET_NAME1, DataSpace(2), t1);
 
-        std::vector<CSL1> csl = {{1,1,1}, {2,3,4}};
+        std::vector<CSL1> csl = {{1, 1, 1}, {2, 3, 4}};
         dataset.write(csl);
 
         file.flush();
@@ -1290,14 +1260,14 @@ BOOST_AUTO_TEST_CASE(HighFiveCompounds) {
         BOOST_CHECK_EQUAL(result[1].m3, 4);
     }
 
-    {   // Nested
+    {  // Nested
         auto dataset = file.createDataSet(DATASET_NAME2, DataSpace(2), t2);
 
-        std::vector<CSL2> csl = {{{1,1,1}, {2,3,4}}};
+        std::vector<CSL2> csl = {{{1, 1, 1}, {2, 3, 4}}};
         dataset.write(csl);
 
         file.flush();
-        std::vector<CSL2> result = {{{1,1,1}, {2,3,4}}};
+        std::vector<CSL2> result = {{{1, 1, 1}, {2, 3, 4}}};
         dataset.select({0}, {2}).read(result);
 
         BOOST_CHECK_EQUAL(result.size(), 2);
@@ -1310,7 +1280,6 @@ BOOST_AUTO_TEST_CASE(HighFiveCompounds) {
     }
 }
 
-
 enum Position {
     FIRST = 1,
     SECOND = 2,
@@ -1318,7 +1287,7 @@ enum Position {
     LAST = -1,
 };
 
-enum class Direction: signed char {
+enum class Direction : signed char {
     FORWARD = 1,
     BACKWARD = -1,
     LEFT = -2,
@@ -1347,7 +1316,6 @@ EnumType<Direction> create_enum_direction() {
 }
 HIGHFIVE_REGISTER_TYPE(Direction, create_enum_direction)
 
-
 BOOST_AUTO_TEST_CASE(HighFiveEnum) {
     const std::string FILE_NAME("enum_test.h5");
     const std::string DATASET_NAME1("/a");
@@ -1355,7 +1323,7 @@ BOOST_AUTO_TEST_CASE(HighFiveEnum) {
 
     File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-    { // Unscoped enum
+    {  // Unscoped enum
         auto e1 = create_enum_position();
         e1.commit(file, "Position");
 
@@ -1370,12 +1338,14 @@ BOOST_AUTO_TEST_CASE(HighFiveEnum) {
         BOOST_CHECK_EQUAL(result, Position::FIRST);
     }
 
-    { // Scoped enum
+    {  // Scoped enum
         auto e1 = create_enum_direction();
         e1.commit(file, "Direction");
 
         auto dataset = file.createDataSet(DATASET_NAME2, DataSpace(5), e1);
-        std::vector<Direction> robot_moves({Direction::BACKWARD, Direction::FORWARD, Direction::FORWARD, Direction::LEFT, Direction::LEFT});
+        std::vector<Direction> robot_moves({Direction::BACKWARD, Direction::FORWARD,
+                                            Direction::FORWARD, Direction::LEFT,
+                                            Direction::LEFT});
         dataset.write(robot_moves);
 
         file.flush();
@@ -1402,41 +1372,42 @@ BOOST_AUTO_TEST_CASE(HighFiveFixedString) {
     /// This will not compile - only char arrays - hits static_assert with a nice error
     // file.createDataSet<int[10]>(DS_NAME, DataSpace(2)));
 
-    { // But char should be fine
+    {  // But char should be fine
         auto ds = file.createDataSet<char[10]>("ds1", DataSpace(2));
         BOOST_CHECK(ds.getDataType().getClass() == DataTypeClass::String);
         ds.write(raw_strings);
     }
 
-    { // char[] is, by default, int8
+    {  // char[] is, by default, int8
         auto ds2 = file.createDataSet("ds2", raw_strings);
         BOOST_CHECK(ds2.getDataType().getClass() == DataTypeClass::Integer);
     }
 
-    { // String Truncate happens low-level if well setup
-        auto ds3 = file.createDataSet<char[6]>("ds3", DataSpace::FromCharArrayStrings(raw_strings));
+    {  // String Truncate happens low-level if well setup
+        auto ds3 = file.createDataSet<char[6]>(
+            "ds3", DataSpace::FromCharArrayStrings(raw_strings));
         ds3.write(raw_strings);
     }
 
-    { // Write as raw elements from pointer (with const)
-        const char (*strings_fixed)[10] = raw_strings;
+    {  // Write as raw elements from pointer (with const)
+        const char(*strings_fixed)[10] = raw_strings;
         // With a pointer we dont know how many strings -> manual DataSpace
         file.createDataSet<char[10]>("ds4", DataSpace(2)).write(strings_fixed);
     }
 
-    { // Cant convert flex-length to fixed-length
+    {  // Cant convert flex-length to fixed-length
         const char* buffer[] = {"abcd", "1234"};
         SilenceHDF5 silencer;
         BOOST_CHECK_THROW(file.createDataSet<char[10]>("ds5", DataSpace(2)).write(buffer),
                           HighFive::DataSetException);
     }
 
-    { // scalar char strings
+    {  // scalar char strings
         const char buffer[] = "abcd";
         file.createDataSet<char[10]>("ds6", DataSpace(1)).write(buffer);
     }
 
-    { // Dedicated FixedLenStringArray
+    {  // Dedicated FixedLenStringArray
         FixedLenStringArray<10> arr{"0000000", "1111111"};
         // For completeness, test also the other constructor
         FixedLenStringArray<10> arrx(std::vector<std::string>{"0000", "1111"});
@@ -1556,12 +1527,8 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
         std::vector<size_t> dims{4};
         DataSpace dataspace(dims);
 
-        DataSet dataset1 = g1.createDataSet(
-            DATASET1_NAME,
-            dataspace, AtomicType<double>());
-        DataSet dataset2 = g1.createDataSet(
-            DATASET2_NAME,
-            dataspace, AtomicType<double>());
+        DataSet dataset1 = g1.createDataSet(DATASET1_NAME, vec1);
+        DataSet dataset2 = g1.createDataSet(DATASET2_NAME, vec2);
 
         // write some data
         dataset1.write(vec1);
@@ -1574,9 +1541,9 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
         std::vector<size_t> ref_dims{2};
         DataSpace ref_dspace(ref_dims);
 
-        DataSet ref_ds = refgroup.createDataSet(REFDATASET_NAME, ref_dspace, AtomicType<Reference>());
+        DataSet ref_ds = refgroup.createDataSet<Reference>(REFDATASET_NAME, ref_dspace);
 
-        auto references = std::vector<Reference>({{g1, dataset1},{file, g1}});
+        auto references = std::vector<Reference>({{g1, dataset1}, {file, g1}});
 
         ref_ds.write(references);
     }
@@ -1585,8 +1552,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
         File file(FILE_NAME, File::ReadOnly);
         Group refgroup = file.getGroup(REFGROUP_NAME);
 
-        DataSet refdataset = refgroup.getDataSet(
-            REFDATASET_NAME);
+        DataSet refdataset = refgroup.getDataSet(REFDATASET_NAME);
         BOOST_CHECK_EQUAL(2, refdataset.getSpace().getDimensions()[0]);
         auto refs = std::vector<Reference>();
         refdataset.read(refs);
@@ -1607,14 +1573,13 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
     }
 }
 
-
 #ifdef H5_USE_EIGEN
 
 template <typename T>
 void test_eigen_vec(File& file,
                     const std::string& test_flavor,
                     const T& vec_input,
-                    T& vec_output){
+                    T& vec_output) {
     const std::string DS_NAME = "ds";
     file.createDataSet(DS_NAME + test_flavor, vec_input).write(vec_input);
     file.getDataSet(DS_NAME + test_flavor).read(vec_output);
@@ -1631,15 +1596,16 @@ BOOST_AUTO_TEST_CASE(HighFiveEigen) {
     // std::vector<of vector <of POD>>
     {
         DS_NAME_FLAVOR = "VectorOfVectorOfPOD";
-        std::vector<std::vector<float>> vec_in{{5.0f, 6.0f, 7.0f}, {5.1f, 6.1f, 7.1f}, {5.2f, 6.2f, 7.2f} };
+        std::vector<std::vector<float>> vec_in{
+            {5.0f, 6.0f, 7.0f}, {5.1f, 6.1f, 7.1f}, {5.2f, 6.2f, 7.2f}};
         std::vector<std::vector<float>> vec_out;
         test_eigen_vec(file, DS_NAME_FLAVOR, vec_in, vec_out);
     }
 
-    //std::vector<Eigen::Vector3d>
+    // std::vector<Eigen::Vector3d>
     {
         DS_NAME_FLAVOR = "VectorOfEigenVector3d";
-        std::vector<Eigen::Vector3d> vec_in{{5.0, 6.0, 7.0},{7.0, 8.0, 9.0}};
+        std::vector<Eigen::Vector3d> vec_in{{5.0, 6.0, 7.0}, {7.0, 8.0, 9.0}};
         std::vector<Eigen::Vector3d> vec_out;
         test_eigen_vec(file, DS_NAME_FLAVOR, vec_in, vec_out);
     }
@@ -1656,8 +1622,9 @@ BOOST_AUTO_TEST_CASE(HighFiveEigen) {
     // Eigen Matrix
     {
         DS_NAME_FLAVOR = "EigenMatrix";
-        Eigen::Matrix<double, 3,3> vec_in; vec_in << 1,2,3,4,5,6,7,8,9;
-        Eigen::Matrix<double, 3,3> vec_out;
+        Eigen::Matrix<double, 3, 3> vec_in;
+        vec_in << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+        Eigen::Matrix<double, 3, 3> vec_out;
 
         test_eigen_vec(file, DS_NAME_FLAVOR, vec_in, vec_out);
     }
@@ -1666,7 +1633,7 @@ BOOST_AUTO_TEST_CASE(HighFiveEigen) {
     {
         DS_NAME_FLAVOR = "EigenMatrixXd";
         Eigen::MatrixXd vec_in = 100. * Eigen::MatrixXd::Random(20, 5);
-        Eigen::MatrixXd vec_out(20,5);
+        Eigen::MatrixXd vec_out(20, 5);
 
         test_eigen_vec(file, DS_NAME_FLAVOR, vec_in, vec_out);
     }
@@ -1680,7 +1647,7 @@ BOOST_AUTO_TEST_CASE(HighFiveEigen) {
         std::vector<Eigen::MatrixXd> vec_in;
         vec_in.push_back(m1);
         vec_in.push_back(m2);
-        std::vector<Eigen::MatrixXd> vec_out(2, Eigen::MatrixXd::Zero(20,5));
+        std::vector<Eigen::MatrixXd> vec_out(2, Eigen::MatrixXd::Zero(20, 5));
 
         test_eigen_vec(file, DS_NAME_FLAVOR, vec_in, vec_out);
     }
@@ -1699,7 +1666,9 @@ BOOST_AUTO_TEST_CASE(HighFiveEigen) {
 
         std::vector<Eigen::MatrixXd> vec_out_exception;
         SilenceHDF5 silencer;
-        BOOST_CHECK_THROW(file.getDataSet(DS_NAME + DS_NAME_FLAVOR).read(vec_out_exception), HighFive::DataSetException);
+        BOOST_CHECK_THROW(
+            file.getDataSet(DS_NAME + DS_NAME_FLAVOR).read(vec_out_exception),
+            HighFive::DataSetException);
     }
 
 #ifdef H5_USE_BOOST
@@ -1719,7 +1688,6 @@ BOOST_AUTO_TEST_CASE(HighFiveEigen) {
 
         test_eigen_vec(file, DS_NAME_FLAVOR, vec_in, vec_out);
     }
-
 
     // boost::multi_array<of EigenMatrixXd>
     {
@@ -1761,8 +1729,9 @@ BOOST_AUTO_TEST_CASE(HighFiveEigen) {
         boost::multi_array<Eigen::MatrixXd, 3> vec_out_exception(boost::extents[3][2][2]);
 
         SilenceHDF5 silencer;
-        BOOST_CHECK_THROW(file.getDataSet(DS_NAME + DS_NAME_FLAVOR).read(vec_out_exception),
-                          HighFive::DataSetException);
+        BOOST_CHECK_THROW(
+            file.getDataSet(DS_NAME + DS_NAME_FLAVOR).read(vec_out_exception),
+            HighFive::DataSetException);
     }
 
 #endif

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1556,6 +1556,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
         BOOST_CHECK_EQUAL(2, refdataset.getSpace().getDimensions()[0]);
         auto refs = std::vector<Reference>();
         refdataset.read(refs);
+        BOOST_CHECK_THROW(refs[0].dereference<Group>(file), HighFive::ReferenceException);
         auto data_ds = refs[0].dereference<DataSet>(file);
         std::vector<double> rdata;
         data_ds.read(rdata);

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1588,7 +1588,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
         DataSet refdataset = refgroup.getDataSet(
             REFDATASET_NAME);
         BOOST_CHECK_EQUAL(2, refdataset.getSpace().getDimensions()[0]);
-        auto refs = std::vector<Reference>(refdataset.getSpace().getDimensions()[0]);
+        auto refs = std::vector<Reference>();
         refdataset.read(refs);
         auto data_ds = refs[0].dereference<DataSet>(file);
         std::vector<double> rdata;

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1532,19 +1532,6 @@ BOOST_AUTO_TEST_CASE(HighFiveFixedLenStringArrayStructure) {
     }
 }
 
-
-template <typename T>
-void test_eigen_vec(File& file,
-                    const std::string& test_flavor,
-                    const T& vec_input,
-                    T& vec_output){
-    const std::string DS_NAME = "ds";
-    file.createDataSet(DS_NAME + test_flavor, vec_input).write(vec_input);
-    file.getDataSet(DS_NAME + test_flavor).read(vec_output);
-    BOOST_CHECK(vec_input == vec_output);
-}
-
-
 BOOST_AUTO_TEST_CASE(HighFiveReference) {
     const std::string FILE_NAME("h5_ref_test.h5");
     const std::string DATASET1_NAME("dset1");
@@ -1622,6 +1609,18 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
 
 
 #ifdef H5_USE_EIGEN
+
+template <typename T>
+void test_eigen_vec(File& file,
+                    const std::string& test_flavor,
+                    const T& vec_input,
+                    T& vec_output){
+    const std::string DS_NAME = "ds";
+    file.createDataSet(DS_NAME + test_flavor, vec_input).write(vec_input);
+    file.getDataSet(DS_NAME + test_flavor).read(vec_output);
+    BOOST_CHECK(vec_input == vec_output);
+}
+
 BOOST_AUTO_TEST_CASE(HighFiveEigen) {
     const std::string FILE_NAME("test_eigen.h5");
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1523,29 +1523,16 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
         // create group
         Group g1 = file.createGroup(GROUP_NAME);
 
-        // Create the data space for the dataset.
-        std::vector<size_t> dims{4};
-        DataSpace dataspace(dims);
-
+        // create datasets and write some data
         DataSet dataset1 = g1.createDataSet(DATASET1_NAME, vec1);
         DataSet dataset2 = g1.createDataSet(DATASET2_NAME, vec2);
 
-        // write some data
-        dataset1.write(vec1);
-        dataset2.write(vec2);
-
-        // create group and dataset to hold reference
+        // create group to hold reference
         Group refgroup = file.createGroup(REFGROUP_NAME);
 
-        // Create the data space for the dataset.
-        std::vector<size_t> ref_dims{2};
-        DataSpace ref_dspace(ref_dims);
-
-        DataSet ref_ds = refgroup.createDataSet<Reference>(REFDATASET_NAME, ref_dspace);
-
+        // create the references and write them into a new dataset inside refgroup
         auto references = std::vector<Reference>({{g1, dataset1}, {file, g1}});
-
-        ref_ds.write(references);
+        DataSet ref_ds = refgroup.createDataSet(REFDATASET_NAME, references);
     }
     // read it back
     {

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1600,7 +1600,7 @@ BOOST_AUTO_TEST_CASE(HighFiveReference) {
         auto group = refs[1].dereference<Group>(file);
         DataSet data_ds2 = group.getDataSet(DATASET2_NAME);
         std::vector<double> rdata2;
-        data_ds.read(rdata2);
+        data_ds2.read(rdata2);
         for (size_t i = 0; i < rdata2.size(); ++i) {
             BOOST_CHECK_EQUAL(rdata2[i], vec2[i]);
         }


### PR DESCRIPTION
## This PR

Adds support for HDF5 [references](https://confluence.hdfgroup.org/display/HDF5/References). To keep things simple we support for now only object references (no region references, which are also not supported in parallel HDF5).
We introduce a new `Reference` class that represents an HDF5 object reference when writing to or reading from a file.

## Rationale

Unlike soft and hard links references can be stored and read as data in HDF5 files as Datasets. They can be used to create more complex data relationships beyond vectors and matrices.

## Use

Here is a minimal example to create and read an HDF5 reference with the new `Reference` class:

```c++
// write references
{
    File file("example.h5", File::ReadWrite | File::Create | File::Truncate);
    // Create some data and write it into a DataSet
    auto data = std::vector<double>({1.0, 2.0});
    DataSet dataset = file.createDataSet("dset", data);

    // Create a Reference vector with one element and write it into a new DataSet
    auto references = std::vector<Reference>({{file, dataset}});
    DataSet ref_ds = file.createDataSet("rds", references);
}
// read references
{
    File file("example.h5", File::ReadOnly);
    // get the reference dataset
    DataSet ref_ds = file.getDataSet("rds");
    // create a vector to read the references into
    auto refs = std::vector<Reference>();
    // read the references
    ref_ds.read(refs);
    auto data_ds = refs[0].dereference<DataSet>(file);
    std::vector<double> rdata;
    data_ds.read(rdata);
}
```