### PR TITLE
expose close() function on Highfive file to allow force closing

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -69,7 +69,14 @@ class File : public Object,
     ///
     void flush();
 
- private:
+    ///
+    /// \brief close
+    ///
+    /// Flushes then closes file handle
+    ///
+    void close();
+
+  private:
     std::string _filename;
 };
 

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -87,6 +87,12 @@ inline void File::flush() {
     }
 }
 
+inline void File::close() {
+    if (H5Fclose(_hid) < 0) {
+        HDF5ErrMapper::ToException<FileException>(
+            std::string("Unable to close file " + _filename));
+    }
+}
 }  // namespace HighFive
 
 #endif  // H5FILE_MISC_HPP


### PR DESCRIPTION
Hi there,

We've noticed that we cannot overwrite h5 files during the same binary execution unless we close all handles to the files.