### PR TITLE
Dont rely on exception in node.exist

### DIFF
--- a/include/highfive/H5Utility.hpp
+++ b/include/highfive/H5Utility.hpp
@@ -23,10 +23,12 @@ public:
         : _client_data(nullptr)
     {
         H5Eget_auto2(H5E_DEFAULT, &_func, &_client_data);
-        if(enable) H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+        if (enable) H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     }
 
-    inline ~SilenceHDF5() { H5Eset_auto2(H5E_DEFAULT, _func, _client_data); }
+    inline ~SilenceHDF5() {
+        H5Eset_auto2(H5E_DEFAULT, _func, _client_data);
+    }
 private:
     H5E_auto2_t _func;
     void* _client_data;

--- a/include/highfive/H5Utility.hpp
+++ b/include/highfive/H5Utility.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c), 2017, Juan Hernando <juan.hernando@epfl.ch>
+ *  Copyright (c), 2017, Blue Brain Project - EPFL (CH)
  *
  *  Distributed under the Boost Software License, Version 1.0.
  *    (See accompanying file LICENSE_1_0.txt or copy at
@@ -19,11 +19,11 @@ namespace HighFive {
 ///
 class SilenceHDF5 {
 public:
-    inline SilenceHDF5()
-        : _client_data(0)
+    inline SilenceHDF5(bool enable=true)
+        : _client_data(nullptr)
     {
         H5Eget_auto2(H5E_DEFAULT, &_func, &_client_data);
-        H5Eset_auto2(H5E_DEFAULT, 0, 0);
+        if(enable) H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
     }
 
     inline ~SilenceHDF5() { H5Eset_auto2(H5E_DEFAULT, _func, _client_data); }

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -152,11 +152,11 @@ class NodeTraits {
     // A wrapper over the low-level H5Lexist
     // It makes behavior consistent among versions and by default transforms
     // errors to exceptions
-    bool _exist(const std::string& node_name, bool raise_errors=true) const;
+    bool _exist(const std::string& node_name, bool raise_errors = true) const;
 
     // Opens an arbitrary object to obtain info
     Object _open(const std::string& node_name,
-                 const DataSetAccessProps& accessProps=DataSetAccessProps()) const;
+                 const DataSetAccessProps& accessProps = DataSetAccessProps()) const;
 };
 
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -132,7 +132,7 @@ class NodeTraits {
     bool exist(const std::string& node_name) const;
 
     ///
-    /// \brief unlink the given dataset or group 
+    /// \brief unlink the given dataset or group
     /// \param node_name dataset/group name to unlink
     void unlink(const std::string& node_name) const;
 
@@ -150,7 +150,9 @@ class NodeTraits {
     typedef Derivate derivate_type;
 
     // A wrapper over the low-level H5Lexist
-    bool _exist(const std::string& node_name) const;
+    // It makes behavior consistent among versions and by default transforms
+    // errors to exceptions
+    bool _exist(const std::string& node_name, bool raise_errors=true) const;
 
     // Opens an arbitrary object to obtain info
     Object _open(const std::string& node_name,

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -196,11 +196,8 @@ inline bool NodeTraits<Derivate>::_exist(const std::string& node_name,
 
     // The root path always exists, but H5Lexists return 0 or 1
     // depending of the version of HDF5, so always return true for it
-    // We should call H5Lexists anyway to check that no error is returned
-    if (node_name == "/")
-        return true;
-
-    return (val > 0);
+    // We had to call H5Lexists anyway to check that there are no errors
+    return (node_name == "/") ? true : (val > 0);
 }
 
 template <typename Derivate>

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -186,9 +186,12 @@ inline bool NodeTraits<Derivate>::_exist(const std::string& node_name,
     SilenceHDF5 silencer{raise_errors};
     const auto val = H5Lexists(static_cast<const Derivate*>(this)->getId(),
                                node_name.c_str(), H5P_DEFAULT);
-    if (raise_errors && val < 0) {
-        HDF5ErrMapper::ToException<GroupException>(
-            std::string("Invalid link for exist() "));
+    if (val < 0) {
+        if (raise_errors) {
+            HDF5ErrMapper::ToException<GroupException>("Invalid link for exist()");
+        } else {
+            return false;
+        }
     }
 
     // The root path always exists, but H5Lexists return 0 or 1

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -207,7 +207,7 @@ inline bool NodeTraits<Derivate>::exist(const std::string& group_path) const {
     if (group_path.find('/') != std::string::npos) {
         _exist("/");  // Shall not throw under normal circumstances
         // Unless "/" (already checked), verify path exists (not thowing errors)
-        return (group_path == "/")? true : _exist(group_path, false);
+        return (group_path == "/") ? true : _exist(group_path, false);
     }
     return _exist(group_path);
 }


### PR DESCRIPTION
The implementation of `Node.exist()` required catching an exception that we generated ourselves. Despite being a simple principle, it kind of used exceptions for flow control and In some compiler toolchains (QT) this would create unwanted error messages (#224, #289)

## This PR
Makes the low-level `_exist` function conditionally treat the error as a normal false, not throwing exception. This design even simplified the implementation of the public `exist()` method.

Fixes #289