### PR TITLE
Add a mechanism to not include target HighFive several times

### DIFF
--- a/CMake/HighFiveConfig.cmake.in
+++ b/CMake/HighFiveConfig.cmake.in
@@ -11,56 +11,58 @@ function(copy_interface_properties target source)
   endforeach()
 endfunction()
 
-# Get HighFive targets
-include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargets.cmake")
+if(NOT TARGET HighFive)
+    # Get HighFive targets
+    include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargets.cmake")
 
-# Recreate combined HighFive
-add_library(HighFive INTERFACE IMPORTED)
-set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS MPI_NO_CPPBIND)  # No c++ bindings
+    # Recreate combined HighFive
+    add_library(HighFive INTERFACE IMPORTED)
+    set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS MPI_NO_CPPBIND)  # No c++ bindings
 
-# Ensure we activate required C++ std
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-  if(CMAKE_VERSION VERSION_LESS 3.8)
-    message(WARNING "HighFive requires minimum C++11. (C++14 for XTensor) \
-        You may need to set CMAKE_CXX_STANDARD in you project")
-  else()
-    # A client request for a higher std overrides this
-    target_compile_features(HighFive INTERFACE cxx_std_11)
-  endif()
+    # Ensure we activate required C++ std
+    if(NOT DEFINED CMAKE_CXX_STANDARD)
+      if(CMAKE_VERSION VERSION_LESS 3.8)
+        message(WARNING "HighFive requires minimum C++11. (C++14 for XTensor) \
+            You may need to set CMAKE_CXX_STANDARD in you project")
+      else()
+        # A client request for a higher std overrides this
+        target_compile_features(HighFive INTERFACE cxx_std_11)
+      endif()
+    endif()
+
+    # If the user sets this flag, all dependencies are preserved.
+    # Useful in central deployments where dependencies are not prepared later
+    option(HIGHFIVE_USE_INSTALL_DEPS "Use original Highfive dependencies" @HIGHFIVE_USE_INSTALL_DEPS@)
+    if(HIGHFIVE_USE_INSTALL_DEPS)
+      # If enabled in the deploy config, request c++14
+      if(@HIGHFIVE_USE_XTENSOR@ AND NOT CMAKE_VERSION VERSION_LESS 3.8)
+        set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
+      endif()
+      message("HIGHFIVE @PROJECT_VERSION@: Using original dependencies (HIGHFIVE_USE_INSTALL_DEPS=YES)")
+      copy_interface_properties(HighFive HighFive_HighFive)
+      return()
+    endif()
+
+    # When not using the pre-built dependencies, give user options
+    option(HIGHFIVE_USE_BOOST "Enable Boost Support" ON)
+    option(HIGHFIVE_USE_EIGEN "Enable Eigen testing" OFF)
+    option(HIGHFIVE_USE_XTENSOR "Enable xtensor testing" OFF)
+
+    # Options when used from external projects. Keep defaults
+    if(NOT DEFINED HIGHFIVE_PARALLEL_HDF5)
+      option(HIGHFIVE_PARALLEL_HDF5 "Enable Parallel HDF5 support" @HIGHFIVE_PARALLEL_HDF5@)
+    endif()
+    if(NOT DEFINED HIGHFIVE_USE_BOOST)
+      option(HIGHFIVE_USE_BOOST "Enable Boost Support" @HIGHFIVE_USE_BOOST@)
+    endif()
+
+    if(HIGHFIVE_USE_XTENSOR AND NOT CMAKE_VERSION VERSION_LESS 3.8)
+      set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
+    endif()
+
+    message("HIGHFIVE @PROJECT_VERSION@: (Re)Detecting Highfive dependencies (HIGHFIVE_USE_INSTALL_DEPS=NO)")
+    include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargetDeps.cmake")
+    foreach(dependency HighFive_libheaders libdeps)
+        copy_interface_properties(HighFive ${dependency})
+    endforeach()
 endif()
-
-# If the user sets this flag, all dependencies are preserved.
-# Useful in central deployments where dependencies are not prepared later
-option(HIGHFIVE_USE_INSTALL_DEPS "Use original Highfive dependencies" @HIGHFIVE_USE_INSTALL_DEPS@)
-if(HIGHFIVE_USE_INSTALL_DEPS)
-  # If enabled in the deploy config, request c++14
-  if(@HIGHFIVE_USE_XTENSOR@ AND NOT CMAKE_VERSION VERSION_LESS 3.8)
-    set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
-  endif()
-  message("HIGHFIVE @PROJECT_VERSION@: Using original dependencies (HIGHFIVE_USE_INSTALL_DEPS=YES)")
-  copy_interface_properties(HighFive HighFive_HighFive)
-  return()
-endif()
-
-# When not using the pre-built dependencies, give user options
-option(HIGHFIVE_USE_BOOST "Enable Boost Support" ON)
-option(HIGHFIVE_USE_EIGEN "Enable Eigen testing" OFF)
-option(HIGHFIVE_USE_XTENSOR "Enable xtensor testing" OFF)
-
-# Options when used from external projects. Keep defaults
-if(NOT DEFINED HIGHFIVE_PARALLEL_HDF5)
-  option(HIGHFIVE_PARALLEL_HDF5 "Enable Parallel HDF5 support" @HIGHFIVE_PARALLEL_HDF5@)
-endif()
-if(NOT DEFINED HIGHFIVE_USE_BOOST)
-  option(HIGHFIVE_USE_BOOST "Enable Boost Support" @HIGHFIVE_USE_BOOST@)
-endif()
-
-if(HIGHFIVE_USE_XTENSOR AND NOT CMAKE_VERSION VERSION_LESS 3.8)
-  set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
-endif()
-
-message("HIGHFIVE @PROJECT_VERSION@: (Re)Detecting Highfive dependencies (HIGHFIVE_USE_INSTALL_DEPS=NO)")
-include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargetDeps.cmake")
-foreach(dependency HighFive_libheaders libdeps)
-    copy_interface_properties(HighFive ${dependency})
-endforeach()

--- a/CMake/HighFiveConfig.cmake.in
+++ b/CMake/HighFiveConfig.cmake.in
@@ -11,58 +11,60 @@ function(copy_interface_properties target source)
   endforeach()
 endfunction()
 
-if(NOT TARGET HighFive)
-    # Get HighFive targets
-    include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargets.cmake")
-
-    # Recreate combined HighFive
-    add_library(HighFive INTERFACE IMPORTED)
-    set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS MPI_NO_CPPBIND)  # No c++ bindings
-
-    # Ensure we activate required C++ std
-    if(NOT DEFINED CMAKE_CXX_STANDARD)
-      if(CMAKE_VERSION VERSION_LESS 3.8)
-        message(WARNING "HighFive requires minimum C++11. (C++14 for XTensor) \
-            You may need to set CMAKE_CXX_STANDARD in you project")
-      else()
-        # A client request for a higher std overrides this
-        target_compile_features(HighFive INTERFACE cxx_std_11)
-      endif()
-    endif()
-
-    # If the user sets this flag, all dependencies are preserved.
-    # Useful in central deployments where dependencies are not prepared later
-    option(HIGHFIVE_USE_INSTALL_DEPS "Use original Highfive dependencies" @HIGHFIVE_USE_INSTALL_DEPS@)
-    if(HIGHFIVE_USE_INSTALL_DEPS)
-      # If enabled in the deploy config, request c++14
-      if(@HIGHFIVE_USE_XTENSOR@ AND NOT CMAKE_VERSION VERSION_LESS 3.8)
-        set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
-      endif()
-      message("HIGHFIVE @PROJECT_VERSION@: Using original dependencies (HIGHFIVE_USE_INSTALL_DEPS=YES)")
-      copy_interface_properties(HighFive HighFive_HighFive)
-      return()
-    endif()
-
-    # When not using the pre-built dependencies, give user options
-    option(HIGHFIVE_USE_BOOST "Enable Boost Support" ON)
-    option(HIGHFIVE_USE_EIGEN "Enable Eigen testing" OFF)
-    option(HIGHFIVE_USE_XTENSOR "Enable xtensor testing" OFF)
-
-    # Options when used from external projects. Keep defaults
-    if(NOT DEFINED HIGHFIVE_PARALLEL_HDF5)
-      option(HIGHFIVE_PARALLEL_HDF5 "Enable Parallel HDF5 support" @HIGHFIVE_PARALLEL_HDF5@)
-    endif()
-    if(NOT DEFINED HIGHFIVE_USE_BOOST)
-      option(HIGHFIVE_USE_BOOST "Enable Boost Support" @HIGHFIVE_USE_BOOST@)
-    endif()
-
-    if(HIGHFIVE_USE_XTENSOR AND NOT CMAKE_VERSION VERSION_LESS 3.8)
-      set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
-    endif()
-
-    message("HIGHFIVE @PROJECT_VERSION@: (Re)Detecting Highfive dependencies (HIGHFIVE_USE_INSTALL_DEPS=NO)")
-    include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargetDeps.cmake")
-    foreach(dependency HighFive_libheaders libdeps)
-        copy_interface_properties(HighFive ${dependency})
-    endforeach()
+if(TARGET HighFive)
+    return()
 endif()
+
+# Get HighFive targets
+include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargets.cmake")
+
+# Recreate combined HighFive
+add_library(HighFive INTERFACE IMPORTED)
+set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS MPI_NO_CPPBIND)  # No c++ bindings
+
+# Ensure we activate required C++ std
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  if(CMAKE_VERSION VERSION_LESS 3.8)
+    message(WARNING "HighFive requires minimum C++11. (C++14 for XTensor) \
+        You may need to set CMAKE_CXX_STANDARD in you project")
+  else()
+    # A client request for a higher std overrides this
+    target_compile_features(HighFive INTERFACE cxx_std_11)
+  endif()
+endif()
+
+# If the user sets this flag, all dependencies are preserved.
+# Useful in central deployments where dependencies are not prepared later
+option(HIGHFIVE_USE_INSTALL_DEPS "Use original Highfive dependencies" @HIGHFIVE_USE_INSTALL_DEPS@)
+if(HIGHFIVE_USE_INSTALL_DEPS)
+  # If enabled in the deploy config, request c++14
+  if(@HIGHFIVE_USE_XTENSOR@ AND NOT CMAKE_VERSION VERSION_LESS 3.8)
+    set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
+  endif()
+  message("HIGHFIVE @PROJECT_VERSION@: Using original dependencies (HIGHFIVE_USE_INSTALL_DEPS=YES)")
+  copy_interface_properties(HighFive HighFive_HighFive)
+  return()
+endif()
+
+# When not using the pre-built dependencies, give user options
+option(HIGHFIVE_USE_BOOST "Enable Boost Support" ON)
+option(HIGHFIVE_USE_EIGEN "Enable Eigen testing" OFF)
+option(HIGHFIVE_USE_XTENSOR "Enable xtensor testing" OFF)
+
+# Options when used from external projects. Keep defaults
+if(NOT DEFINED HIGHFIVE_PARALLEL_HDF5)
+  option(HIGHFIVE_PARALLEL_HDF5 "Enable Parallel HDF5 support" @HIGHFIVE_PARALLEL_HDF5@)
+endif()
+if(NOT DEFINED HIGHFIVE_USE_BOOST)
+  option(HIGHFIVE_USE_BOOST "Enable Boost Support" @HIGHFIVE_USE_BOOST@)
+endif()
+
+if(HIGHFIVE_USE_XTENSOR AND NOT CMAKE_VERSION VERSION_LESS 3.8)
+  set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
+endif()
+
+message("HIGHFIVE @PROJECT_VERSION@: (Re)Detecting Highfive dependencies (HIGHFIVE_USE_INSTALL_DEPS=NO)")
+include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargetDeps.cmake")
+foreach(dependency HighFive_libheaders libdeps)
+    copy_interface_properties(HighFive ${dependency})
+endforeach()


### PR DESCRIPTION
I was inspired by Qt5CoreConfig.cmake.

We have to do that if the project is included several time, for example by Brion.
`Brion` include `HighFive` and `MVDTool`.
`MVDTool` include `HighFive`
This cause a failure because the target `HighFive` is defined twice.