### PR TITLE
Add inline to Reference::get_ref

### DIFF
--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -48,7 +48,7 @@ inline T Reference::dereference(const Object& location) const {
     return T(obj);
 }
 
-Object Reference::get_ref(const Object& location) const {
+inline Object Reference::get_ref(const Object& location) const {
     hid_t res;
 #if (H5Rdereference_vers == 2)
     if ((res = H5Rdereference(location.getId(), H5P_DEFAULT, H5R_OBJECT, &href)) < 0) {


### PR DESCRIPTION
Helps to prevent redefinition errors when building downstream projects.