### PR TITLE
Fix SilenceHDF5 initialization for NodeTraits

### DIFF
--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -185,7 +185,7 @@ inline std::vector<std::string> NodeTraits<Derivate>::listObjectNames() const {
 template <typename Derivate>
 inline bool NodeTraits<Derivate>::_exist(const std::string& node_name,
                                          bool raise_errors) const {
-    SilenceHDF5 silencer{raise_errors};
+    SilenceHDF5 silencer{!raise_errors};
     const auto val = H5Lexists(static_cast<const Derivate*>(this)->getId(),
                                node_name.c_str(), H5P_DEFAULT);
     if (val < 0) {


### PR DESCRIPTION
`SilenceHDF5` should be enabled when `raise_error` is set to `false`. This should fix #331 and #326.