### PR TITLE
SFINAE for eigen

### DIFF
--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -73,26 +73,29 @@ inline size_t getSize(const File& file, const std::string& path);
 /// \return the shape of the DataSet
 inline std::vector<size_t> getShape(const File& file, const std::string& path);
 
-///
-/// \brief Write an Eigen matrix to a new DataSet in an open HDF5 file.
-///
-/// \param file Writeable opened file
-/// \param path Path of the DataSet
-/// \param data eigen matrix to write
-/// \param mode Write mode
-///
-/// \return the newly created DataSet
-///
-#ifdef H5_USE_EIGEN
-template <class T, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>& data,
-                    DumpMode mode = DumpMode::Create);
-#endif
+template<typename T>
+struct is_easy{
+	static const bool value=std::is_arithmetic<T>::value
+        || std::is_same<char *, typename std::decay<T>::type>::value
+        || std::is_same<const char *, typename std::decay<T>::type>::value
+        || std::is_same<std::string, typename std::decay<T>::type>::value
+	;
+};
+
+
+template<class T>
+struct is_vector {
+    static const bool value = false;
+};
+
+template<class T>
+struct is_vector<std::vector<T>> {
+    const static bool value = true;
+};
+
 
 ///
-/// \brief Write an Eigen::Ref object to a new DataSet in an open HDF5 file.
+/// \brief Write any (dense) Eigen object to a new DataSet in an open HDF5 file.
 ///
 /// \param file Writeable opened file
 /// \param path Path of the DataSet
@@ -105,27 +108,10 @@ inline DataSet dump(File& file,
 template <class T>
 inline DataSet dump(File& file,
                     const std::string& path,
-                    const Eigen::Ref<T>& data,
+                    const Eigen::DenseBase<T>& data,
                     DumpMode mode = DumpMode::Create);
 #endif
 
-///
-/// \brief Write an Eigen::Map object to a new DataSet in an open HDF5 file.
-///
-/// \param file Writeable opened file
-/// \param path Path of the DataSet
-/// \param data eigen matrix to write
-/// \param mode Write mode
-///
-/// \return the newly created DataSet
-///
-#ifdef H5_USE_EIGEN
-template <class T>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const Eigen::Map<T>& data,
-                    DumpMode mode = DumpMode::Create);
-#endif
 
 ///
 /// \brief Write "xt::xarray<T>" to a new DataSet in an open HDF5 file.
@@ -163,6 +149,7 @@ inline DataSet dump(File& file,
                     DumpMode mode = DumpMode::Create);
 #endif
 
+
 ///
 /// \brief Write "std::vector<T>" to a new DataSet in an open HDF5 file.
 ///
@@ -173,10 +160,10 @@ inline DataSet dump(File& file,
 ///
 /// \return the newly created DataSet
 ///
-template <class T>
+template <class T, typename std::enable_if<is_vector<T>::value,int>::type=0>
 inline DataSet dump(File& file,
                     const std::string& path,
-                    const std::vector<T>& data,
+                    const T& data,
                     DumpMode mode = DumpMode::Create);
 
 ///
@@ -189,7 +176,7 @@ inline DataSet dump(File& file,
 ///
 /// \return The newly created DataSet
 ///
-template <class T>
+template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 inline DataSet dump(File& file,
                     const std::string& path,
                     const T& data,
@@ -205,7 +192,7 @@ inline DataSet dump(File& file,
 ///
 /// \return The newly created DataSet
 ///
-template <class T>
+template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 inline DataSet dump(File& file,
                     const std::string& path,
                     const T& data,
@@ -220,6 +207,7 @@ inline DataSet dump(File& file,
 ///
 /// \return the read data
 ///
+// template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 template <class T>
 inline T load(const File& file,
               const std::string& path,
@@ -233,8 +221,12 @@ inline T load(const File& file,
 ///
 /// \return the read data
 ///
+// template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 template <class T>
 inline T load(const File& file, const std::string& path);
+
+
+
 
 }  // namespace H5Easy
 

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -49,10 +49,10 @@ using HighFive::File;
 
 ///
 /// \brief Write mode for DataSets
-enum class DumpMode
-{
-  Create, /*!< Dump only if DataSet does not exist, otherwise throw. */
-  Overwrite /*!< If DataSet already exists overwrite it if data has the same shape, otherwise throw. */
+enum class DumpMode {
+    Create,   /*!< Dump only if DataSet does not exist, otherwise throw. */
+    Overwrite /*!< If DataSet already exists overwrite it if data has the same shape,
+                 otherwise throw. */
 };
 
 ///
@@ -72,7 +72,6 @@ inline size_t getSize(const File& file, const std::string& path);
 ///
 /// \return the shape of the DataSet
 inline std::vector<size_t> getShape(const File& file, const std::string& path);
-
 
 ///
 /// \brief Write scalar/string to a new DataSet in an open HDF5 file.
@@ -101,10 +100,8 @@ inline DataSet dump(File& file,
 /// \return The newly created DataSet
 ///
 template <class T>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const T& data,
-                    const std::vector<size_t>& idx);
+inline DataSet
+dump(File& file, const std::string& path, const T& data, const std::vector<size_t>& idx);
 
 ///
 /// \brief Load entry "(i,j)" from a rank-two DataSet in an open HDF5 file to a scalar.
@@ -116,9 +113,7 @@ inline DataSet dump(File& file,
 /// \return the read data
 ///
 template <class T>
-inline T load(const File& file,
-              const std::string& path,
-              const std::vector<size_t>& idx);
+inline T load(const File& file, const std::string& path, const std::vector<size_t>& idx);
 
 ///
 /// \brief Load a DataSet in an open HDF5 file to an object (templated).
@@ -133,10 +128,10 @@ inline T load(const File& file, const std::string& path);
 
 }  // namespace H5Easy
 
+#include "h5easy_bits/H5Easy_Eigen.hpp"
 #include "h5easy_bits/H5Easy_misc.hpp"
 #include "h5easy_bits/H5Easy_scalar.hpp"
 #include "h5easy_bits/H5Easy_vector.hpp"
-#include "h5easy_bits/H5Easy_Eigen.hpp"
 #include "h5easy_bits/H5Easy_xtensor.hpp"
 
 #endif  // H5EASY_HPP

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -73,99 +73,7 @@ inline size_t getSize(const File& file, const std::string& path);
 /// \return the shape of the DataSet
 inline std::vector<size_t> getShape(const File& file, const std::string& path);
 
-template<typename T>
-struct is_easy{
-	static const bool value=std::is_arithmetic<T>::value
-        || std::is_same<char *, typename std::decay<T>::type>::value
-        || std::is_same<const char *, typename std::decay<T>::type>::value
-        || std::is_same<std::string, typename std::decay<T>::type>::value
-	;
-};
-
-
-template<class T>
-struct is_vector {
-    static const bool value = false;
-};
-
-template<class T>
-struct is_vector<std::vector<T>> {
-    const static bool value = true;
-};
-
-
-///
-/// \brief Write any (dense) Eigen object to a new DataSet in an open HDF5 file.
-///
-/// \param file Writeable opened file
-/// \param path Path of the DataSet
-/// \param data eigen matrix to write
-/// \param mode Write mode
-///
-/// \return the newly created DataSet
-///
-#ifdef H5_USE_EIGEN
-template <class T>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const Eigen::DenseBase<T>& data,
-                    DumpMode mode = DumpMode::Create);
-#endif
-
-
-///
-/// \brief Write "xt::xarray<T>" to a new DataSet in an open HDF5 file.
-///
-/// \param file A writeable opened HDF5 file
-/// \param path Path of the DataSet
-/// \param data xtensor array to write
-/// \param mode write mode
-///
-/// \return the newly created DataSet
-///
-#ifdef H5_USE_XTENSOR
-template <class T>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const xt::xarray<T>& data,
-                    DumpMode mode = DumpMode::Create);
-#endif
-
-///
-/// \brief Write "xt::xtensor<T,rank>" to a new DataSet in an open HDF5 file.
-///
-/// \param file opened File (has to be writeable)
-/// \param path path of the DataSet
-/// \param data the data to write
-/// \param mode write mode
-///
-/// \return the newly created DataSet
-///
-#ifdef H5_USE_XTENSOR
-template <class T, size_t rank>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const xt::xtensor<T, rank>& data,
-                    DumpMode mode = DumpMode::Create);
-#endif
-
-
-///
-/// \brief Write "std::vector<T>" to a new DataSet in an open HDF5 file.
-///
-/// \param file opened File (has to be writeable)
-/// \param path path of the DataSet
-/// \param data the data to write
-/// \param mode write mode
-///
-/// \return the newly created DataSet
-///
-template <class T, typename std::enable_if<is_vector<T>::value,int>::type=0>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const T& data,
-                    DumpMode mode = DumpMode::Create);
-
+                    
 ///
 /// \brief Write scalar/string to a new DataSet in an open HDF5 file.
 ///
@@ -176,7 +84,7 @@ inline DataSet dump(File& file,
 ///
 /// \return The newly created DataSet
 ///
-template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
+template <class T>
 inline DataSet dump(File& file,
                     const std::string& path,
                     const T& data,
@@ -192,7 +100,7 @@ inline DataSet dump(File& file,
 ///
 /// \return The newly created DataSet
 ///
-template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
+template <class T>
 inline DataSet dump(File& file,
                     const std::string& path,
                     const T& data,
@@ -224,8 +132,6 @@ inline T load(const File& file,
 // template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 template <class T>
 inline T load(const File& file, const std::string& path);
-
-
 
 
 }  // namespace H5Easy

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-// optionally enable plug-in xtensor and load the library
+// optionally enable xtensor plug-in and load the library
 #ifdef XTENSOR_VERSION_MAJOR
 #ifndef H5_USE_XTENSOR
 #define H5_USE_XTENSOR
@@ -24,7 +24,7 @@
 #include <xtensor/xtensor.hpp>
 #endif
 
-// optionally enable plug-in Eigen and load the library
+// optionally enable Eigen plug-in and load the library
 #ifdef EIGEN_WORLD_VERSION
 #ifndef H5_USE_EIGEN
 #define H5_USE_EIGEN
@@ -50,9 +50,8 @@ using HighFive::File;
 ///
 /// \brief Write mode for DataSets
 enum class DumpMode {
-    Create,   /*!< Dump only if DataSet does not exist, otherwise throw. */
-    Overwrite /*!< If DataSet already exists overwrite it if data has the same shape,
-                 otherwise throw. */
+    Create, /*!< Dump only if DataSet does not exist, otherwise throw. */
+    Overwrite /*!< If DataSet already exists overwrite it if data has the same shape, otherwise throw. */
 };
 
 ///
@@ -100,8 +99,10 @@ inline DataSet dump(File& file,
 /// \return The newly created DataSet
 ///
 template <class T>
-inline DataSet
-dump(File& file, const std::string& path, const T& data, const std::vector<size_t>& idx);
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    const std::vector<size_t>& idx);
 
 ///
 /// \brief Load entry "(i,j)" from a rank-two DataSet in an open HDF5 file to a scalar.

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -73,7 +73,7 @@ inline size_t getSize(const File& file, const std::string& path);
 /// \return the shape of the DataSet
 inline std::vector<size_t> getShape(const File& file, const std::string& path);
 
-                    
+
 ///
 /// \brief Write scalar/string to a new DataSet in an open HDF5 file.
 ///
@@ -115,7 +115,6 @@ inline DataSet dump(File& file,
 ///
 /// \return the read data
 ///
-// template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 template <class T>
 inline T load(const File& file,
               const std::string& path,
@@ -129,10 +128,8 @@ inline T load(const File& file,
 ///
 /// \return the read data
 ///
-// template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 template <class T>
 inline T load(const File& file, const std::string& path);
-
 
 }  // namespace H5Easy
 

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -19,88 +19,89 @@ namespace H5Easy {
 
 namespace detail {
 
-template<typename T>
-struct io_impl<T,typename std::enable_if<std::is_base_of<Eigen::DenseBase<T>,T>::value>::type>: public io_impl_base<T> {
-		
-	// return the shape of Eigen::DenseBase<T> object as size 1 or 2 "std::vector<size_t>"
-	inline static std::vector<size_t> shape(const T& data) {
-		if (std::decay<T>::type::RowsAtCompileTime == 1) {
-			return {static_cast<size_t>(data.cols())};
-		}
-		if (std::decay<T>::type::ColsAtCompileTime == 1) {
-			return {static_cast<size_t>(data.rows())};
-		}
-		return {static_cast<size_t>(data.rows()),
-				static_cast<size_t>(data.cols())};
-	}
-	
-	using EigenIndex = Eigen::DenseIndex;
+template <typename T>
+struct io_impl<
+    T,
+    typename std::enable_if<std::is_base_of<Eigen::DenseBase<T>, T>::value>::type> {
 
-	// get the shape of a "DataSet" as size 2 "std::vector<Eigen::Index>"
-	inline static std::vector<EigenIndex> shape(const File& file,
-                                               const std::string& path,
-                                               const DataSet& dataset,
-                                               int RowsAtCompileTime) {
-		std::vector<size_t> dims = dataset.getDimensions();
+    // return the shape of Eigen::DenseBase<T> object as size 1 or 2 "std::vector<size_t>"
+    inline static std::vector<size_t> shape(const T& data) {
+        if (std::decay<T>::type::RowsAtCompileTime == 1) {
+            return {static_cast<size_t>(data.cols())};
+        }
+        if (std::decay<T>::type::ColsAtCompileTime == 1) {
+            return {static_cast<size_t>(data.rows())};
+        }
+        return {static_cast<size_t>(data.rows()), static_cast<size_t>(data.cols())};
+    }
 
-		if (dims.size() == 1 && RowsAtCompileTime == 1) {
-			return std::vector<EigenIndex>{1u, static_cast<EigenIndex>(dims[0])};
-		}
-		if (dims.size() == 1) {
-			return std::vector<EigenIndex>{static_cast<EigenIndex>(dims[0]), 1u};
-		}
-		if (dims.size() == 2) {
-			return std::vector<EigenIndex>{static_cast<EigenIndex>(dims[0]),
+    using EigenIndex = Eigen::DenseIndex;
+
+    // get the shape of a "DataSet" as size 2 "std::vector<Eigen::Index>"
+    inline static std::vector<EigenIndex> shape(const File& file,
+                                                const std::string& path,
+                                                const DataSet& dataset,
+                                                int RowsAtCompileTime) {
+        std::vector<size_t> dims = dataset.getDimensions();
+
+        if (dims.size() == 1 && RowsAtCompileTime == 1) {
+            return std::vector<EigenIndex>{1u, static_cast<EigenIndex>(dims[0])};
+        }
+        if (dims.size() == 1) {
+            return std::vector<EigenIndex>{static_cast<EigenIndex>(dims[0]), 1u};
+        }
+        if (dims.size() == 2) {
+            return std::vector<EigenIndex>{static_cast<EigenIndex>(dims[0]),
                                            static_cast<EigenIndex>(dims[1])};
-		}
+        }
 
-		throw detail::error(file, path, "H5Easy::load: Inconsistent rank");
-	}
+        throw detail::error(file, path, "H5Easy::load: Inconsistent rank");
+    }
 
-	// write to open DataSet of the correct size
-	// (use Eigen::Ref to convert to RowMajor; no action if no conversion is needed)
-	inline static void write(DataSet& dataset, const T& data) {
-		Eigen::Ref<
-			const Eigen::Array<
-				typename std::decay<T>::type::Scalar,
-				std::decay<T>::type::RowsAtCompileTime,
-				std::decay<T>::type::ColsAtCompileTime,
-				std::decay<T>::type::ColsAtCompileTime==1 ? Eigen::ColMajor : Eigen::RowMajor,
-				std::decay<T>::type::MaxRowsAtCompileTime,
-				std::decay<T>::type::MaxColsAtCompileTime>,
-			0,
-			Eigen::InnerStride<1>
-		> row_major(data);
+    // write to open DataSet of the correct size
+    // (use Eigen::Ref to convert to RowMajor; no action if no conversion is needed)
+    inline static void write(DataSet& dataset, const T& data) {
+        Eigen::Ref<const Eigen::Array<typename std::decay<T>::type::Scalar,
+                                      std::decay<T>::type::RowsAtCompileTime,
+                                      std::decay<T>::type::ColsAtCompileTime,
+                                      std::decay<T>::type::ColsAtCompileTime == 1
+                                          ? Eigen::ColMajor
+                                          : Eigen::RowMajor,
+                                      std::decay<T>::type::MaxRowsAtCompileTime,
+                                      std::decay<T>::type::MaxColsAtCompileTime>,
+                   0, Eigen::InnerStride<1>>
+            row_major(data);
 
-		dataset.write_raw(row_major.data());
-	}
+        dataset.write_raw(row_major.data());
+    }
 
-	// create DataSet and write data
-	static DataSet dump(File& file, const std::string& path, const T& data) {
-		using value_type = typename std::decay<T>::type::Scalar;
-		detail::createGroupsToDataSet(file, path);
-		DataSet dataset = file.createDataSet<value_type>(path, DataSpace(shape(data)));
-		write(dataset, data);
-		file.flush();
-		return dataset;
-	}
+    // create DataSet and write data
+    static DataSet dump(File& file, const std::string& path, const T& data) {
+        using value_type = typename std::decay<T>::type::Scalar;
+        detail::createGroupsToDataSet(file, path);
+        DataSet dataset = file.createDataSet<value_type>(path, DataSpace(shape(data)));
+        write(dataset, data);
+        file.flush();
+        return dataset;
+    }
 
-	// replace data of an existing DataSet of the correct size
-	static DataSet overwrite(File& file, const std::string& path, const T& data) {
-		DataSet dataset = file.getDataSet(path);
-		if (dataset.getDimensions() != shape(data)) {
-			throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
-		}
-		write(dataset, data);
-		file.flush();
-		return dataset;
-	}
-
-	// load from DataSet
-	// convert to ColMajor if needed (HDF5 always stores row-major)
-	static T load(const File& file, const std::string& path) {
+    // replace data of an existing DataSet of the correct size
+    static DataSet overwrite(File& file, const std::string& path, const T& data) {
         DataSet dataset = file.getDataSet(path);
-        std::vector<typename T::Index> dims = shape(file, path, dataset, T::RowsAtCompileTime);
+        if (dataset.getDimensions() != shape(data)) {
+            throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
+        }
+        write(dataset, data);
+        file.flush();
+        return dataset;
+    }
+
+    // load from DataSet
+    // convert to ColMajor if needed (HDF5 always stores row-major)
+    static T load(const File& file, const std::string& path) {
+        DataSet dataset = file.getDataSet(path);
+        std::vector<typename T::Index> dims = shape(file, path, dataset,
+                                                    T::RowsAtCompileTime);
         T data(dims[0], dims[1]);
         dataset.read(data.data());
 
@@ -108,18 +109,15 @@ struct io_impl<T,typename std::enable_if<std::is_base_of<Eigen::DenseBase<T>,T>:
             return data;
         }
 
-        return Eigen::Map<Eigen::Array<
-            typename T::Scalar,
-            T::RowsAtCompileTime,
-            T::ColsAtCompileTime,
-            T::ColsAtCompileTime==1?Eigen::ColMajor:Eigen::RowMajor,
-            T::MaxRowsAtCompileTime,
-            T::MaxColsAtCompileTime>>(data.data(), dims[0], dims[1]);
+        return Eigen::Map<
+            Eigen::Array<typename T::Scalar, T::RowsAtCompileTime, T::ColsAtCompileTime,
+                         T::ColsAtCompileTime == 1 ? Eigen::ColMajor : Eigen::RowMajor,
+                         T::MaxRowsAtCompileTime, T::MaxColsAtCompileTime>>(
+            data.data(), dims[0], dims[1]);
     }
 };
 
-
-} // namespace detail
+}  // namespace detail
 }  // namespace H5Easy
 
 #endif  // H5_USE_EIGEN

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -139,13 +139,13 @@ inline DataSet dump(File& file, const std::string& path, const Derived& data, Du
 }  // namespace eigen
 
 // front-end
-template <typename Derived>
-struct load_impl<Eigen::DenseBase<Derived>> {
-    static Derived
+template <typename T>
+struct load_impl<T, typename std::enable_if<std::is_base_of<Eigen::DenseBase<T>,T>::value>::type> {
+    static T
     run(const File& file,
         const std::string& path)
     {
-        return detail::eigen::load_impl<Derived>::run(file,path);
+        return detail::eigen::load_impl<T>::run(file,path);
     }
 };
 

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -16,10 +16,8 @@ namespace H5Easy {
 namespace detail {
 
 // Generate error-stream and return "Exception" (not yet thrown).
-inline Exception error(const File& file,
-                       const std::string& path,
-                       const std::string& message)
-{
+inline Exception
+error(const File& file, const std::string& path, const std::string& message) {
     std::ostringstream ss;
     ss << message << std::endl
        << "Path: " << path << std::endl
@@ -35,8 +33,7 @@ inline Exception error(const File& file,
 /// \param path path to a DataSet
 ///
 /// \return group the path of the group above the DataSet
-inline std::string getParentName(const std::string& path)
-{
+inline std::string getParentName(const std::string& path) {
     std::size_t idx = path.find_last_of("/\\");
 
     if (idx == std::string::npos) {
@@ -55,8 +52,7 @@ inline std::string getParentName(const std::string& path)
 /// \param file opened File
 /// \param path path of the DataSet
 ///
-inline void createGroupsToDataSet(File& file, const std::string& path)
-{
+inline void createGroupsToDataSet(File& file, const std::string& path) {
     std::string group_name = getParentName(path);
 
     if (!file.exist(group_name)) {

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -16,8 +16,9 @@ namespace H5Easy {
 namespace detail {
 
 // Generate error-stream and return "Exception" (not yet thrown).
-inline Exception
-error(const File& file, const std::string& path, const std::string& message) {
+inline Exception error(const File& file,
+                       const std::string& path,
+                       const std::string& message) {
     std::ostringstream ss;
     ss << message << std::endl
        << "Path: " << path << std::endl
@@ -35,7 +36,6 @@ error(const File& file, const std::string& path, const std::string& message) {
 /// \return group the path of the group above the DataSet
 inline std::string getParentName(const std::string& path) {
     std::size_t idx = path.find_last_of("/\\");
-
     if (idx == std::string::npos) {
         return "/";
     } else if (idx == 0) {
@@ -54,7 +54,6 @@ inline std::string getParentName(const std::string& path) {
 ///
 inline void createGroupsToDataSet(File& file, const std::string& path) {
     std::string group_name = getParentName(path);
-
     if (!file.exist(group_name)) {
         file.createGroup(group_name);
     }

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -130,7 +130,7 @@ struct load_impl
 }  // namespace detail
 
 // front-end
-template <class T>
+template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 inline DataSet dump(File& file, const std::string& path, const T& data, DumpMode mode)
 {
     if (!file.exist(path)) {
@@ -143,7 +143,7 @@ inline DataSet dump(File& file, const std::string& path, const T& data, DumpMode
 }
 
 // front-end
-template <class T>
+template <class T, typename std::enable_if<is_easy<T>::value,int>::type=0>
 inline DataSet dump(File& file,
                     const std::string& path,
                     const T& data,

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -29,21 +29,18 @@ The full API set is:
 * load_part
 
 */
-template<typename T, typename = void>
-struct io_impl
-{
+template <typename T, typename = void>
+struct io_impl {
     // create DataSet and write data
-    static DataSet dump(File& file, const std::string& path, const T& data)
-    {
-        detail::createGroupsToDataSet(file, path);	
+    static DataSet dump(File& file, const std::string& path, const T& data) {
+        detail::createGroupsToDataSet(file, path);
         DataSet dataset = file.createDataSet<T>(path, DataSpace::From(data));
         dataset.write(data);
         file.flush();
         return dataset;
     }
     // replace data of an existing DataSet of the correct size
-    static DataSet overwrite(File& file, const std::string& path, const T& data)
-    {
+    static DataSet overwrite(File& file, const std::string& path, const T& data) {
         DataSet dataset = file.getDataSet(path);
         if (dataset.getElementCount() != 1) {
             throw detail::error(file, path, "H5Easy::dump: Existing field not a scalar");
@@ -54,10 +51,9 @@ struct io_impl
     }
     // create/write extendible DataSet and write data
     static DataSet dump_extend(File& file,
-                       const std::string& path,
-                       const T& data,
-                       const std::vector<size_t>& idx)
-    {
+                               const std::string& path,
+                               const T& data,
+                               const std::vector<size_t>& idx) {
         std::vector<size_t> ones(idx.size(), 1);
 
         if (file.exist(path)) {
@@ -66,7 +62,8 @@ struct io_impl
             std::vector<size_t> shape = dims;
             if (dims.size() != idx.size()) {
                 throw detail::error(file, path,
-                    "H5Easy::dump: Rank of the index and the existing field do not match");
+                                    "H5Easy::dump: Rank of the index and the existing "
+                                    "field do not match");
             }
             for (size_t i = 0; i < dims.size(); ++i) {
                 shape[i] = std::max(dims[i], idx[i] + 1);
@@ -96,10 +93,8 @@ struct io_impl
         return dataset;
     }
     // load a part of a larger DataSet
-    static T load_part(const File& file,
-                 const std::string& path,
-                 const std::vector<size_t>& idx)
-    {
+    static T
+    load_part(const File& file, const std::string& path, const std::vector<size_t>& idx) {
         std::vector<size_t> ones(idx.size(), 1);
         DataSet dataset = file.getDataSet(path);
         T data;
@@ -107,18 +102,15 @@ struct io_impl
         return data;
     }
     // load entire DataSet
-    static T load(const File& file, const std::string& path)
-    {
+    static T load(const File& file, const std::string& path) {
         DataSet dataset = file.getDataSet(path);
         T data;
         dataset.read(data);
         return data;
     }
-    
 };
 
 }  // namespace detail
-
 
 /*
 Frontend functions only dispatch to io_impl<T> and are common for all datatypes.
@@ -126,8 +118,7 @@ Frontend functions only dispatch to io_impl<T> and are common for all datatypes.
 
 // front-end
 template <class T>
-inline DataSet dump(File& file, const std::string& path, const T& data, DumpMode mode)
-{
+inline DataSet dump(File& file, const std::string& path, const T& data, DumpMode mode) {
     if (!file.exist(path)) {
         return detail::io_impl<T>::dump(file, path, data);
     } else if (mode == DumpMode::Overwrite) {
@@ -139,25 +130,20 @@ inline DataSet dump(File& file, const std::string& path, const T& data, DumpMode
 
 // front-end
 template <class T>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const T& data,
-                    const std::vector<size_t>& idx)
-{
+inline DataSet
+dump(File& file, const std::string& path, const T& data, const std::vector<size_t>& idx) {
     return detail::io_impl<T>::dump_extend(file, path, data, idx);
 }
 
 // front-end
 template <class T>
-inline T load(const File& file, const std::string& path, const std::vector<size_t>& idx)
-{
+inline T load(const File& file, const std::string& path, const std::vector<size_t>& idx) {
     return detail::io_impl<T>::load_part(file, path, idx);
 }
 
 // front-end
 template <class T>
-inline T load(const File& file, const std::string& path)
-{
+inline T load(const File& file, const std::string& path) {
     return detail::io_impl<T>::load(file, path);
 }
 

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -114,8 +114,9 @@ struct load_impl
 
 }  // namespace scalar
 
-// load from DataSet
-template <class T, class E = void>
+// load from DataSet: base template (used as fallback)
+// inspired by https://stackoverflow.com/questions/281725/template-specialization-based-on-inherit-class/282006
+template<class T, typename = void>
 struct load_impl
 {
     static T run(const File& file, const std::string& path)

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -17,9 +17,8 @@ namespace H5Easy {
 namespace detail {
 
 /*
-This base class presents fallback methods which will be automatically
-called from specializations, if not defined in the specialization.
-Every specialization of io_impl<T> should inherit from io_impl_base<T>.
+I/O template for scalar types; it is base template for partial specialization
+thus will be used as fallback if more specialized templates don't match.
 
 The full API set is:
 
@@ -30,8 +29,8 @@ The full API set is:
 * load_part
 
 */
-template<typename T>
-struct io_impl_base
+template<typename T, typename = void>
+struct io_impl
 {
     // create DataSet and write data
     static DataSet dump(File& file, const std::string& path, const T& data)
@@ -117,14 +116,6 @@ struct io_impl_base
     }
     
 };
-
-/*
-Base template for specialization;
-The defaults are all implemented in io_impl_base, thus there is nothing new here.
-*/
-template<typename T, typename = void>
-struct io_impl: public io_impl_base<T>{};
-
 
 }  // namespace detail
 

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -17,34 +17,33 @@ namespace H5Easy {
 
 namespace detail {
 
-template<class T> struct is_vector: std::false_type  {};
-template<class T> struct is_vector<std::vector<T>> : std::true_type {};
+template <class T>
+struct is_vector : std::false_type {};
+template <class T>
+struct is_vector<std::vector<T>> : std::true_type {};
 
-using HighFive::details::type_of_array;
 using HighFive::details::get_dim_vector;
+using HighFive::details::type_of_array;
 
 /*
 This vector specialization does not implement load, load_part, dump_extend.
 Since it inherits from io_impl_base, implementations there will be called automatically.
  */
-template<typename T>
-struct io_impl<T,typename std::enable_if<is_vector<T>::value>::type> {
+template <typename T>
+struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
 
-	// create DataSet and write data
-	static DataSet dump(File& file, const std::string& path, const T& data)
-	{
-		using type_name = typename type_of_array<T>::type;
-		detail::createGroupsToDataSet(file, path);
-		DataSet dataset = file.createDataSet<type_name>(path, DataSpace::From(data));
-		dataset.write(data);
-		file.flush();
-		return dataset;
-	}
-    static DataSet overwrite(File& file, const std::string& path, const T& data)
-    {
+    // create DataSet and write data
+    static DataSet dump(File& file, const std::string& path, const T& data) {
+        using type_name = typename type_of_array<T>::type;
+        detail::createGroupsToDataSet(file, path);
+        DataSet dataset = file.createDataSet<type_name>(path, DataSpace::From(data));
+        dataset.write(data);
+        file.flush();
+        return dataset;
+    }
+    static DataSet overwrite(File& file, const std::string& path, const T& data) {
         DataSet dataset = file.getDataSet(path);
-        if (get_dim_vector(data) != dataset.getDimensions())
-        {
+        if (get_dim_vector(data) != dataset.getDimensions()) {
             throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
         }
         dataset.write(data);
@@ -53,8 +52,7 @@ struct io_impl<T,typename std::enable_if<is_vector<T>::value>::type> {
     }
     // load entire DataSet
     // (copied verbatim from generic implementation)
-    static T load(const File& file, const std::string& path)
-    {
+    static T load(const File& file, const std::string& path) {
         DataSet dataset = file.getDataSet(path);
         T data;
         dataset.read(data);

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -28,7 +28,7 @@ This vector specialization does not implement load, load_part, dump_extend.
 Since it inherits from io_impl_base, implementations there will be called automatically.
  */
 template<typename T>
-struct io_impl<T,typename std::enable_if<is_vector<T>::value>::type>: public io_impl_base<T> {
+struct io_impl<T,typename std::enable_if<is_vector<T>::value>::type> {
 
 	// create DataSet and write data
 	static DataSet dump(File& file, const std::string& path, const T& data)
@@ -50,6 +50,15 @@ struct io_impl<T,typename std::enable_if<is_vector<T>::value>::type>: public io_
         dataset.write(data);
         file.flush();
         return dataset;
+    }
+    // load entire DataSet
+    // (copied verbatim from generic implementation)
+    static T load(const File& file, const std::string& path)
+    {
+        DataSet dataset = file.getDataSet(path);
+        T data;
+        dataset.read(data);
+        return data;
     }
 };
 

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -59,16 +59,16 @@ struct overwrite_impl
 }  // namespace detail
 
 // front-end
-template <class T>
+template <class VectorT, typename std::enable_if<is_vector<VectorT>::value,int>::type=0>
 inline DataSet dump(File& file,
                     const std::string& path,
-                    const std::vector<T>& data,
+                    const VectorT& data,
                     DumpMode mode)
 {
     if (!file.exist(path)) {
-        return detail::vector::dump_impl<T>::run(file, path, data);
+        return detail::vector::dump_impl<typename VectorT::value_type>::run(file, path, data);
     } else if (mode == DumpMode::Overwrite) {
-        return detail::vector::overwrite_impl<T>::run(file, path, data);
+        return detail::vector::overwrite_impl<typename VectorT::value_type>::run(file, path, data);
     } else {
         throw detail::error(file, path, "H5Easy: path already exists");
     }

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -11,7 +11,7 @@
 
 #include "../H5Easy.hpp"
 #include "H5Easy_misc.hpp"
-#include "H5Easy_scalar.hpp"  // to get the basic "load_impl"
+#include "H5Easy_scalar.hpp"
 
 namespace H5Easy {
 
@@ -25,14 +25,9 @@ struct is_vector<std::vector<T>> : std::true_type {};
 using HighFive::details::get_dim_vector;
 using HighFive::details::type_of_array;
 
-/*
-This vector specialization does not implement load, load_part, dump_extend.
-Since it inherits from io_impl_base, implementations there will be called automatically.
- */
 template <typename T>
 struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
 
-    // create DataSet and write data
     static DataSet dump(File& file, const std::string& path, const T& data) {
         using type_name = typename type_of_array<T>::type;
         detail::createGroupsToDataSet(file, path);
@@ -41,6 +36,7 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         file.flush();
         return dataset;
     }
+
     static DataSet overwrite(File& file, const std::string& path, const T& data) {
         DataSet dataset = file.getDataSet(path);
         if (get_dim_vector(data) != dataset.getDimensions()) {
@@ -50,8 +46,7 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         file.flush();
         return dataset;
     }
-    // load entire DataSet
-    // (copied verbatim from generic implementation)
+
     static T load(const File& file, const std::string& path) {
         DataSet dataset = file.getDataSet(path);
         T data;

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -25,7 +25,7 @@ template <class T> struct is_xtensor<xt::xarray<T>> : std::true_type {};
 template <class T, size_t N> struct is_xtensor<xt::xtensor<T, N>> : std::true_type {};
 
 template<typename T>
-struct io_impl<T,typename std::enable_if<is_xtensor<T>::value>::type>: public io_impl_base<T> {
+struct io_impl<T,typename std::enable_if<is_xtensor<T>::value>::type> {
 	// helper function
 	inline static std::vector<size_t> shape(const T& data)
 	{

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -19,113 +19,56 @@ namespace H5Easy {
 
 namespace detail {
 
-namespace xtensor {
+// handled xtensor types
+template <class T> struct is_xtensor: std::false_type  {};
+template <class T> struct is_xtensor<xt::xarray<T>> : std::true_type {};
+template <class T, size_t N> struct is_xtensor<xt::xtensor<T, N>> : std::true_type {};
 
-// return the shape of the xtensor-object as "std::vector<size_t>"
-template <class T>
-inline std::vector<size_t> shape(const T& data)
-{
-    return std::vector<size_t>(data.shape().cbegin(), data.shape().cend());
-}
+template<typename T>
+struct io_impl<T,typename std::enable_if<is_xtensor<T>::value>::type>: public io_impl_base<T> {
+	// helper function
+	inline static std::vector<size_t> shape(const T& data)
+	{
+		return std::vector<size_t>(data.shape().cbegin(), data.shape().cend());
+	}
 
-// create DataSet and write data
-template <class T>
-static DataSet dump_impl(File& file, const std::string& path, const T& data)
-{
-    using value_type = typename std::decay_t<T>::value_type;
-    detail::createGroupsToDataSet(file, path);
-    DataSet dataset = file.createDataSet<value_type>(path, DataSpace(shape(data)));
-    dataset.write_raw(data.data());
-    file.flush();
-    return dataset;
-}
+	// create DataSet and write data
+	static DataSet dump(File& file, const std::string& path, const T& data)
+	{
+		using value_type = typename std::decay_t<T>::value_type;
+		detail::createGroupsToDataSet(file, path);
+		DataSet dataset = file.createDataSet<value_type>(path, DataSpace(shape(data)));
+		dataset.write_raw(data.data());
+		file.flush();
+		return dataset;
+	}
 
-// replace data of an existing DataSet of the correct size
-template <class T>
-static DataSet overwrite_impl(File& file, const std::string& path, const T& data)
-{
-    DataSet dataset = file.getDataSet(path);
-    if (dataset.getDimensions() != shape(data)) {
-        throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
-    }
-    dataset.write_raw(data.data());
-    file.flush();
-    return dataset;
-}
+	// replace data of an existing DataSet of the correct size
+	static DataSet overwrite(File& file, const std::string& path, const T& data)
+	{
+		DataSet dataset = file.getDataSet(path);
+		if (dataset.getDimensions() != shape(data)) {
+			throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
+		}
+		dataset.write_raw(data.data());
+		file.flush();
+		return dataset;
+	}
 
-// load xtensor-object from DataSet
-template <class T>
-struct load_impl
-{
-    static T run(const File& file, const std::string& path)
-    {
-        DataSet dataset = file.getDataSet(path);
-        std::vector<size_t> dims = dataset.getDimensions();
-        T data = T::from_shape(dims);
-        dataset.read(data.data());
-        return data;
-    }
-};
-
-// universal front-end (to minimise double code)
-template <class T>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const T& data,
-                    DumpMode mode)
-{
-    if (!file.exist(path)) {
-        return detail::xtensor::dump_impl(file, path, data);
-    } else if (mode == DumpMode::Overwrite) {
-        return detail::xtensor::overwrite_impl(file, path, data);
-    } else {
-        throw detail::error(file, path, "H5Easy: path already exists");
-    }
-}
-
-}  // namespace xtensor
-
-// front-end
-template <class T>
-struct load_impl<xt::xarray<T>>
-{
-    static xt::xarray<T> run(const File& file, const std::string& path)
-    {
-        return detail::xtensor::load_impl<xt::xarray<T>>::run(file, path);
-    }
-};
-
-// front-end
-template <class T, size_t rank>
-struct load_impl<xt::xtensor<T, rank>>
-{
-    static xt::xtensor<T, rank> run(const File& file, const std::string& path)
-    {
-        return detail::xtensor::load_impl<xt::xtensor<T, rank>>::run(file, path);
-    }
+	static T load(const File& file, const std::string& path)
+	{
+		DataSet dataset = file.getDataSet(path);
+		std::vector<size_t> dims = dataset.getDimensions();
+		T data = T::from_shape(dims);
+		dataset.read(data.data());
+		return data;
+	}
+	
+	// TODO: load_part
+	// TODO: extend
 };
 
 }  // namespace detail
-
-// front-end
-template <class T>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const xt::xarray<T>& data,
-                    DumpMode mode)
-{
-    return detail::xtensor::dump(file, path, data, mode);
-}
-
-// front-end
-template <class T, size_t rank>
-inline DataSet dump(File& file,
-                    const std::string& path,
-                    const xt::xtensor<T, rank>& data,
-                    DumpMode mode)
-{
-    return detail::xtensor::dump(file, path, data, mode);
-}
 
 }  // namespace H5Easy
 

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -11,7 +11,7 @@
 
 #include "../H5Easy.hpp"
 #include "H5Easy_misc.hpp"
-#include "H5Easy_scalar.hpp"  // to get the basic "load_impl"
+#include "H5Easy_scalar.hpp"
 
 #ifdef H5_USE_XTENSOR
 
@@ -19,7 +19,6 @@ namespace H5Easy {
 
 namespace detail {
 
-// handled xtensor types
 template <class T>
 struct is_xtensor : std::false_type {};
 template <class T>
@@ -29,12 +28,11 @@ struct is_xtensor<xt::xtensor<T, N>> : std::true_type {};
 
 template <typename T>
 struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
-    // helper function
+
     inline static std::vector<size_t> shape(const T& data) {
         return std::vector<size_t>(data.shape().cbegin(), data.shape().cend());
     }
 
-    // create DataSet and write data
     static DataSet dump(File& file, const std::string& path, const T& data) {
         using value_type = typename std::decay_t<T>::value_type;
         detail::createGroupsToDataSet(file, path);
@@ -44,7 +42,6 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return dataset;
     }
 
-    // replace data of an existing DataSet of the correct size
     static DataSet overwrite(File& file, const std::string& path, const T& data) {
         DataSet dataset = file.getDataSet(path);
         if (dataset.getDimensions() != shape(data)) {
@@ -63,8 +60,6 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return data;
     }
 
-    // TODO: load_part
-    // TODO: extend
 };
 
 }  // namespace detail

--- a/src/examples/easy_load_dump.cpp
+++ b/src/examples/easy_load_dump.cpp
@@ -78,7 +78,7 @@ int main()
         D = H5Easy::load<Eigen::MatrixXd>(file, "/path/to/D");
 
 
-        Eigen::MatrixXd D2 = Eigen::ArrayXd::Random(10,5);
+        Eigen::ArrayXd D2 = Eigen::ArrayXd::Random(30);
 
         H5Easy::dump(file, "/path/to/D2", D2);
         H5Easy::dump(file, "/path/to/D2", D2, H5Easy::DumpMode::Overwrite);

--- a/src/examples/easy_load_dump.cpp
+++ b/src/examples/easy_load_dump.cpp
@@ -69,12 +69,21 @@ int main()
 #ifdef H5_USE_EIGEN
     // (over)write and read Eigen::Matrix
     {
+        // matrix
         Eigen::MatrixXd D = Eigen::MatrixXd::Random(10,5);
 
         H5Easy::dump(file, "/path/to/D", D);
         H5Easy::dump(file, "/path/to/D", D, H5Easy::DumpMode::Overwrite);
 
         D = H5Easy::load<Eigen::MatrixXd>(file, "/path/to/D");
+
+
+        Eigen::MatrixXd D2 = Eigen::ArrayXd::Random(10,5);
+
+        H5Easy::dump(file, "/path/to/D2", D2);
+        H5Easy::dump(file, "/path/to/D2", D2, H5Easy::DumpMode::Overwrite);
+
+        D2 = H5Easy::load<Eigen::ArrayXd>(file, "/path/to/D2");
     }
 #endif
 

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -213,6 +213,41 @@ BOOST_AUTO_TEST_CASE(H5Easy_Eigen_MatrixX)
     BOOST_CHECK_EQUAL(B.isApprox(B_r), true);
 }
 
+BOOST_AUTO_TEST_CASE(H5Easy_Eigen_ArrayXX)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    Eigen::ArrayXXf A = 100. * Eigen::ArrayXXf::Random(20, 5);
+    Eigen::ArrayXXi B = A.cast<int>();
+
+    H5Easy::dump(file, "/path/to/A", A);
+    H5Easy::dump(file, "/path/to/B", B);
+
+    Eigen::ArrayXXf A_r = H5Easy::load<Eigen::MatrixXf>(file, "/path/to/A");
+    Eigen::ArrayXXi B_r = H5Easy::load<Eigen::MatrixXi>(file, "/path/to/B");
+
+    BOOST_CHECK_EQUAL(A.isApprox(A_r), true);
+    BOOST_CHECK_EQUAL(B.isApprox(B_r), true);
+}
+
+BOOST_AUTO_TEST_CASE(H5Easy_Eigen_ArrayX)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    Eigen::ArrayXf A = Eigen::ArrayXf::Random(50);
+    Eigen::ArrayXi B = A.cast<int>();
+
+    H5Easy::dump(file, "/path/to/A", A);
+    H5Easy::dump(file, "/path/to/B", B);
+
+    Eigen::ArrayXf A_r = H5Easy::load<Eigen::ArrayXf>(file, "/path/to/A");
+    Eigen::ArrayXi B_r = H5Easy::load<Eigen::ArrayXi>(file, "/path/to/B");
+
+    BOOST_CHECK_EQUAL(A.isApprox(A_r), true);
+    BOOST_CHECK_EQUAL(B.isApprox(B_r), true);
+}
+
+
 BOOST_AUTO_TEST_CASE(H5Easy_Eigen_VectorX)
 {
     H5Easy::File file("test.h5", H5Easy::File::Overwrite);


### PR DESCRIPTION
This is something like proof of concept (it does not compile) for SFINAE so that load/dump can be easily tailored for specific types incl. CPRT (Eigen).

Generic functions (for scalars, strings) are limited via the `is_easy`, specially treated is vector with `is_vector`. This is good for dumping.

For loading, I am too dumb to make load_impl available with enable_if only as needed, maybe someone could figure that out better than me.