### PR TITLE
Adding missing function to H5Attribute; [H5Easy] Enabling compression & Adding attributes

### DIFF
--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -57,6 +57,12 @@ class Attribute : public Object {
     void read(T& array) const;
 
     ///
+    /// Read the attribute into a buffer
+    ///
+    template <typename T>
+    void read(T* array) const;
+
+    ///
     /// Write the integrality N-dimension buffer to this attribute
     /// An exception is raised if the numbers of dimension of the buffer and of
     /// the attribute are different
@@ -65,6 +71,12 @@ class Attribute : public Object {
     /// dimensional array )
     template <typename T>
     void write(const T& buffer);
+
+    ///
+    /// Write a buffer to this attribute
+    ///
+    template <typename T>
+    void write_raw(const T& buffer);
 
   private:
     Attribute() = default;

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -107,7 +107,10 @@ public:
     /// \brief Dump-settings
     /// \param Any of DumpMode, Flush, Compression in arbitrary number and order.
     template <class... Args>
-    DumpOptions(Args... args);
+    DumpOptions(Args... args)
+    {
+        set(args...);
+    }
 
     ///
     /// \brief Set setting.
@@ -117,7 +120,7 @@ public:
     ///
     /// \brief Set setting.
     /// \param flush: Flush.
-    inline void set(Flush flush);
+    inline void set(Flush mode);
 
     ///
     /// \brief Set setting.
@@ -153,27 +156,27 @@ public:
 
     ///
     /// \brief Check to overwrite.
-    inline bool Overwrite() const;
+    inline bool isOverwrite() const;
 
     ///
     /// \brief Check to flush.
-    inline bool Flush() const;
+    inline bool isFlush() const;
 
     ///
     /// \brief Check to compress.
-    inline bool Compress() const;
+    inline bool isCompress() const;
 
     ///
     /// \brief Get deflate-level.
-    inline unsigned DeflateLevel() const;
+    inline unsigned getDeflateLevel() const;
 
     ///
     /// \brief Check to compute the chunk-size automatically.
-    inline bool AutomaticChunkSize() const;
+    inline bool isAutomaticChunkSize() const;
 
     ///
     /// \brief Get chunk size.
-    inline std::vector<hsize_t> ChunkSize() const;
+    inline std::vector<hsize_t> getChunkSize() const;
 
 private:
     bool m_overwrite = false;

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -255,7 +255,7 @@ inline DataSet dump(File& file,
 ///
 /// \brief Write a scalar to a (new, extendable) DataSet in an open HDF5 file.
 ///
-/// \param file opened File (has to be writeable)
+/// \param file open File (has to be writeable)
 /// \param path path of the DataSet
 /// \param data the data to write
 /// \param idx the indices to which to write

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -39,6 +39,7 @@
 
 namespace H5Easy {
 
+using HighFive::Attribute;
 using HighFive::AtomicType;
 using HighFive::Chunking;
 using HighFive::DataSet;
@@ -85,12 +86,12 @@ inline size_t getSize(const File& file, const std::string& path);
 inline std::vector<size_t> getShape(const File& file, const std::string& path);
 
 ///
-/// \brief Write scalar/string to a new DataSet in an open HDF5 file.
+/// \brief Write object (templated) to a (new) DataSet in an open HDF5 file.
 ///
 /// \param file Writeable opened file
 /// \param path Path of the DataSet
 /// \param data Data to write
-/// \param write_options Write mode, any combination of DumpMode and Compression
+/// \param write_options Write mode, e.g. DumpMode or Compression
 ///
 /// \return The newly created DataSet
 ///
@@ -138,6 +139,36 @@ inline T load(const File& file, const std::string& path, const std::vector<size_
 ///
 template <class T>
 inline T load(const File& file, const std::string& path);
+
+///
+/// \brief Write object (templated) to a (new) Attribute in an open HDF5 file.
+///
+/// \param file Writeable opened file
+/// \param path Path of the DataSet
+/// \param key Name of the attribute
+/// \param data Data to write
+/// \param write_options Write mode, e.g. DumpMode
+///
+/// \return The newly created DataSet
+///
+template <class T, class... Args>
+inline Attribute dump_attr(File& file,
+                           const std::string& path,
+                           const std::string& key,
+                           const T& data,
+                           Args... write_options);
+
+///
+/// \brief Load a Attribute in an open HDF5 file to an object (templated).
+///
+/// \param file opened File (has to be writeable)
+/// \param path path of the DataSet
+/// \param key Name of the attribute
+///
+/// \return the read data
+///
+template <class T>
+inline T load_attr(const File& file, const std::string& path, const std::string& key);
 
 }  // namespace H5Easy
 

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -59,7 +59,7 @@ enum class DumpMode {
 };
 
 ///
-/// \brief Enable/disable automatic flushing.
+/// \brief Enable/disable automatic flushing after write operations.
 enum class Flush
 {
     False = 0, /*!< No automatic flushing. */
@@ -70,9 +70,9 @@ enum class Flush
 /// \brief Enable/disable compression for written DataSets.
 enum class Compression
 {
-    None = 0, /*!< No compression. (default) */
-    Medium = 5, /*!< Medium compression level. */
-    High = 9 /*!< High compression level. */
+    False = 0, /*!< No compression. */
+    Medium = 5, /*!< Medium compression (deflate level 5). */
+    High = 9 /*!< High compression (deflate level 9). */
 };
 
 ///
@@ -105,7 +105,7 @@ public:
 
     ///
     /// \brief Dump-settings
-    /// \param Any of DumpMode, Flush, Compression in arbitrary number and order.
+    /// \param Any of DumpMode, Flush, Compression, CompressionLevel in arbitrary number and order.
     template <class... Args>
     DumpOptions(Args... args)
     {
@@ -134,7 +134,7 @@ public:
 
     ///
     /// \brief Set settings.
-    /// \param Any of DumpMode, Flush, Compression in arbitrary number and order.
+    /// \param Any of DumpMode, Flush, Compression, CompressionLevel in arbitrary number and order.
     template <class T, class... Args>
     inline void set(T arg, Args... args);
 
@@ -144,13 +144,13 @@ public:
     inline void setDeflateLevel(unsigned level);
 
     ///
-    /// \brief Set chunk-size. If the input is rank zero, automatic chunking is enabled.
+    /// \brief Set chunk-size. If the input is rank (size) zero, automatic chunking is enabled.
     /// \param shape: chunk size along each dimension.
     template <class T>
     inline void setChunkSize(const std::vector<T>& shape);
 
     ///
-    /// \brief Set chunk-size. If the input is rank zero, automatic chunking is enabled.
+    /// \brief Set chunk-size. If the input is rank (size) zero, automatic chunking is enabled.
     /// \param shape: chunk size along each dimension.
     inline void setChunkSize(std::initializer_list<size_t> shape);
 
@@ -171,8 +171,8 @@ public:
     inline unsigned getDeflateLevel() const;
 
     ///
-    /// \brief Check to compute the chunk-size automatically.
-    inline bool isAutomaticChunkSize() const;
+    /// \brief Check if chunk-size is manually set (or should be computed automatically).
+    inline bool isChunkSize() const;
 
     ///
     /// \brief Get chunk size.

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -89,7 +89,7 @@ private:
 };
 
 ///
-/// Dump-settings.
+/// \brief Options for dumping data
 ///
 /// By default:
 /// - DumpMode::Create

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -174,7 +174,7 @@ public:
     inline bool compress() const;
 
     ///
-    /// \brief Get deflate-level.
+    /// \brief Get deflation level.
     inline unsigned getDeflateLevel() const;
 
     ///

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -330,11 +330,11 @@ inline T load(const File& file, const std::string& path);
 /// \return The newly created DataSet
 ///
 template <class T>
-inline Attribute dump_attr(File& file,
-                           const std::string& path,
-                           const std::string& key,
-                           const T& data,
-                           DumpMode mode = DumpMode::Create);
+inline Attribute dumpAttribute(File& file,
+                               const std::string& path,
+                               const std::string& key,
+                               const T& data,
+                               DumpMode mode = DumpMode::Create);
 
 ///
 /// \brief Write object (templated) to a (new) Attribute in an open HDF5 file.
@@ -348,11 +348,11 @@ inline Attribute dump_attr(File& file,
 /// \return The newly created DataSet
 ///
 template <class T>
-inline Attribute dump_attr(File& file,
-                           const std::string& path,
-                           const std::string& key,
-                           const T& data,
-                           const DumpOptions& options);
+inline Attribute dumpAttribute(File& file,
+                               const std::string& path,
+                               const std::string& key,
+                               const T& data,
+                               const DumpOptions& options);
 
 ///
 /// \brief Load a Attribute in an open HDF5 file to an object (templated).
@@ -364,7 +364,7 @@ inline Attribute dump_attr(File& file,
 /// \return the read data
 ///
 template <class T>
-inline T load_attr(const File& file, const std::string& path, const std::string& key);
+inline T loadAttribute(const File& file, const std::string& path, const std::string& key);
 
 }  // namespace H5Easy
 

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -67,26 +67,38 @@ enum class Flush
 };
 
 ///
-/// \brief Enable/disable compression for written DataSets.
-enum class Compression
-{
-    False = 0, /*!< No compression. */
-    Medium = 5, /*!< Medium compression (deflate level 5). */
-    High = 9 /*!< High compression (deflate level 9). */
-};
-
-///
 /// \brief Set compression-level for written DataSets.
-class CompressionLevel
+class Compression
 {
 public:
-    CompressionLevel(unsigned deflate_level);
 
+    //
+    // \brief Set compression-level.
+    Compression(unsigned deflate_level);
+
+    //
+    // \brief High compression: deflate level 9
+    static const Compression High;
+
+    //
+    // \brief Medium compression: deflate level 5
+    static const Compression Medium;
+
+    //
+    // \brief No compression: deflate level 0
+    static const Compression False;
+
+    //
+    // \brief Return deflate level.
     inline unsigned get() const;
 
 private:
     unsigned m_deflate_level;
 };
+
+const Compression Compression::High{9};
+const Compression Compression::Medium{5};
+const Compression Compression::False{0};
 
 ///
 /// \brief Options for dumping data
@@ -125,12 +137,7 @@ public:
     ///
     /// \brief Set setting.
     /// \param level: Compression.
-    inline void set(Compression level);
-
-    ///
-    /// \brief Set setting.
-    /// \param level: CompressionLevel
-    inline void set(const CompressionLevel& level);
+    inline void set(const Compression& level);
 
     ///
     /// \brief Set settings.

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -181,7 +181,6 @@ public:
 private:
     bool m_overwrite = false;
     bool m_flush = true;
-    bool m_compress = false;
     unsigned m_deflate_level = 0;
     std::vector<hsize_t> m_chunk_size = {};
 };

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -253,7 +253,7 @@ inline DataSet dump(File& file,
                     const std::vector<size_t>& idx);
 
 ///
-/// \brief Write a scalar to a (new, extendible) DataSet in an open HDF5 file.
+/// \brief Write a scalar to a (new, extendable) DataSet in an open HDF5 file.
 ///
 /// \param file opened File (has to be writeable)
 /// \param path path of the DataSet

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -67,38 +67,28 @@ enum class Flush
 };
 
 ///
-/// \brief Set compression-level for written DataSets.
+/// \brief Set compression level for written DataSets.
 class Compression
 {
 public:
 
     //
-    // \brief Set compression-level.
-    Compression(unsigned deflate_level);
+    // \brief Enable compression with the highest compression level (9).
+    // or disable compression (set compression level to 0).
+    explicit Compression(bool enable = true);
 
     //
-    // \brief High compression: deflate level 9
-    static const Compression High;
+    // \brief Set compression level.
+    template <class T>
+    Compression(T level);
 
     //
-    // \brief Medium compression: deflate level 5
-    static const Compression Medium;
-
-    //
-    // \brief No compression: deflate level 0
-    static const Compression False;
-
-    //
-    // \brief Return deflate level.
+    // \brief Return compression level.
     inline unsigned get() const;
 
 private:
-    unsigned m_deflate_level;
+    unsigned m_compression_level;
 };
-
-const Compression Compression::High{9};
-const Compression Compression::Medium{5};
-const Compression Compression::False{0};
 
 ///
 /// \brief Options for dumping data
@@ -106,7 +96,7 @@ const Compression Compression::False{0};
 /// By default:
 /// - DumpMode::Create
 /// - Flush::True
-/// - Compression::False
+/// - Compression: false
 /// - ChunkSize: automatic.
 class DumpOptions
 {
@@ -146,11 +136,6 @@ public:
     inline void set(T arg, Args... args);
 
     ///
-    /// \brief Set deflate level.
-    /// \param level: deflate level (0-9).
-    inline void setDeflateLevel(unsigned level);
-
-    ///
     /// \brief Set chunk-size. If the input is rank (size) zero, automatic chunking is enabled.
     /// \param shape: chunk size along each dimension.
     template <class T>
@@ -175,7 +160,7 @@ public:
 
     ///
     /// \brief Get deflation level.
-    inline unsigned getDeflateLevel() const;
+    inline unsigned getCompressionLevel() const;
 
     ///
     /// \brief Check if chunk-size is manually set (or should be computed automatically).
@@ -188,7 +173,7 @@ public:
 private:
     bool m_overwrite = false;
     bool m_flush = true;
-    unsigned m_deflate_level = 0;
+    unsigned m_compression_level = 0;
     std::vector<hsize_t> m_chunk_size = {};
 };
 

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -44,15 +44,26 @@ using HighFive::Chunking;
 using HighFive::DataSet;
 using HighFive::DataSetCreateProps;
 using HighFive::DataSpace;
+using HighFive::Deflate;
 using HighFive::Exception;
 using HighFive::File;
 using HighFive::ObjectType;
+using HighFive::Shuffle;
 
 ///
 /// \brief Write mode for DataSets
 enum class DumpMode {
-    Create, /*!< Dump only if DataSet does not exist, otherwise throw. */
+    Create, /*!< Dump only if DataSet does not exist, otherwise throw. (default) */
     Overwrite /*!< If DataSet already exists overwrite it if data has the same shape, otherwise throw. */
+};
+
+///
+/// \brief Compression-level for writing DataSets
+enum class Compression
+{
+    None, /*!< No compression. (default) */
+    Medium, /*!< Medium compression level. */
+    High /*!< High compression level. */
 };
 
 ///
@@ -79,15 +90,15 @@ inline std::vector<size_t> getShape(const File& file, const std::string& path);
 /// \param file Writeable opened file
 /// \param path Path of the DataSet
 /// \param data Data to write
-/// \param mode Write mode
+/// \param write_options Write mode, any combination of DumpMode and Compression
 ///
 /// \return The newly created DataSet
 ///
-template <class T>
+template <class T, class... Args>
 inline DataSet dump(File& file,
                     const std::string& path,
                     const T& data,
-                    DumpMode mode = DumpMode::Create);
+                    Args... write_options);
 
 ///
 /// \brief Write a scalar to a (new, extendible) DataSet in an open HDF5 file.

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -91,23 +91,23 @@ private:
 };
 
 ///
-/// \brief Options for dumping data
+/// \brief Options for dumping data.
 ///
 /// By default:
 /// - DumpMode::Create
 /// - Flush::True
-/// - Compression: false
+/// - Compression(false)
 /// - ChunkSize: automatic.
 class DumpOptions
 {
 public:
     ///
-    /// \brief Dump-settings.
+    /// \brief Constructor: accept all defaults.
     DumpOptions() = default;
 
     ///
-    /// \brief Dump-settings
-    /// \param Any of DumpMode, Flush, Compression, CompressionLevel in arbitrary number and order.
+    /// \brief Constructor: overwrite (some of the) defaults.
+    /// \param Any of DumpMode, Flush, Compression in arbitrary number and order.
     template <class... Args>
     DumpOptions(Args... args)
     {
@@ -115,35 +115,35 @@ public:
     }
 
     ///
-    /// \brief Set setting.
+    /// \brief Overwrite setting.
     /// \param mode: DumpMode.
     inline void set(DumpMode mode);
 
     ///
-    /// \brief Set setting.
-    /// \param flush: Flush.
+    /// \brief Overwrite setting.
+    /// \param flush Flush.
     inline void set(Flush mode);
 
     ///
-    /// \brief Set setting.
-    /// \param level: Compression.
+    /// \brief Overwrite setting.
+    /// \param level Compression.
     inline void set(const Compression& level);
 
     ///
-    /// \brief Set settings.
-    /// \param Any of DumpMode, Flush, Compression, CompressionLevel in arbitrary number and order.
+    /// \brief Overwrite settings.
+    /// \param Any of DumpMode, Flush, Compression in arbitrary number and order.
     template <class T, class... Args>
     inline void set(T arg, Args... args);
 
     ///
     /// \brief Set chunk-size. If the input is rank (size) zero, automatic chunking is enabled.
-    /// \param shape: chunk size along each dimension.
+    /// \param shape Chunk size along each dimension.
     template <class T>
     inline void setChunkSize(const std::vector<T>& shape);
 
     ///
     /// \brief Set chunk-size. If the input is rank (size) zero, automatic chunking is enabled.
-    /// \param shape: chunk size along each dimension.
+    /// \param shape Chunk size along each dimension.
     inline void setChunkSize(std::initializer_list<size_t> shape);
 
     ///
@@ -159,7 +159,7 @@ public:
     inline bool compress() const;
 
     ///
-    /// \brief Get deflation level.
+    /// \brief Get compression level.
     inline unsigned getCompressionLevel() const;
 
     ///

--- a/include/highfive/H5Easy.hpp
+++ b/include/highfive/H5Easy.hpp
@@ -156,15 +156,15 @@ public:
 
     ///
     /// \brief Check to overwrite.
-    inline bool isOverwrite() const;
+    inline bool overwrite() const;
 
     ///
     /// \brief Check to flush.
-    inline bool isFlush() const;
+    inline bool flush() const;
 
     ///
     /// \brief Check to compress.
-    inline bool isCompress() const;
+    inline bool compress() const;
 
     ///
     /// \brief Get deflate-level.
@@ -172,7 +172,7 @@ public:
 
     ///
     /// \brief Check if chunk-size is manually set (or should be computed automatically).
-    inline bool isChunkSize() const;
+    inline bool isChunked() const;
 
     ///
     /// \brief Get chunk size.

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -81,6 +81,22 @@ inline void Attribute::read(T& array) const {
 }
 
 template <typename T>
+inline void Attribute::read(T* array) const {
+    static_assert(!std::is_const<T>::value,
+                  "read() requires a non-const structure to read data into");
+    using element_type = typename details::type_of_array<T>::type;
+    DataSpace mem_space = getMemSpace();
+
+    const DataType mem_datatype = create_and_check_datatype<element_type>();
+
+    if (H5Aread(getId(), mem_datatype.getId(),
+                static_cast<void*>(array)) < 0) {
+        HDF5ErrMapper::ToException<AttributeException>(
+            "Error during HDF5 Read: ");
+    }
+}
+
+template <typename T>
 inline void Attribute::write(const T& buffer) {
     using element_type = typename details::type_of_array<T>::type;
     const size_t dim_buffer = details::array_dims<T>::value;
@@ -95,6 +111,21 @@ inline void Attribute::write(const T& buffer) {
         throw DataSpaceException(ss.str());
     }
 
+    const DataType mem_datatype = create_and_check_datatype<element_type>();
+    details::data_converter<T> converter(mem_space);
+
+    if (H5Awrite(getId(), mem_datatype.getId(),
+                 static_cast<const void*>(converter.transform_write(buffer))) < 0) {
+        HDF5ErrMapper::ToException<DataSetException>(
+            "Error during HDF5 Write: ");
+    }
+}
+
+template <typename T>
+inline void Attribute::write_raw(const T& buffer) {
+    using element_type = typename details::type_of_array<T>::type;
+    DataSpace space = getSpace();
+    DataSpace mem_space = getMemSpace();
     const DataType mem_datatype = create_and_check_datatype<element_type>();
     details::data_converter<T> converter(mem_space);
 

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -75,10 +75,13 @@ struct io_impl<
         dataset.write_raw(row_major.data());
     }
 
-    static DataSet dump(File& file, const std::string& path, const T& data) {
+    static DataSet dump(File& file,
+                        const std::string& path,
+                        const T& data,
+                        const DumpSettings& settings) {
         using value_type = typename std::decay<T>::type::Scalar;
         detail::createGroupsToDataSet(file, path);
-        DataSet dataset = file.createDataSet<value_type>(path, DataSpace(shape(data)));
+        DataSet dataset = init_dataset<value_type>(file, path, shape(data), settings);
         write(dataset, data);
         file.flush();
         return dataset;

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -62,7 +62,7 @@ struct io_impl<
     inline static DataSet dump(File& file,
                         const std::string& path,
                         const T& data,
-                        const DumpSettings& settings) {
+                        const DumpOptions& options) {
         // use Eigen::Ref to convert to RowMajor; no action if no conversion is needed
         Eigen::Ref<
             const Eigen::Array<
@@ -76,9 +76,11 @@ struct io_impl<
             Eigen::InnerStride<1>> row_major(data);
 
         using value_type = typename std::decay<T>::type::Scalar;
-        DataSet dataset = init_dataset<value_type>(file, path, shape(data), settings);
+        DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(row_major.data());
-        file.flush();
+        if (options.Flush()) {
+            file.flush();
+        }
         return dataset;
     }
 
@@ -106,7 +108,7 @@ struct io_impl<
                                const std::string& path,
                                const std::string& key,
                                const T& data,
-                               const DumpSettings& settings) {
+                               const DumpOptions& options) {
         // use Eigen::Ref to convert to RowMajor; no action if no conversion is needed
         Eigen::Ref<
             const Eigen::Array<
@@ -120,9 +122,11 @@ struct io_impl<
             Eigen::InnerStride<1>> row_major(data);
 
         using value_type = typename std::decay<T>::type::Scalar;
-        Attribute atrribute = init_attribute<value_type>(file, path, key, shape(data), settings);
+        Attribute atrribute = init_attribute<value_type>(file, path, key, shape(data), options);
         atrribute.write_raw(row_major.data());
-        file.flush();
+        if (options.Flush()) {
+            file.flush();
+        }
         return atrribute;
     }
 

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -39,13 +39,14 @@ struct io_impl<
             0,
             Eigen::InnerStride<1>>;
 
-        using col_major = Eigen::Map<Eigen::Array<
-            typename T::Scalar,
-            T::RowsAtCompileTime,
-            T::ColsAtCompileTime,
-            T::ColsAtCompileTime == 1 ? Eigen::ColMajor : Eigen::RowMajor,
-            T::MaxRowsAtCompileTime,
-            T::MaxColsAtCompileTime>>;
+        using col_major = Eigen::Map<
+            Eigen::Array<
+                typename std::decay<T>::type::Scalar,
+                std::decay<T>::type::RowsAtCompileTime,
+                std::decay<T>::type::ColsAtCompileTime,
+                std::decay<T>::type::ColsAtCompileTime == 1 ? Eigen::ColMajor : Eigen::RowMajor,
+                std::decay<T>::type::MaxRowsAtCompileTime,
+                std::decay<T>::type::MaxColsAtCompileTime>>;
     };
 
     // return the shape of Eigen::DenseBase<T> object as size 1 or 2 "std::vector<size_t>"
@@ -84,13 +85,13 @@ struct io_impl<
     }
 
     inline static DataSet dump(File& file,
-                        const std::string& path,
-                        const T& data,
-                        const DumpOptions& options) {
+                               const std::string& path,
+                               const T& data,
+                               const DumpOptions& options) {
         using row_major_type = typename types<T>::row_major;
         using value_type = typename std::decay<T>::type::Scalar;
         row_major_type row_major(data);
-        DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
+        DataSet dataset = initDataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(row_major.data());
         if (options.flush()) {
             file.flush();
@@ -110,15 +111,15 @@ struct io_impl<
         return col_major(data.data(), dims[0], dims[1]);
     }
 
-    inline static Attribute dump_attr(File& file,
-                               const std::string& path,
-                               const std::string& key,
-                               const T& data,
-                               const DumpOptions& options) {
+    inline static Attribute dumpAttribute(File& file,
+                                          const std::string& path,
+                                          const std::string& key,
+                                          const T& data,
+                                          const DumpOptions& options) {
         using row_major_type = typename types<T>::row_major;
         using value_type = typename std::decay<T>::type::Scalar;
         row_major_type row_major(data);
-        Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), options);
+        Attribute attribute = initAttribute<value_type>(file, path, key, shape(data), options);
         attribute.write_raw(row_major.data());
         if (options.flush()) {
             file.flush();
@@ -126,7 +127,9 @@ struct io_impl<
         return attribute;
     }
 
-    inline static T load_attr(const File& file, const std::string& path, const std::string& key) {
+    inline static T loadAttribute(const File& file,
+                                  const std::string& path,
+                                  const std::string& key) {
         DataSet dataset = file.getDataSet(path);
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -78,7 +78,7 @@ struct io_impl<
         using value_type = typename std::decay<T>::type::Scalar;
         DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(row_major.data());
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return dataset;
@@ -124,7 +124,7 @@ struct io_impl<
         using value_type = typename std::decay<T>::type::Scalar;
         Attribute atrribute = init_attribute<value_type>(file, path, key, shape(data), options);
         atrribute.write_raw(row_major.data());
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return atrribute;

--- a/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_Eigen.hpp
@@ -92,7 +92,7 @@ struct io_impl<
         row_major_type row_major(data);
         DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(row_major.data());
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return dataset;
@@ -120,7 +120,7 @@ struct io_impl<
         row_major_type row_major(data);
         Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), options);
         attribute.write_raw(row_major.data());
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return attribute;

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -81,7 +81,7 @@ inline DataSet init_dataset(File& file,
 {
     if (!file.exist(path)) {
         detail::createGroupsToDataSet(file, path);
-        if (!options.compress()) {
+        if (!options.compress() && !options.isChunked()) {
             return file.createDataSet<T>(path, DataSpace(shape));
         } else {
             std::vector<hsize_t> chunks(shape.begin(), shape.end());
@@ -93,8 +93,10 @@ inline DataSet init_dataset(File& file,
             }
             DataSetCreateProps props;
             props.add(Chunking(chunks));
-            props.add(Shuffle());
-            props.add(Deflate(options.getDeflateLevel()));
+            if (options.compress()) {
+                props.add(Shuffle());
+                props.add(Deflate(options.getDeflateLevel()));
+            }
             return file.createDataSet<T>(path, DataSpace(shape), props);
         }
     } else if (options.overwrite() && file.getObjectType(path) == ObjectType::Dataset) {

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -156,7 +156,7 @@ inline DataSet init_dataset(File& file,
 
 // get a opened DataSet: scalar
 template <class T>
-inline DataSet init_dataset(File& file,
+inline DataSet init_dataset_scalar(File& file,
                             const std::string& path,
                             const T& data,
                             const DumpSettings& settings)

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -186,7 +186,6 @@ inline Attribute init_attribute_scalar(File& file,
 }
 
 }  // namespace detail
-
 }  // namespace H5Easy
 
 #endif  // H5EASY_BITS_MISC_HPP

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -74,10 +74,10 @@ inline Exception dump_error(File& file, const std::string& path)
 
 // get a opened DataSet: nd-array
 template <class T>
-inline DataSet init_dataset(File& file,
-                            const std::string& path,
-                            const std::vector<size_t>& shape,
-                            const DumpOptions& options)
+inline DataSet initDataset(File& file,
+                           const std::string& path,
+                           const std::vector<size_t>& shape,
+                           const DumpOptions& options)
 {
     if (!file.exist(path)) {
         detail::createGroupsToDataSet(file, path);
@@ -111,10 +111,10 @@ inline DataSet init_dataset(File& file,
 
 // get a opened DataSet: scalar
 template <class T>
-inline DataSet init_dataset_scalar(File& file,
-                                   const std::string& path,
-                                   const T& data,
-                                   const DumpOptions& options)
+inline DataSet initScalarDataset(File& file,
+                                 const std::string& path,
+                                 const T& data,
+                                 const DumpOptions& options)
 {
     if (!file.exist(path)) {
         detail::createGroupsToDataSet(file, path);
@@ -131,17 +131,17 @@ inline DataSet init_dataset_scalar(File& file,
 
 // get a opened Attribute: nd-array
 template <class T>
-inline Attribute init_attribute(File& file,
-                                const std::string& path,
-                                const std::string& key,
-                                const std::vector<size_t>& shape,
-                                const DumpOptions& options)
+inline Attribute initAttribute(File& file,
+                               const std::string& path,
+                               const std::string& key,
+                               const std::vector<size_t>& shape,
+                               const DumpOptions& options)
 {
     if (!file.exist(path)) {
-        throw error(file, path, "H5Easy::dump_attr: DataSet does not exist");
+        throw error(file, path, "H5Easy::dumpAttribute: DataSet does not exist");
     }
     if (file.getObjectType(path) != ObjectType::Dataset) {
-        throw error(file, path, "H5Easy::dump_attr: path not a DataSet");
+        throw error(file, path, "H5Easy::dumpAttribute: path not a DataSet");
     }
     DataSet dataset = file.getDataSet(path);
     if (!dataset.hasAttribute(key)) {
@@ -150,7 +150,7 @@ inline Attribute init_attribute(File& file,
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();
         if (dataspace.getDimensions() != shape) {
-            throw error(file, path, "H5Easy::dump_attr: Inconsistent dimensions");
+            throw error(file, path, "H5Easy::dumpAttribute: Inconsistent dimensions");
         }
         return attribute;
     }
@@ -160,17 +160,17 @@ inline Attribute init_attribute(File& file,
 
 // get a opened Attribute: scalar
 template <class T>
-inline Attribute init_attribute_scalar(File& file,
+inline Attribute initScalarAttribute(File& file,
                                      const std::string& path,
                                      const std::string& key,
                                      const T& data,
                                      const DumpOptions& options)
 {
     if (!file.exist(path)) {
-        throw error(file, path, "H5Easy::dump_attr: DataSet does not exist");
+        throw error(file, path, "H5Easy::dumpAttribute: DataSet does not exist");
     }
     if (file.getObjectType(path) != ObjectType::Dataset) {
-        throw error(file, path, "H5Easy::dump_attr: path not a DataSet");
+        throw error(file, path, "H5Easy::dumpAttribute: path not a DataSet");
     }
     DataSet dataset = file.getDataSet(path);
     if (!dataset.hasAttribute(key)) {
@@ -179,7 +179,7 @@ inline Attribute init_attribute_scalar(File& file,
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();
         if (dataspace.getElementCount() != 1) {
-            throw error(file, path, "H5Easy::dump_attr: Existing field not a scalar");
+            throw error(file, path, "H5Easy::dumpAttribute: Existing field not a scalar");
         }
         return attribute;
     }

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -15,6 +15,85 @@ namespace H5Easy {
 
 namespace detail {
 
+// structure to pass-on dump-settings
+struct DumpSettings
+{
+    inline DumpSettings() = default;
+
+    inline void set(DumpMode mode)
+    {
+        switch(mode){
+            case DumpMode::Overwrite:
+                overwrite = true;
+                break;
+            default:
+                overwrite = false;
+                break;
+        }
+    }
+
+    inline void set(Compression mode)
+    {
+        switch(mode){
+            case Compression::Medium:
+                deflate_level = 5;
+                compress = true;
+                break;
+            case Compression::High:
+                deflate_level = 9;
+                compress = true;
+                break;
+            default:
+                compress = false;
+                break;
+        }
+    }
+
+    bool overwrite = false;
+    bool compress = false;
+    unsigned deflate_level = 0;
+};
+
+// variadic template to read the DumpSettings
+inline void read_dumpsettings(DumpSettings&)
+{
+}
+
+template <class T, class... Args>
+inline void read_dumpsettings(DumpSettings& options, T arg, Args... args)
+{
+    options.set(arg);
+    read_dumpsettings(options, args...);
+}
+
+// process DumpSettings
+template <class... Args>
+inline DumpSettings get_dumpsettings(Args... args)
+{
+    DumpSettings out;
+    read_dumpsettings(out, args...);
+    return out;
+}
+
+// get a opened DataSet
+template <class T>
+inline DataSet init_dataset(File& file,
+                            const std::string& path,
+                            const std::vector<size_t>& shape,
+                            const DumpSettings& settings)
+{
+    if (settings.compress == false) {
+        return file.createDataSet<T>(path, DataSpace(shape));
+    }
+
+    std::vector<hsize_t> hshape(shape.begin(), shape.end());
+    DataSetCreateProps props;
+    props.add(Chunking(hshape));
+    props.add(Shuffle());
+    props.add(Deflate(settings.deflate_level));
+    return file.createDataSet<T>(path, DataSpace(shape), props);
+}
+
 // Generate error-stream and return "Exception" (not yet thrown).
 inline Exception error(const File& file,
                        const std::string& path,

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -81,12 +81,12 @@ inline DataSet init_dataset(File& file,
 {
     if (!file.exist(path)) {
         detail::createGroupsToDataSet(file, path);
-        if (!options.Compress()) {
+        if (!options.isCompress()) {
             return file.createDataSet<T>(path, DataSpace(shape));
         } else {
             std::vector<hsize_t> chunks(shape.begin(), shape.end());
-            if (!options.AutomaticChunkSize()) {
-                chunks = options.ChunkSize();
+            if (!options.isAutomaticChunkSize()) {
+                chunks = options.getChunkSize();
                 if (chunks.size() != shape.size()) {
                     throw error(file, path, "H5Easy::dump: Incorrect rank ChunkSize");
                 }
@@ -94,10 +94,10 @@ inline DataSet init_dataset(File& file,
             DataSetCreateProps props;
             props.add(Chunking(chunks));
             props.add(Shuffle());
-            props.add(Deflate(options.DeflateLevel()));
+            props.add(Deflate(options.getDeflateLevel()));
             return file.createDataSet<T>(path, DataSpace(shape), props);
         }
-    } else if (options.Overwrite() && file.getObjectType(path) == ObjectType::Dataset) {
+    } else if (options.isOverwrite() && file.getObjectType(path) == ObjectType::Dataset) {
         DataSet dataset = file.getDataSet(path);
         if (dataset.getDimensions() != shape) {
             throw error(file, path, "H5Easy::dump: Inconsistent dimensions");
@@ -117,7 +117,7 @@ inline DataSet init_dataset_scalar(File& file,
     if (!file.exist(path)) {
         detail::createGroupsToDataSet(file, path);
         return file.createDataSet<T>(path, DataSpace::From(data));
-    } else if (options.Overwrite() && file.getObjectType(path) == ObjectType::Dataset) {
+    } else if (options.isOverwrite() && file.getObjectType(path) == ObjectType::Dataset) {
         DataSet dataset = file.getDataSet(path);
         if (dataset.getElementCount() != 1) {
             throw error(file, path, "H5Easy::dump: Existing field not a scalar");
@@ -144,7 +144,7 @@ inline Attribute init_attribute(File& file,
     DataSet dataset = file.getDataSet(path);
     if (!dataset.hasAttribute(key)) {
         return dataset.createAttribute<T>(key, DataSpace(shape));
-    } else if (options.Overwrite()) {
+    } else if (options.isOverwrite()) {
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();
         if (dataspace.getDimensions() != shape) {
@@ -173,7 +173,7 @@ inline Attribute init_attribute_scalar(File& file,
     DataSet dataset = file.getDataSet(path);
     if (!dataset.hasAttribute(key)) {
         return dataset.createAttribute<T>(key, DataSpace::From(data));
-    } else if (options.Overwrite()) {
+    } else if (options.isOverwrite()) {
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();
         if (dataspace.getElementCount() != 1) {

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -85,7 +85,7 @@ inline DataSet init_dataset(File& file,
             return file.createDataSet<T>(path, DataSpace(shape));
         } else {
             std::vector<hsize_t> chunks(shape.begin(), shape.end());
-            if (!options.isAutomaticChunkSize()) {
+            if (options.isChunkSize()) {
                 chunks = options.getChunkSize();
                 if (chunks.size() != shape.size()) {
                     throw error(file, path, "H5Easy::dump: Incorrect rank ChunkSize");

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -95,7 +95,7 @@ inline DataSet init_dataset(File& file,
             props.add(Chunking(chunks));
             if (options.compress()) {
                 props.add(Shuffle());
-                props.add(Deflate(options.getDeflateLevel()));
+                props.add(Deflate(options.getCompressionLevel()));
             }
             return file.createDataSet<T>(path, DataSpace(shape), props);
         }

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -81,11 +81,11 @@ inline DataSet init_dataset(File& file,
 {
     if (!file.exist(path)) {
         detail::createGroupsToDataSet(file, path);
-        if (!options.isCompress()) {
+        if (!options.compress()) {
             return file.createDataSet<T>(path, DataSpace(shape));
         } else {
             std::vector<hsize_t> chunks(shape.begin(), shape.end());
-            if (options.isChunkSize()) {
+            if (options.isChunked()) {
                 chunks = options.getChunkSize();
                 if (chunks.size() != shape.size()) {
                     throw error(file, path, "H5Easy::dump: Incorrect rank ChunkSize");
@@ -97,7 +97,7 @@ inline DataSet init_dataset(File& file,
             props.add(Deflate(options.getDeflateLevel()));
             return file.createDataSet<T>(path, DataSpace(shape), props);
         }
-    } else if (options.isOverwrite() && file.getObjectType(path) == ObjectType::Dataset) {
+    } else if (options.overwrite() && file.getObjectType(path) == ObjectType::Dataset) {
         DataSet dataset = file.getDataSet(path);
         if (dataset.getDimensions() != shape) {
             throw error(file, path, "H5Easy::dump: Inconsistent dimensions");
@@ -117,7 +117,7 @@ inline DataSet init_dataset_scalar(File& file,
     if (!file.exist(path)) {
         detail::createGroupsToDataSet(file, path);
         return file.createDataSet<T>(path, DataSpace::From(data));
-    } else if (options.isOverwrite() && file.getObjectType(path) == ObjectType::Dataset) {
+    } else if (options.overwrite() && file.getObjectType(path) == ObjectType::Dataset) {
         DataSet dataset = file.getDataSet(path);
         if (dataset.getElementCount() != 1) {
             throw error(file, path, "H5Easy::dump: Existing field not a scalar");
@@ -144,7 +144,7 @@ inline Attribute init_attribute(File& file,
     DataSet dataset = file.getDataSet(path);
     if (!dataset.hasAttribute(key)) {
         return dataset.createAttribute<T>(key, DataSpace(shape));
-    } else if (options.isOverwrite()) {
+    } else if (options.overwrite()) {
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();
         if (dataspace.getDimensions() != shape) {
@@ -173,7 +173,7 @@ inline Attribute init_attribute_scalar(File& file,
     DataSet dataset = file.getDataSet(path);
     if (!dataset.hasAttribute(key)) {
         return dataset.createAttribute<T>(key, DataSpace::From(data));
-    } else if (options.isOverwrite()) {
+    } else if (options.overwrite()) {
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();
         if (dataspace.getElementCount() != 1) {

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -22,13 +22,7 @@ inline unsigned CompressionLevel::get() const
     return m_deflate_level;
 }
 
-template <class... Args>
-inline DumpOptions::DumpOptions(Args... args)
-{
-    set(args...);
-}
-
-inline void DumpOptions::set(enum DumpMode mode)
+inline void DumpOptions::set(DumpMode mode)
 {
     if (mode == DumpMode::Create) {
         m_overwrite = false;
@@ -41,12 +35,12 @@ inline void DumpOptions::set(enum DumpMode mode)
     }
 }
 
-inline void DumpOptions::set(enum Flush flush)
+inline void DumpOptions::set(Flush mode)
 {
-    if (flush == Flush::False) {
+    if (mode == Flush::False) {
         m_flush = false;
     }
-    else if (flush == Flush::True) {
+    else if (mode == Flush::True) {
         m_flush = true;
     }
     else {
@@ -54,7 +48,7 @@ inline void DumpOptions::set(enum Flush flush)
     }
 }
 
-inline void DumpOptions::set(enum Compression level)
+inline void DumpOptions::set(Compression level)
 {
     if (level == Compression::None) {
         m_compress = false;
@@ -97,27 +91,27 @@ inline void DumpOptions::setChunkSize(std::initializer_list<size_t> shape)
     m_chunk_size = std::vector<hsize_t>(shape.begin(), shape.end());
 }
 
-inline bool DumpOptions::Overwrite() const
+inline bool DumpOptions::isOverwrite() const
 {
     return m_overwrite;
 }
 
-inline bool DumpOptions::Flush() const
+inline bool DumpOptions::isFlush() const
 {
     return m_flush;
 }
 
-inline bool DumpOptions::Compress() const
+inline bool DumpOptions::isCompress() const
 {
     return m_compress;
 }
 
-inline unsigned DumpOptions::DeflateLevel() const
+inline unsigned DumpOptions::getDeflateLevel() const
 {
     return m_deflate_level;
 }
 
-inline bool DumpOptions::AutomaticChunkSize() const
+inline bool DumpOptions::isAutomaticChunkSize() const
 {
     if (m_chunk_size.size() == 0) {
         return true;
@@ -126,7 +120,7 @@ inline bool DumpOptions::AutomaticChunkSize() const
     return false;
 }
 
-inline std::vector<hsize_t> DumpOptions::ChunkSize() const
+inline std::vector<hsize_t> DumpOptions::getChunkSize() const
 {
     return m_chunk_size;
 }

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -164,26 +164,26 @@ inline T load(const File& file, const std::string& path) {
 }
 
 template <class T>
-inline Attribute dump_attr(File& file,
-                           const std::string& path,
-                           const std::string& key,
-                           const T& data,
-                           DumpMode mode) {
-    return detail::io_impl<T>::dump_attr(file, path, key, data, DumpOptions(mode));
+inline Attribute dumpAttribute(File& file,
+                               const std::string& path,
+                               const std::string& key,
+                               const T& data,
+                               DumpMode mode) {
+    return detail::io_impl<T>::dumpAttribute(file, path, key, data, DumpOptions(mode));
 }
 
 template <class T>
-inline Attribute dump_attr(File& file,
-                           const std::string& path,
-                           const std::string& key,
-                           const T& data,
-                           const DumpOptions& options) {
-    return detail::io_impl<T>::dump_attr(file, path, key, data, options);
+inline Attribute dumpAttribute(File& file,
+                               const std::string& path,
+                               const std::string& key,
+                               const T& data,
+                               const DumpOptions& options) {
+    return detail::io_impl<T>::dumpAttribute(file, path, key, data, options);
 }
 
 template <class T>
-inline T load_attr(const File& file, const std::string& path, const std::string& key) {
-    return detail::io_impl<T>::load_attr(file, path, key);
+inline T loadAttribute(const File& file, const std::string& path, const std::string& key) {
+    return detail::io_impl<T>::loadAttribute(file, path, key);
 }
 
 }  // namespace H5Easy

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -1,0 +1,227 @@
+/*
+ *  Copyright (c), 2017, Adrien Devresse <adrien.devresse@epfl.ch>
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#ifndef H5EASY_BITS_PUBLIC_HPP
+#define H5EASY_BITS_PUBLIC_HPP
+
+#include "../H5Easy.hpp"
+
+namespace H5Easy {
+
+inline CompressionLevel::CompressionLevel(unsigned deflate_level) : m_deflate_level(deflate_level)
+{
+}
+
+inline unsigned CompressionLevel::get() const
+{
+    return m_deflate_level;
+}
+
+template <class... Args>
+inline DumpOptions::DumpOptions(Args... args)
+{
+    set(args...);
+}
+
+inline void DumpOptions::set(enum DumpMode mode)
+{
+    if (mode == DumpMode::Create) {
+        m_overwrite = false;
+    }
+    else if (mode == DumpMode::Overwrite) {
+        m_overwrite = true;
+    }
+    else {
+        throw std::runtime_error("Unknown DumpMode");
+    }
+}
+
+inline void DumpOptions::set(enum Flush flush)
+{
+    if (flush == Flush::False) {
+        m_flush = false;
+    }
+    else if (flush == Flush::True) {
+        m_flush = true;
+    }
+    else {
+        throw std::runtime_error("Unknown Flush");
+    }
+}
+
+inline void DumpOptions::set(enum Compression level)
+{
+    if (level == Compression::None) {
+        m_compress = false;
+    }
+    else if (level == Compression::Medium || level == Compression::High) {
+        m_compress = true;
+        m_deflate_level = static_cast<unsigned>(level);
+    }
+    else {
+        throw std::runtime_error("Unknown Compression");
+    }
+}
+
+inline void DumpOptions::set(const CompressionLevel& level)
+{
+    m_compress = true;
+    m_deflate_level = level.get();
+}
+
+template <class T, class... Args>
+inline void DumpOptions::set(T arg, Args... args)
+{
+    set(arg);
+    set(args...);
+}
+
+inline void DumpOptions::setDeflateLevel(unsigned level)
+{
+    m_deflate_level = level;
+}
+
+template <class T>
+inline void DumpOptions::setChunkSize(const std::vector<T>& shape)
+{
+    m_chunk_size = std::vector<hsize_t>(shape.begin(), shape.end());
+}
+
+inline void DumpOptions::setChunkSize(std::initializer_list<size_t> shape)
+{
+    m_chunk_size = std::vector<hsize_t>(shape.begin(), shape.end());
+}
+
+inline bool DumpOptions::Overwrite() const
+{
+    return m_overwrite;
+}
+
+inline bool DumpOptions::Flush() const
+{
+    return m_flush;
+}
+
+inline bool DumpOptions::Compress() const
+{
+    return m_compress;
+}
+
+inline unsigned DumpOptions::DeflateLevel() const
+{
+    return m_deflate_level;
+}
+
+inline bool DumpOptions::AutomaticChunkSize() const
+{
+    if (m_chunk_size.size() == 0) {
+        return true;
+    }
+
+    return false;
+}
+
+inline std::vector<hsize_t> DumpOptions::ChunkSize() const
+{
+    return m_chunk_size;
+}
+
+inline size_t getSize(const File& file, const std::string& path) {
+    return file.getDataSet(path).getElementCount();
+}
+
+inline std::vector<size_t> getShape(const File& file, const std::string& path) {
+    return file.getDataSet(path).getDimensions();
+}
+
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    const DumpOptions& options) {
+    return detail::io_impl<T>::dump(file, path, data, options);
+}
+
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    DumpMode mode) {
+    return detail::io_impl<T>::dump(file, path, data, DumpOptions(mode));
+}
+
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    const std::vector<size_t>& idx,
+                    const DumpOptions& options) {
+    return detail::io_impl<T>::dump_extend(file, path, data, idx, options);
+}
+
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    const std::initializer_list<size_t>& idx,
+                    const DumpOptions& options) {
+    return detail::io_impl<T>::dump_extend(file, path, data, idx, options);
+}
+
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    const std::vector<size_t>& idx) {
+    return detail::io_impl<T>::dump_extend(file, path, data, idx, DumpOptions());
+}
+
+template <class T>
+inline DataSet dump(File& file,
+                    const std::string& path,
+                    const T& data,
+                    const std::initializer_list<size_t>& idx) {
+    return detail::io_impl<T>::dump_extend(file, path, data, idx, DumpOptions());
+}
+
+template <class T>
+inline T load(const File& file, const std::string& path, const std::vector<size_t>& idx) {
+    return detail::io_impl<T>::load_part(file, path, idx);
+}
+
+template <class T>
+inline T load(const File& file, const std::string& path) {
+    return detail::io_impl<T>::load(file, path);
+}
+
+template <class T>
+inline Attribute dump_attr(File& file,
+                           const std::string& path,
+                           const std::string& key,
+                           const T& data,
+                           DumpMode mode) {
+    return detail::io_impl<T>::dump_attr(file, path, key, data, DumpOptions(mode));
+}
+
+template <class T>
+inline Attribute dump_attr(File& file,
+                           const std::string& path,
+                           const std::string& key,
+                           const T& data,
+                           const DumpOptions& options) {
+    return detail::io_impl<T>::dump_attr(file, path, key, data, options);
+}
+
+template <class T>
+inline T load_attr(const File& file, const std::string& path, const std::string& key) {
+    return detail::io_impl<T>::load_attr(file, path, key);
+}
+
+}  // namespace H5Easy
+
+#endif  // H5EASY_BITS_MISC_HPP

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -91,17 +91,17 @@ inline void DumpOptions::setChunkSize(std::initializer_list<size_t> shape)
     m_chunk_size = std::vector<hsize_t>(shape.begin(), shape.end());
 }
 
-inline bool DumpOptions::isOverwrite() const
+inline bool DumpOptions::overwrite() const
 {
     return m_overwrite;
 }
 
-inline bool DumpOptions::isFlush() const
+inline bool DumpOptions::flush() const
 {
     return m_flush;
 }
 
-inline bool DumpOptions::isCompress() const
+inline bool DumpOptions::compress() const
 {
     return m_compress;
 }
@@ -111,13 +111,9 @@ inline unsigned DumpOptions::getDeflateLevel() const
     return m_deflate_level;
 }
 
-inline bool DumpOptions::isChunkSize() const
+inline bool DumpOptions::isChunked() const
 {
-    if (m_chunk_size.size() == 0) {
-        return false;
-    }
-
-    return true;
+    return m_chunk_size.size() > 0;
 }
 
 inline std::vector<hsize_t> DumpOptions::getChunkSize() const

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -51,10 +51,9 @@ inline void DumpOptions::set(Flush mode)
 inline void DumpOptions::set(Compression level)
 {
     if (level == Compression::False) {
-        m_compress = false;
+        m_deflate_level = static_cast<unsigned>(0);
     }
     else if (level == Compression::Medium || level == Compression::High) {
-        m_compress = true;
         m_deflate_level = static_cast<unsigned>(level);
     }
     else {
@@ -64,7 +63,6 @@ inline void DumpOptions::set(Compression level)
 
 inline void DumpOptions::set(const CompressionLevel& level)
 {
-    m_compress = true;
     m_deflate_level = level.get();
 }
 
@@ -103,7 +101,7 @@ inline bool DumpOptions::flush() const
 
 inline bool DumpOptions::compress() const
 {
-    return m_compress;
+    return m_deflate_level > 0;
 }
 
 inline unsigned DumpOptions::getDeflateLevel() const

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -50,7 +50,7 @@ inline void DumpOptions::set(Flush mode)
 
 inline void DumpOptions::set(Compression level)
 {
-    if (level == Compression::None) {
+    if (level == Compression::False) {
         m_compress = false;
     }
     else if (level == Compression::Medium || level == Compression::High) {
@@ -111,13 +111,13 @@ inline unsigned DumpOptions::getDeflateLevel() const
     return m_deflate_level;
 }
 
-inline bool DumpOptions::isAutomaticChunkSize() const
+inline bool DumpOptions::isChunkSize() const
 {
     if (m_chunk_size.size() == 0) {
-        return true;
+        return false;
     }
 
-    return false;
+    return true;
 }
 
 inline std::vector<hsize_t> DumpOptions::getChunkSize() const

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -24,28 +24,12 @@ inline unsigned Compression::get() const
 
 inline void DumpOptions::set(DumpMode mode)
 {
-    if (mode == DumpMode::Create) {
-        m_overwrite = false;
-    }
-    else if (mode == DumpMode::Overwrite) {
-        m_overwrite = true;
-    }
-    else {
-        throw std::runtime_error("Unknown DumpMode");
-    }
+    m_overwrite = static_cast<bool>(mode);
 }
 
 inline void DumpOptions::set(Flush mode)
 {
-    if (mode == Flush::False) {
-        m_flush = false;
-    }
-    else if (mode == Flush::True) {
-        m_flush = true;
-    }
-    else {
-        throw std::runtime_error("Unknown Flush");
-    }
+    m_flush = static_cast<bool>(mode);
 }
 
 inline void DumpOptions::set(const Compression& level)

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -13,13 +13,23 @@
 
 namespace H5Easy {
 
-inline Compression::Compression(unsigned deflate_level) : m_deflate_level(deflate_level)
+inline Compression::Compression(bool enable)
+{
+    if (enable) {
+        m_compression_level = 9;
+    } else {
+        m_compression_level = 0;
+    }
+}
+
+template <class T>
+inline Compression::Compression(T level) : m_compression_level(static_cast<unsigned>(level))
 {
 }
 
 inline unsigned Compression::get() const
 {
-    return m_deflate_level;
+    return m_compression_level;
 }
 
 inline void DumpOptions::set(DumpMode mode)
@@ -34,7 +44,7 @@ inline void DumpOptions::set(Flush mode)
 
 inline void DumpOptions::set(const Compression& level)
 {
-    m_deflate_level = level.get();
+    m_compression_level = level.get();
 }
 
 template <class T, class... Args>
@@ -42,11 +52,6 @@ inline void DumpOptions::set(T arg, Args... args)
 {
     set(arg);
     set(args...);
-}
-
-inline void DumpOptions::setDeflateLevel(unsigned level)
-{
-    m_deflate_level = level;
 }
 
 template <class T>
@@ -72,12 +77,12 @@ inline bool DumpOptions::flush() const
 
 inline bool DumpOptions::compress() const
 {
-    return m_deflate_level > 0;
+    return m_compression_level > 0;
 }
 
-inline unsigned DumpOptions::getDeflateLevel() const
+inline unsigned DumpOptions::getCompressionLevel() const
 {
-    return m_deflate_level;
+    return m_compression_level;
 }
 
 inline bool DumpOptions::isChunked() const

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -13,11 +13,11 @@
 
 namespace H5Easy {
 
-inline CompressionLevel::CompressionLevel(unsigned deflate_level) : m_deflate_level(deflate_level)
+inline Compression::Compression(unsigned deflate_level) : m_deflate_level(deflate_level)
 {
 }
 
-inline unsigned CompressionLevel::get() const
+inline unsigned Compression::get() const
 {
     return m_deflate_level;
 }
@@ -48,20 +48,7 @@ inline void DumpOptions::set(Flush mode)
     }
 }
 
-inline void DumpOptions::set(Compression level)
-{
-    if (level == Compression::False) {
-        m_deflate_level = static_cast<unsigned>(0);
-    }
-    else if (level == Compression::Medium || level == Compression::High) {
-        m_deflate_level = static_cast<unsigned>(level);
-    }
-    else {
-        throw std::runtime_error("Unknown Compression");
-    }
-}
-
-inline void DumpOptions::set(const CompressionLevel& level)
+inline void DumpOptions::set(const Compression& level)
 {
     m_deflate_level = level.get();
 }

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -29,7 +29,7 @@ struct io_impl {
                                const DumpOptions& options) {
         DataSet dataset = init_dataset_scalar(file, path, data, options);
         dataset.write(data);
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return dataset;
@@ -49,7 +49,7 @@ struct io_impl {
                                       const DumpOptions& options) {
         Attribute attribute = init_attribute_scalar(file, path, key, data, options);
         attribute.write(data);
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return attribute;
@@ -85,7 +85,7 @@ struct io_impl {
                 dataset.resize(shape);
             }
             dataset.select(idx, ones).write(data);
-            if (options.isFlush()) {
+            if (options.flush()) {
                 file.flush();
             }
             return dataset;
@@ -96,7 +96,7 @@ struct io_impl {
         const size_t unlim = DataSpace::UNLIMITED;
         std::vector<size_t> unlim_shape(idx.size(), unlim);
         std::vector<hsize_t> chunks(idx.size(), 10);
-        if (options.isChunkSize()) {
+        if (options.isChunked()) {
             chunks = options.getChunkSize();
             if (chunks.size() != idx.size()) {
                 throw error(file, path, "H5Easy::dump: Incorrect rank ChunkSize");
@@ -110,7 +110,7 @@ struct io_impl {
         props.add(Chunking(chunks));
         DataSet dataset = file.createDataSet(path, dataspace, AtomicType<T>(), props);
         dataset.select(idx, ones).write(data);
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return dataset;

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -27,7 +27,7 @@ struct io_impl {
                         const std::string& path,
                         const T& data,
                         const DumpSettings& settings) {
-        DataSet dataset = init_dataset(file, path, data, settings);
+        DataSet dataset = init_dataset_scalar(file, path, data, settings);
         dataset.write(data);
         file.flush();
         return dataset;

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -27,7 +27,7 @@ struct io_impl {
                                const std::string& path,
                                const T& data,
                                const DumpOptions& options) {
-        DataSet dataset = init_dataset_scalar(file, path, data, options);
+        DataSet dataset = initScalarDataset(file, path, data, options);
         dataset.write(data);
         if (options.flush()) {
             file.flush();
@@ -42,12 +42,12 @@ struct io_impl {
         return data;
     }
 
-    inline static Attribute dump_attr(File& file,
-                                      const std::string& path,
-                                      const std::string& key,
-                                      const T& data,
-                                      const DumpOptions& options) {
-        Attribute attribute = init_attribute_scalar(file, path, key, data, options);
+    inline static Attribute dumpAttribute(File& file,
+                                          const std::string& path,
+                                          const std::string& key,
+                                          const T& data,
+                                          const DumpOptions& options) {
+        Attribute attribute = initScalarAttribute(file, path, key, data, options);
         attribute.write(data);
         if (options.flush()) {
             file.flush();
@@ -55,7 +55,9 @@ struct io_impl {
         return attribute;
     }
 
-    inline static T load_attr(const File& file, const std::string& path, const std::string& key) {
+    inline static T loadAttribute(const File& file,
+                                  const std::string& path,
+                                  const std::string& key) {
         DataSet dataset = file.getDataSet(path);
         Attribute attribute = dataset.getAttribute(key);
         T data;
@@ -76,7 +78,7 @@ struct io_impl {
             std::vector<size_t> shape = dims;
             if (dims.size() != idx.size()) {
                 throw detail::error(file, path,
-                    "H5Easy::dump: Rank of the index and the existing field do not match");
+                    "H5Easy::dump: Dimension of the index and the existing field do not match");
             }
             for (size_t i = 0; i < dims.size(); ++i) {
                 shape[i] = std::max(dims[i], idx[i] + 1);
@@ -99,7 +101,7 @@ struct io_impl {
         if (options.isChunked()) {
             chunks = options.getChunkSize();
             if (chunks.size() != idx.size()) {
-                throw error(file, path, "H5Easy::dump: Incorrect rank ChunkSize");
+                throw error(file, path, "H5Easy::dump: Incorrect dimension ChunkSize");
             }
         }
         for (size_t& i : shape) {

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -47,12 +47,12 @@ struct io_impl {
                                       const std::string& key,
                                       const T& data,
                                       const DumpOptions& options) {
-        Attribute atrribute = init_attribute_scalar(file, path, key, data, options);
-        atrribute.write(data);
+        Attribute attribute = init_attribute_scalar(file, path, key, data, options);
+        attribute.write(data);
         if (options.isFlush()) {
             file.flush();
         }
-        return atrribute;
+        return attribute;
     }
 
     inline static T load_attr(const File& file, const std::string& path, const std::string& key) {
@@ -128,7 +128,6 @@ struct io_impl {
 };
 
 }  // namespace detail
-
 }  // namespace H5Easy
 
 #endif  // H5EASY_BITS_SCALAR_HPP

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -29,7 +29,7 @@ struct io_impl {
                                const DumpOptions& options) {
         DataSet dataset = init_dataset_scalar(file, path, data, options);
         dataset.write(data);
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return dataset;
@@ -49,7 +49,7 @@ struct io_impl {
                                       const DumpOptions& options) {
         Attribute atrribute = init_attribute_scalar(file, path, key, data, options);
         atrribute.write(data);
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return atrribute;
@@ -85,7 +85,7 @@ struct io_impl {
                 dataset.resize(shape);
             }
             dataset.select(idx, ones).write(data);
-            if (options.Flush()) {
+            if (options.isFlush()) {
                 file.flush();
             }
             return dataset;
@@ -96,8 +96,8 @@ struct io_impl {
         const size_t unlim = DataSpace::UNLIMITED;
         std::vector<size_t> unlim_shape(idx.size(), unlim);
         std::vector<hsize_t> chunks(idx.size(), 10);
-        if (!options.AutomaticChunkSize()) {
-            chunks = options.ChunkSize();
+        if (!options.isAutomaticChunkSize()) {
+            chunks = options.getChunkSize();
             if (chunks.size() != idx.size()) {
                 throw error(file, path, "H5Easy::dump: Incorrect rank ChunkSize");
             }
@@ -110,7 +110,7 @@ struct io_impl {
         props.add(Chunking(chunks));
         DataSet dataset = file.createDataSet(path, dataspace, AtomicType<T>(), props);
         dataset.select(idx, ones).write(data);
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return dataset;

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -96,7 +96,7 @@ struct io_impl {
         const size_t unlim = DataSpace::UNLIMITED;
         std::vector<size_t> unlim_shape(idx.size(), unlim);
         std::vector<hsize_t> chunks(idx.size(), 10);
-        if (!options.isAutomaticChunkSize()) {
+        if (options.isChunkSize()) {
             chunks = options.getChunkSize();
             if (chunks.size() != idx.size()) {
                 throw error(file, path, "H5Easy::dump: Incorrect rank ChunkSize");

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -31,11 +31,13 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
     inline static DataSet dump(File& file,
                         const std::string& path,
                         const T& data,
-                        const DumpSettings& settings) {
+                        const DumpOptions& options) {
         using value_type = typename type_of_array<T>::type;
-        DataSet dataset = init_dataset<value_type>(file, path, get_dim_vector(data), settings);
+        DataSet dataset = init_dataset<value_type>(file, path, get_dim_vector(data), options);
         dataset.write(data);
-        file.flush();
+        if (options.Flush()) {
+            file.flush();
+        }
         return dataset;
     }
 
@@ -50,12 +52,14 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
                               const std::string& path,
                               const std::string& key,
                               const T& data,
-                              const DumpSettings& settings) {
+                              const DumpOptions& options) {
         using value_type = typename type_of_array<T>::type;
         std::vector<size_t> shape = get_dim_vector(data);
-        Attribute attribute = init_attribute<value_type>(file, path, key, shape, settings);
+        Attribute attribute = init_attribute<value_type>(file, path, key, shape, options);
         attribute.write(data);
-        file.flush();
+        if (options.Flush()) {
+            file.flush();
+        }
         return attribute;
     }
 

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -45,6 +45,27 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         dataset.read(data);
         return data;
     }
+
+   static Attribute dump_attr(File& file,
+                              const std::string& path,
+                              const std::string& key,
+                              const T& data,
+                              const DumpSettings& settings) {
+        using value_type = typename type_of_array<T>::type;
+        std::vector<size_t> shape = get_dim_vector(data);
+        Attribute attribute = init_attribute<value_type>(file, path, key, shape, settings);
+        attribute.write(data);
+        file.flush();
+        return attribute;
+    }
+
+    static T load_attr(const File& file, const std::string& path, const std::string& key) {
+        DataSet dataset = file.getDataSet(path);
+        Attribute attribute = dataset.getAttribute(key);
+        T data;
+        attribute.read(data);
+        return data;
+    }
 };
 
 }  // namespace detail

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -29,11 +29,11 @@ template <typename T>
 struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
 
     inline static DataSet dump(File& file,
-                        const std::string& path,
-                        const T& data,
-                        const DumpOptions& options) {
+                               const std::string& path,
+                               const T& data,
+                               const DumpOptions& options) {
         using value_type = typename type_of_array<T>::type;
-        DataSet dataset = init_dataset<value_type>(file, path, get_dim_vector(data), options);
+        DataSet dataset = initDataset<value_type>(file, path, get_dim_vector(data), options);
         dataset.write(data);
         if (options.flush()) {
             file.flush();
@@ -48,14 +48,14 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         return data;
     }
 
-   inline static Attribute dump_attr(File& file,
-                              const std::string& path,
-                              const std::string& key,
-                              const T& data,
-                              const DumpOptions& options) {
+   inline static Attribute dumpAttribute(File& file,
+                                         const std::string& path,
+                                         const std::string& key,
+                                         const T& data,
+                                         const DumpOptions& options) {
         using value_type = typename type_of_array<T>::type;
         std::vector<size_t> shape = get_dim_vector(data);
-        Attribute attribute = init_attribute<value_type>(file, path, key, shape, options);
+        Attribute attribute = initAttribute<value_type>(file, path, key, shape, options);
         attribute.write(data);
         if (options.flush()) {
             file.flush();
@@ -63,7 +63,9 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         return attribute;
     }
 
-    inline static T load_attr(const File& file, const std::string& path, const std::string& key) {
+    inline static T loadAttribute(const File& file,
+                                  const std::string& path,
+                                  const std::string& key) {
         DataSet dataset = file.getDataSet(path);
         Attribute attribute = dataset.getAttribute(key);
         T data;

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -31,20 +31,9 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
     static DataSet dump(File& file,
                         const std::string& path,
                         const T& data,
-                        const DumpSettings&) {
-        using type_name = typename type_of_array<T>::type;
-        detail::createGroupsToDataSet(file, path);
-        DataSet dataset = file.createDataSet<type_name>(path, DataSpace::From(data));
-        dataset.write(data);
-        file.flush();
-        return dataset;
-    }
-
-    static DataSet overwrite(File& file, const std::string& path, const T& data) {
-        DataSet dataset = file.getDataSet(path);
-        if (get_dim_vector(data) != dataset.getDimensions()) {
-            throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
-        }
+                        const DumpSettings& settings) {
+        using value_type = typename type_of_array<T>::type;
+        DataSet dataset = init_dataset<value_type>(file, path, get_dim_vector(data), settings);
         dataset.write(data);
         file.flush();
         return dataset;

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -35,7 +35,7 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         using value_type = typename type_of_array<T>::type;
         DataSet dataset = init_dataset<value_type>(file, path, get_dim_vector(data), options);
         dataset.write(data);
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return dataset;
@@ -57,7 +57,7 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         std::vector<size_t> shape = get_dim_vector(data);
         Attribute attribute = init_attribute<value_type>(file, path, key, shape, options);
         attribute.write(data);
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return attribute;

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -28,7 +28,10 @@ using HighFive::details::type_of_array;
 template <typename T>
 struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
 
-    static DataSet dump(File& file, const std::string& path, const T& data) {
+    static DataSet dump(File& file,
+                        const std::string& path,
+                        const T& data,
+                        const DumpSettings&) {
         using type_name = typename type_of_array<T>::type;
         detail::createGroupsToDataSet(file, path);
         DataSet dataset = file.createDataSet<type_name>(path, DataSpace::From(data));

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -28,7 +28,7 @@ using HighFive::details::type_of_array;
 template <typename T>
 struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
 
-    static DataSet dump(File& file,
+    inline static DataSet dump(File& file,
                         const std::string& path,
                         const T& data,
                         const DumpSettings& settings) {
@@ -39,14 +39,14 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         return dataset;
     }
 
-    static T load(const File& file, const std::string& path) {
+    inline static T load(const File& file, const std::string& path) {
         DataSet dataset = file.getDataSet(path);
         T data;
         dataset.read(data);
         return data;
     }
 
-   static Attribute dump_attr(File& file,
+   inline static Attribute dump_attr(File& file,
                               const std::string& path,
                               const std::string& key,
                               const T& data,
@@ -59,7 +59,7 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         return attribute;
     }
 
-    static T load_attr(const File& file, const std::string& path, const std::string& key) {
+    inline static T load_attr(const File& file, const std::string& path, const std::string& key) {
         DataSet dataset = file.getDataSet(path);
         Attribute attribute = dataset.getAttribute(key);
         T data;

--- a/include/highfive/h5easy_bits/H5Easy_vector.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_vector.hpp
@@ -35,7 +35,7 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         using value_type = typename type_of_array<T>::type;
         DataSet dataset = init_dataset<value_type>(file, path, get_dim_vector(data), options);
         dataset.write(data);
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return dataset;
@@ -57,7 +57,7 @@ struct io_impl<T, typename std::enable_if<is_vector<T>::value>::type> {
         std::vector<size_t> shape = get_dim_vector(data);
         Attribute attribute = init_attribute<value_type>(file, path, key, shape, options);
         attribute.write(data);
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return attribute;

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -38,18 +38,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
                         const T& data,
                         const DumpSettings& settings) {
         using value_type = typename std::decay_t<T>::value_type;
-        detail::createGroupsToDataSet(file, path);
-        DataSet dataset = init_dataset<value_type>(file, path, shape(data), settings);;
-        dataset.write_raw(data.data());
-        file.flush();
-        return dataset;
-    }
-
-    static DataSet overwrite(File& file, const std::string& path, const T& data) {
-        DataSet dataset = file.getDataSet(path);
-        if (dataset.getDimensions() != shape(data)) {
-            throw detail::error(file, path, "H5Easy::dump: Inconsistent dimensions");
-        }
+        DataSet dataset = init_dataset<value_type>(file, path, shape(data), settings);
         dataset.write_raw(data.data());
         file.flush();
         return dataset;
@@ -66,9 +55,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
 };
 
 }  // namespace detail
-
 }  // namespace H5Easy
 
 #endif  // H5_USE_XTENSOR
-
 #endif  // H5EASY_BITS_XTENSOR_HPP

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -40,7 +40,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         using value_type = typename std::decay_t<T>::value_type;
         DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(data.data());
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return dataset;
@@ -62,7 +62,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         using value_type = typename std::decay_t<T>::value_type;
         Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), options);
         attribute.write_raw(data.data());
-        if (options.isFlush()) {
+        if (options.flush()) {
             file.flush();
         }
         return attribute;

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -33,10 +33,13 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return std::vector<size_t>(data.shape().cbegin(), data.shape().cend());
     }
 
-    static DataSet dump(File& file, const std::string& path, const T& data) {
+    static DataSet dump(File& file,
+                        const std::string& path,
+                        const T& data,
+                        const DumpSettings& settings) {
         using value_type = typename std::decay_t<T>::value_type;
         detail::createGroupsToDataSet(file, path);
-        DataSet dataset = file.createDataSet<value_type>(path, DataSpace(shape(data)));
+        DataSet dataset = init_dataset<value_type>(file, path, shape(data), settings);;
         dataset.write_raw(data.data());
         file.flush();
         return dataset;

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -38,7 +38,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
                         const T& data,
                         const DumpOptions& options) {
         using value_type = typename std::decay_t<T>::value_type;
-        DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
+        DataSet dataset = initDataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(data.data());
         if (options.flush()) {
             file.flush();
@@ -54,13 +54,13 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return data;
     }
 
-    inline static Attribute dump_attr(File& file,
-                               const std::string& path,
-                               const std::string& key,
-                               const T& data,
-                               const DumpOptions& options) {
+    inline static Attribute dumpAttribute(File& file,
+                                          const std::string& path,
+                                          const std::string& key,
+                                          const T& data,
+                                          const DumpOptions& options) {
         using value_type = typename std::decay_t<T>::value_type;
-        Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), options);
+        Attribute attribute = initAttribute<value_type>(file, path, key, shape(data), options);
         attribute.write_raw(data.data());
         if (options.flush()) {
             file.flush();
@@ -68,7 +68,9 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return attribute;
     }
 
-    inline static T load_attr(const File& file, const std::string& path, const std::string& key) {
+    inline static T loadAttribute(const File& file,
+                                  const std::string& path,
+                                  const std::string& key) {
         DataSet dataset = file.getDataSet(path);
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -33,7 +33,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return std::vector<size_t>(data.shape().cbegin(), data.shape().cend());
     }
 
-    static DataSet dump(File& file,
+    inline static DataSet dump(File& file,
                         const std::string& path,
                         const T& data,
                         const DumpSettings& settings) {
@@ -44,7 +44,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return dataset;
     }
 
-    static T load(const File& file, const std::string& path) {
+    inline static T load(const File& file, const std::string& path) {
         DataSet dataset = file.getDataSet(path);
         std::vector<size_t> dims = dataset.getDimensions();
         T data = T::from_shape(dims);
@@ -52,7 +52,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return data;
     }
 
-    static Attribute dump_attr(File& file,
+    inline static Attribute dump_attr(File& file,
                                const std::string& path,
                                const std::string& key,
                                const T& data,
@@ -64,7 +64,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return attribute;
     }
 
-    static T load_attr(const File& file, const std::string& path, const std::string& key) {
+    inline static T load_attr(const File& file, const std::string& path, const std::string& key) {
         DataSet dataset = file.getDataSet(path);
         Attribute attribute = dataset.getAttribute(key);
         DataSpace dataspace = attribute.getSpace();

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -52,6 +52,27 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         return data;
     }
 
+    static Attribute dump_attr(File& file,
+                               const std::string& path,
+                               const std::string& key,
+                               const T& data,
+                               const DumpSettings& settings) {
+        using value_type = typename std::decay_t<T>::value_type;
+        Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), settings);
+        attribute.write_raw(data.data());
+        file.flush();
+        return attribute;
+    }
+
+    static T load_attr(const File& file, const std::string& path, const std::string& key) {
+        DataSet dataset = file.getDataSet(path);
+        Attribute attribute = dataset.getAttribute(key);
+        DataSpace dataspace = attribute.getSpace();
+        std::vector<size_t> dims = dataspace.getDimensions();
+        T data = T::from_shape(dims);
+        attribute.read(data.data());
+        return data;
+    }
 };
 
 }  // namespace detail

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -36,11 +36,13 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
     inline static DataSet dump(File& file,
                         const std::string& path,
                         const T& data,
-                        const DumpSettings& settings) {
+                        const DumpOptions& options) {
         using value_type = typename std::decay_t<T>::value_type;
-        DataSet dataset = init_dataset<value_type>(file, path, shape(data), settings);
+        DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(data.data());
-        file.flush();
+        if (options.Flush()) {
+            file.flush();
+        }
         return dataset;
     }
 
@@ -56,11 +58,13 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
                                const std::string& path,
                                const std::string& key,
                                const T& data,
-                               const DumpSettings& settings) {
+                               const DumpOptions& options) {
         using value_type = typename std::decay_t<T>::value_type;
-        Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), settings);
+        Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), options);
         attribute.write_raw(data.data());
-        file.flush();
+        if (options.Flush()) {
+            file.flush();
+        }
         return attribute;
     }
 

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -40,7 +40,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         using value_type = typename std::decay_t<T>::value_type;
         DataSet dataset = init_dataset<value_type>(file, path, shape(data), options);
         dataset.write_raw(data.data());
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return dataset;
@@ -62,7 +62,7 @@ struct io_impl<T, typename std::enable_if<is_xtensor<T>::value>::type> {
         using value_type = typename std::decay_t<T>::value_type;
         Attribute attribute = init_attribute<value_type>(file, path, key, shape(data), options);
         attribute.write_raw(data.data());
-        if (options.Flush()) {
+        if (options.isFlush()) {
             file.flush();
         }
         return attribute;

--- a/src/examples/easy_attribute.cpp
+++ b/src/examples/easy_attribute.cpp
@@ -1,0 +1,40 @@
+/// To enable plug-ins, load the relevant libraries BEFORE HighFive. E.g.
+///
+///   #include <xtensor/xtensor.hpp>
+///   #include <Eigen/Eigen>
+///   #include <highfive/H5Easy.hpp>
+///
+/// or ask HighFive to include them. E.g.
+///
+///   #define H5_USE_XTENSOR
+///   #define H5_USE_EIGEN
+///   #include <highfive/H5Easy.hpp>
+///
+
+// optionally enable plug-in xtensor
+#ifdef H5_USE_XTENSOR
+#include <xtensor/xtensor.hpp>
+#endif
+
+// optionally enable plug-in Eigen
+#ifdef H5_USE_EIGEN
+#include <Eigen/Eigen>
+#endif
+
+#include <highfive/H5Easy.hpp>
+
+int main()
+{
+    H5Easy::File file("example.h5", H5Easy::File::Overwrite);
+
+    std::vector<double> A = {1.0, 2.0, 3.0};
+    std::string desc = "This is an important dataset.";
+    double T = 1.234;
+
+    H5Easy::dump(file, "/path/to/A", A);
+    H5Easy::dump_attr(file, "/path/to/A", "description", desc);
+    H5Easy::dump_attr(file, "/path/to/A", "temperature", T);
+
+
+    return 0;
+}

--- a/src/examples/easy_attribute.cpp
+++ b/src/examples/easy_attribute.cpp
@@ -32,8 +32,8 @@ int main()
     double temperature = 1.234;
 
     H5Easy::dump(file, "/path/to/measurement", measurement);
-    H5Easy::dump_attr(file, "/path/to/measurement", "description", desc);
-    H5Easy::dump_attr(file, "/path/to/measurement", "temperature", temperature);
+    H5Easy::dumpAttribute(file, "/path/to/measurement", "description", desc);
+    H5Easy::dumpAttribute(file, "/path/to/measurement", "temperature", temperature);
 
 
     return 0;

--- a/src/examples/easy_attribute.cpp
+++ b/src/examples/easy_attribute.cpp
@@ -27,13 +27,13 @@ int main()
 {
     H5Easy::File file("example.h5", H5Easy::File::Overwrite);
 
-    std::vector<double> A = {1.0, 2.0, 3.0};
+    std::vector<double> measurement = {1.0, 2.0, 3.0};
     std::string desc = "This is an important dataset.";
-    double T = 1.234;
+    double temperature = 1.234;
 
-    H5Easy::dump(file, "/path/to/A", A);
-    H5Easy::dump_attr(file, "/path/to/A", "description", desc);
-    H5Easy::dump_attr(file, "/path/to/A", "temperature", T);
+    H5Easy::dump(file, "/path/to/measurement", measurement);
+    H5Easy::dump_attr(file, "/path/to/measurement", "description", desc);
+    H5Easy::dump_attr(file, "/path/to/measurement", "temperature", temperature);
 
 
     return 0;

--- a/src/examples/easy_dumpoptions.cpp
+++ b/src/examples/easy_dumpoptions.cpp
@@ -51,14 +51,14 @@ int main()
         std::vector<double> C = {1.0, 2.0, 3.0};
 
         H5Easy::dump(file, "/path/to/C", C,
-            H5Easy::DumpOptions(H5Easy::CompressionLevel(8)));
+            H5Easy::DumpOptions(H5Easy::Compression(8)));
     }
 
     // advanced - compression - set deflate level & chunk size
     {
         std::vector<double> D = {1.0, 2.0, 3.0};
 
-        H5Easy::DumpOptions options(H5Easy::CompressionLevel(8));
+        H5Easy::DumpOptions options(H5Easy::Compression(8));
         options.setChunkSize({3});
 
         H5Easy::dump(file, "/path/to/D", D, options);

--- a/src/examples/easy_dumpoptions.cpp
+++ b/src/examples/easy_dumpoptions.cpp
@@ -40,13 +40,13 @@ int main()
         std::vector<double> B = {1.0, 2.0, 3.0};
 
         H5Easy::dump(file, "/path/to/B", B,
-            H5Easy::DumpOptions(H5Easy::Compression::High));
+            H5Easy::DumpOptions(H5Easy::Compression()));
 
         H5Easy::dump(file, "/path/to/B", B,
-            H5Easy::DumpOptions(H5Easy::Compression::High, H5Easy::DumpMode::Overwrite));
+            H5Easy::DumpOptions(H5Easy::Compression(), H5Easy::DumpMode::Overwrite));
     }
 
-    // advanced - compression - set deflate level
+    // advanced - compression - set compression level
     {
         std::vector<double> C = {1.0, 2.0, 3.0};
 
@@ -54,7 +54,7 @@ int main()
             H5Easy::DumpOptions(H5Easy::Compression(8)));
     }
 
-    // advanced - compression - set deflate level & chunk size
+    // advanced - compression - set compression level & chunk size
     {
         std::vector<double> D = {1.0, 2.0, 3.0};
 

--- a/src/examples/easy_dumpoptions.cpp
+++ b/src/examples/easy_dumpoptions.cpp
@@ -1,0 +1,90 @@
+/// To enable plug-ins, load the relevant libraries BEFORE HighFive. E.g.
+///
+///   #include <xtensor/xtensor.hpp>
+///   #include <Eigen/Eigen>
+///   #include <highfive/H5Easy.hpp>
+///
+/// or ask HighFive to include them. E.g.
+///
+///   #define H5_USE_XTENSOR
+///   #define H5_USE_EIGEN
+///   #include <highfive/H5Easy.hpp>
+///
+
+// optionally enable plug-in xtensor
+#ifdef H5_USE_XTENSOR
+#include <xtensor/xtensor.hpp>
+#endif
+
+// optionally enable plug-in Eigen
+#ifdef H5_USE_EIGEN
+#include <Eigen/Eigen>
+#endif
+
+#include <highfive/H5Easy.hpp>
+
+int main()
+{
+    H5Easy::File file("example.h5", H5Easy::File::Overwrite);
+
+    // plain options
+    {
+        std::vector<double> A = {1.0, 2.0, 3.0};
+
+        H5Easy::dump(file, "/path/to/A", A);
+        H5Easy::dump(file, "/path/to/A", A, H5Easy::DumpMode::Overwrite);
+    }
+
+    // advanced - compression
+    {
+        std::vector<double> B = {1.0, 2.0, 3.0};
+
+        H5Easy::dump(file, "/path/to/B", B,
+            H5Easy::DumpOptions(H5Easy::Compression::High));
+
+        H5Easy::dump(file, "/path/to/B", B,
+            H5Easy::DumpOptions(H5Easy::Compression::High, H5Easy::DumpMode::Overwrite));
+    }
+
+    // advanced - compression - set deflate level
+    {
+        std::vector<double> C = {1.0, 2.0, 3.0};
+
+        H5Easy::dump(file, "/path/to/C", C,
+            H5Easy::DumpOptions(H5Easy::CompressionLevel(8)));
+    }
+
+    // advanced - compression - set deflate level & chunk size
+    {
+        std::vector<double> D = {1.0, 2.0, 3.0};
+
+        H5Easy::DumpOptions options(H5Easy::CompressionLevel(8));
+        options.setChunkSize({3});
+
+        H5Easy::dump(file, "/path/to/D", D, options);
+    }
+
+    // advanced - set chunk size
+    {
+        int E = 10;
+
+        H5Easy::DumpOptions options;
+        options.setChunkSize({100, 100});
+
+        H5Easy::dump(file, "/path/to/E", E, {0, 0}, options);
+        H5Easy::dump(file, "/path/to/E", E, {0, 1}, options);
+        // ...
+    }
+
+    // advanced - no automatic flushing
+    {
+        std::vector<double> F = {1.0, 2.0, 3.0};
+
+        H5Easy::dump(file, "/path/to/F", F,
+            H5Easy::DumpOptions(H5Easy::Flush::False));
+
+        file.flush();
+    }
+
+    return 0;
+}

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -72,19 +72,11 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector2d)
 {
     H5Easy::File file("test.h5", H5Easy::File::Overwrite);
 
-    using type = std::vector<std::vector<size_t>>;
-
-    type a(3);
-    a[0].push_back(0);
-    a[0].push_back(1);
-    a[1].push_back(2);
-    a[1].push_back(3);
-    a[2].push_back(4);
-    a[2].push_back(5);
+    std::vector<std::vector<size_t>> a({{0, 1}, {2, 3}, {4, 5}});
 
     H5Easy::dump(file, "/path/to/a", a);
 
-    type a_r = H5Easy::load<type>(file, "/path/to/a");
+    decltype(a) a_r = H5Easy::load<decltype(a)>(file, "/path/to/a");
 
     BOOST_CHECK_EQUAL(a == a_r, true);
 }
@@ -93,15 +85,7 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector2d_compression)
 {
     H5Easy::File file("test.h5", H5Easy::File::Overwrite);
 
-    using type = std::vector<std::vector<size_t>>;
-
-    type a(3);
-    a[0].push_back(0);
-    a[0].push_back(1);
-    a[1].push_back(2);
-    a[1].push_back(3);
-    a[2].push_back(4);
-    a[2].push_back(5);
+    std::vector<std::vector<size_t>> a({{0, 1}, {2, 3}, {4, 5}});
 
     H5Easy::dump(file, "/path/to/a", a,
         H5Easy::DumpOptions(H5Easy::Compression::High));
@@ -109,7 +93,7 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector2d_compression)
     H5Easy::dump(file, "/path/to/a", a,
         H5Easy::DumpOptions(H5Easy::Compression::High, H5Easy::DumpMode::Overwrite));
 
-    type a_r = H5Easy::load<type>(file, "/path/to/a");
+    decltype(a) a_r = H5Easy::load<decltype(a)>(file, "/path/to/a");
 
     BOOST_CHECK_EQUAL(a == a_r, true);
 }
@@ -120,23 +104,7 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector3d)
 
     using type = std::vector<std::vector<std::vector<size_t>>>;
 
-    type a(3);
-    a[0].resize(2);
-    a[1].resize(2);
-    a[2].resize(2);
-
-    a[0][0].push_back(0);
-    a[0][0].push_back(1);
-    a[0][1].push_back(2);
-    a[0][1].push_back(3);
-    a[1][0].push_back(4);
-    a[1][0].push_back(5);
-    a[1][1].push_back(6);
-    a[1][1].push_back(7);
-    a[2][0].push_back(8);
-    a[2][0].push_back(9);
-    a[2][1].push_back(10);
-    a[2][1].push_back(11);
+    type a({{{0, 1}, {2, 3}}, {{4, 5}, {6, 7}}, {{8, 9}, {10, 11}}});
 
     H5Easy::dump(file, "/path/to/a", a);
 

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -103,8 +103,11 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector2d_compression)
     a[2].push_back(4);
     a[2].push_back(5);
 
-    H5Easy::dump(file, "/path/to/a", a, H5Easy::Compression::High);
-    H5Easy::dump(file, "/path/to/a", a, H5Easy::Compression::High, H5Easy::DumpMode::Overwrite);
+    H5Easy::dump(file, "/path/to/a", a,
+        H5Easy::DumpOptions(H5Easy::Compression::High));
+
+    H5Easy::dump(file, "/path/to/a", a,
+        H5Easy::DumpOptions(H5Easy::Compression::High, H5Easy::DumpMode::Overwrite));
 
     type a_r = H5Easy::load<type>(file, "/path/to/a");
 

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -36,27 +36,27 @@
 BOOST_AUTO_TEST_CASE(H5Easy_Compression)
 {
     {
-        H5Easy::DumpOptions options(H5Easy::Compression::High);
+        H5Easy::DumpOptions options = H5Easy::DumpOptions(H5Easy::Compression());
         BOOST_CHECK_EQUAL(options.compress(), true);
-        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 9);
+        BOOST_CHECK_EQUAL(options.getCompressionLevel(), 9);
     }
 
     {
-        H5Easy::DumpOptions options(H5Easy::Compression::Medium);
+        H5Easy::DumpOptions options(H5Easy::Compression(true));
         BOOST_CHECK_EQUAL(options.compress(), true);
-        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 5);
+        BOOST_CHECK_EQUAL(options.getCompressionLevel(), 9);
     }
 
     {
-        H5Easy::DumpOptions options(H5Easy::Compression::False);
+        H5Easy::DumpOptions options(H5Easy::Compression(false));
         BOOST_CHECK_EQUAL(options.compress(), false);
-        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 0);
+        BOOST_CHECK_EQUAL(options.getCompressionLevel(), 0);
     }
 
     {
         H5Easy::DumpOptions options(H5Easy::Compression(8));
         BOOST_CHECK_EQUAL(options.compress(), true);
-        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 8);
+        BOOST_CHECK_EQUAL(options.getCompressionLevel(), 8);
     }
 }
 
@@ -115,10 +115,10 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector2d_compression)
     std::vector<std::vector<size_t>> a({{0, 1}, {2, 3}, {4, 5}});
 
     H5Easy::dump(file, "/path/to/a", a,
-        H5Easy::DumpOptions(H5Easy::Compression::High));
+        H5Easy::DumpOptions(H5Easy::Compression(9)));
 
     H5Easy::dump(file, "/path/to/a", a,
-        H5Easy::DumpOptions(H5Easy::Compression::High, H5Easy::DumpMode::Overwrite));
+        H5Easy::DumpOptions(H5Easy::Compression(), H5Easy::DumpMode::Overwrite));
 
     decltype(a) a_r = H5Easy::load<decltype(a)>(file, "/path/to/a");
 
@@ -246,13 +246,13 @@ BOOST_AUTO_TEST_CASE(H5Easy_xtensor_compress)
     xt::xtensor<int, 2> B = A;
 
     H5Easy::dump(file, "/path/to/A", A,
-        H5Easy::DumpOptions(H5Easy::Compression::High));
+        H5Easy::DumpOptions(H5Easy::Compression()));
 
     H5Easy::dump(file, "/path/to/A", A,
-        H5Easy::DumpOptions(H5Easy::Compression::High, H5Easy::DumpMode::Overwrite));
+        H5Easy::DumpOptions(H5Easy::Compression(), H5Easy::DumpMode::Overwrite));
 
     H5Easy::dump(file, "/path/to/B", B,
-        H5Easy::DumpOptions(H5Easy::Compression::High));
+        H5Easy::DumpOptions(H5Easy::Compression()));
 
     xt::xtensor<double,2> A_r = H5Easy::load<xt::xtensor<double,2>>(file, "/path/to/A");
     xt::xtensor<int, 2> B_r = H5Easy::load<xt::xtensor<int, 2>>(file, "/path/to/B");

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -33,6 +33,33 @@
 #include <boost/mpl/list.hpp>
 #include <boost/test/unit_test.hpp>
 
+BOOST_AUTO_TEST_CASE(H5Easy_Compression)
+{
+    {
+        H5Easy::DumpOptions options(H5Easy::Compression::High);
+        BOOST_CHECK_EQUAL(options.compress(), true);
+        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 9);
+    }
+
+    {
+        H5Easy::DumpOptions options(H5Easy::Compression::Medium);
+        BOOST_CHECK_EQUAL(options.compress(), true);
+        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 5);
+    }
+
+    {
+        H5Easy::DumpOptions options(H5Easy::Compression::False);
+        BOOST_CHECK_EQUAL(options.compress(), false);
+        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 0);
+    }
+
+    {
+        H5Easy::DumpOptions options(H5Easy::Compression(8));
+        BOOST_CHECK_EQUAL(options.compress(), true);
+        BOOST_CHECK_EQUAL(options.getDeflateLevel(), 8);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(H5Easy_scalar)
 {
     H5Easy::File file("test.h5", H5Easy::File::Overwrite);

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -193,6 +193,23 @@ BOOST_AUTO_TEST_CASE(H5Easy_xarray)
     BOOST_CHECK_EQUAL(xt::allclose(A, A_r), true);
     BOOST_CHECK_EQUAL(xt::all(xt::equal(B, B_r)), true);
 }
+
+BOOST_AUTO_TEST_CASE(H5Easy_xtensor_compress)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    xt::xtensor<double, 2> A = 100. * xt::random::randn<double>({20, 5});
+    xt::xtensor<int, 2> B = A;
+
+    H5Easy::dump(file, "/path/to/A", A, H5Easy::Compression::High);
+    H5Easy::dump(file, "/path/to/B", B, H5Easy::Compression::High);
+
+    xt::xtensor<double,2> A_r = H5Easy::load<xt::xtensor<double,2>>(file, "/path/to/A");
+    xt::xtensor<int, 2> B_r = H5Easy::load<xt::xtensor<int, 2>>(file, "/path/to/B");
+
+    BOOST_CHECK_EQUAL(xt::allclose(A, A_r), true);
+    BOOST_CHECK_EQUAL(xt::all(xt::equal(B, B_r)), true);
+}
 #endif
 
 #ifdef H5_USE_EIGEN

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -149,14 +149,14 @@ BOOST_AUTO_TEST_CASE(H5Easy_Attribute_scalar)
     std::string c = "12345";
 
     H5Easy::dump(file, "/path/to/a", a);
-    H5Easy::dump_attr(file, "/path/to/a", "a", a);
-    H5Easy::dump_attr(file, "/path/to/a", "a", a, H5Easy::DumpMode::Overwrite);
-    H5Easy::dump_attr(file, "/path/to/a", "b", b);
-    H5Easy::dump_attr(file, "/path/to/a", "c", c);
+    H5Easy::dumpAttribute(file, "/path/to/a", "a", a);
+    H5Easy::dumpAttribute(file, "/path/to/a", "a", a, H5Easy::DumpMode::Overwrite);
+    H5Easy::dumpAttribute(file, "/path/to/a", "b", b);
+    H5Easy::dumpAttribute(file, "/path/to/a", "c", c);
 
-    double a_r = H5Easy::load_attr<double>(file, "/path/to/a", "a");
-    int b_r = H5Easy::load_attr<int>(file, "/path/to/a", "b");
-    std::string c_r = H5Easy::load_attr<std::string>(file, "/path/to/a", "c");
+    double a_r = H5Easy::loadAttribute<double>(file, "/path/to/a", "a");
+    int b_r = H5Easy::loadAttribute<int>(file, "/path/to/a", "b");
+    std::string c_r = H5Easy::loadAttribute<std::string>(file, "/path/to/a", "c");
 
     BOOST_CHECK_EQUAL(a == a_r, true);
     BOOST_CHECK_EQUAL(b == b_r, true);
@@ -269,11 +269,11 @@ BOOST_AUTO_TEST_CASE(H5Easy_Attribute_xtensor)
     xt::xtensor<int, 2> B = A;
 
     H5Easy::dump(file, "/path/to/A", A);
-    H5Easy::dump_attr(file, "/path/to/A", "A", A);
-    H5Easy::dump_attr(file, "/path/to/A", "B", B);
+    H5Easy::dumpAttribute(file, "/path/to/A", "A", A);
+    H5Easy::dumpAttribute(file, "/path/to/A", "B", B);
 
-    xt::xtensor<double,2> A_r = H5Easy::load_attr<xt::xtensor<double,2>>(file, "/path/to/A", "A");
-    xt::xtensor<int, 2> B_r = H5Easy::load_attr<xt::xtensor<int, 2>>(file, "/path/to/A", "B");
+    xt::xtensor<double,2> A_r = H5Easy::loadAttribute<xt::xtensor<double,2>>(file, "/path/to/A", "A");
+    xt::xtensor<int, 2> B_r = H5Easy::loadAttribute<xt::xtensor<int, 2>>(file, "/path/to/A", "B");
 
     BOOST_CHECK_EQUAL(xt::allclose(A, A_r), true);
     BOOST_CHECK_EQUAL(xt::all(xt::equal(B, B_r)), true);
@@ -412,11 +412,11 @@ BOOST_AUTO_TEST_CASE(H5Easy_Attribute_Eigen_MatrixX)
     Eigen::MatrixXi B = A.cast<int>();
 
     H5Easy::dump(file, "/path/to/A", A);
-    H5Easy::dump_attr(file, "/path/to/A", "A", A);
-    H5Easy::dump_attr(file, "/path/to/A", "B", B);
+    H5Easy::dumpAttribute(file, "/path/to/A", "A", A);
+    H5Easy::dumpAttribute(file, "/path/to/A", "B", B);
 
-    Eigen::MatrixXd A_r = H5Easy::load_attr<Eigen::MatrixXd>(file, "/path/to/A", "A");
-    Eigen::MatrixXi B_r = H5Easy::load_attr<Eigen::MatrixXi>(file, "/path/to/A", "B");
+    Eigen::MatrixXd A_r = H5Easy::loadAttribute<Eigen::MatrixXd>(file, "/path/to/A", "A");
+    Eigen::MatrixXi B_r = H5Easy::loadAttribute<Eigen::MatrixXi>(file, "/path/to/A", "B");
 
     BOOST_CHECK_EQUAL(A.isApprox(A_r), true);
     BOOST_CHECK_EQUAL(B.isApprox(B_r), true);

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -44,6 +44,7 @@ BOOST_AUTO_TEST_CASE(H5Easy_scalar)
     H5Easy::dump(file, "/path/to/a", a);
     H5Easy::dump(file, "/path/to/b", b);
     H5Easy::dump(file, "/path/to/c", c);
+    H5Easy::dump(file, "/path/to/c", c, H5Easy::DumpMode::Overwrite);
 
     double a_r = H5Easy::load<double>(file, "/path/to/a");
     int b_r = H5Easy::load<int>(file, "/path/to/b");
@@ -88,6 +89,28 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector2d)
     BOOST_CHECK_EQUAL(a == a_r, true);
 }
 
+BOOST_AUTO_TEST_CASE(H5Easy_vector2d_compression)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    using type = std::vector<std::vector<size_t>>;
+
+    type a(3);
+    a[0].push_back(0);
+    a[0].push_back(1);
+    a[1].push_back(2);
+    a[1].push_back(3);
+    a[2].push_back(4);
+    a[2].push_back(5);
+
+    H5Easy::dump(file, "/path/to/a", a, H5Easy::Compression::High);
+    H5Easy::dump(file, "/path/to/a", a, H5Easy::Compression::High, H5Easy::DumpMode::Overwrite);
+
+    type a_r = H5Easy::load<type>(file, "/path/to/a");
+
+    BOOST_CHECK_EQUAL(a == a_r, true);
+}
+
 BOOST_AUTO_TEST_CASE(H5Easy_vector3d)
 {
     H5Easy::File file("test.h5", H5Easy::File::Overwrite);
@@ -99,16 +122,16 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector3d)
     a[1].resize(2);
     a[2].resize(2);
 
-    a[0][0].push_back( 0);
-    a[0][0].push_back( 1);
-    a[0][1].push_back( 2);
-    a[0][1].push_back( 3);
-    a[1][0].push_back( 4);
-    a[1][0].push_back( 5);
-    a[1][1].push_back( 6);
-    a[1][1].push_back( 7);
-    a[2][0].push_back( 8);
-    a[2][0].push_back( 9);
+    a[0][0].push_back(0);
+    a[0][0].push_back(1);
+    a[0][1].push_back(2);
+    a[0][1].push_back(3);
+    a[1][0].push_back(4);
+    a[1][0].push_back(5);
+    a[1][1].push_back(6);
+    a[1][1].push_back(7);
+    a[2][0].push_back(8);
+    a[2][0].push_back(9);
     a[2][1].push_back(10);
     a[2][1].push_back(11);
 
@@ -202,6 +225,7 @@ BOOST_AUTO_TEST_CASE(H5Easy_xtensor_compress)
     xt::xtensor<int, 2> B = A;
 
     H5Easy::dump(file, "/path/to/A", A, H5Easy::Compression::High);
+    H5Easy::dump(file, "/path/to/A", A, H5Easy::Compression::High, H5Easy::DumpMode::Overwrite);
     H5Easy::dump(file, "/path/to/B", B, H5Easy::Compression::High);
 
     xt::xtensor<double,2> A_r = H5Easy::load<xt::xtensor<double,2>>(file, "/path/to/A");

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -250,9 +250,14 @@ BOOST_AUTO_TEST_CASE(H5Easy_xtensor_compress)
     xt::xtensor<double, 2> A = 100. * xt::random::randn<double>({20, 5});
     xt::xtensor<int, 2> B = A;
 
-    H5Easy::dump(file, "/path/to/A", A, H5Easy::Compression::High);
-    H5Easy::dump(file, "/path/to/A", A, H5Easy::Compression::High, H5Easy::DumpMode::Overwrite);
-    H5Easy::dump(file, "/path/to/B", B, H5Easy::Compression::High);
+    H5Easy::dump(file, "/path/to/A", A,
+        H5Easy::DumpOptions(H5Easy::Compression::High));
+
+    H5Easy::dump(file, "/path/to/A", A,
+        H5Easy::DumpOptions(H5Easy::Compression::High, H5Easy::DumpMode::Overwrite));
+
+    H5Easy::dump(file, "/path/to/B", B,
+        H5Easy::DumpOptions(H5Easy::Compression::High));
 
     xt::xtensor<double,2> A_r = H5Easy::load<xt::xtensor<double,2>>(file, "/path/to/A");
     xt::xtensor<int, 2> B_r = H5Easy::load<xt::xtensor<int, 2>>(file, "/path/to/B");

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -142,6 +142,29 @@ BOOST_AUTO_TEST_CASE(H5Easy_vector3d)
     BOOST_CHECK_EQUAL(a == a_r, true);
 }
 
+BOOST_AUTO_TEST_CASE(H5Easy_Attribute_scalar)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    double a = 1.2345;
+    int b = 12345;
+    std::string c = "12345";
+
+    H5Easy::dump(file, "/path/to/a", a);
+    H5Easy::dump_attr(file, "/path/to/a", "a", a);
+    H5Easy::dump_attr(file, "/path/to/a", "a", a, H5Easy::DumpMode::Overwrite);
+    H5Easy::dump_attr(file, "/path/to/a", "b", b);
+    H5Easy::dump_attr(file, "/path/to/a", "c", c);
+
+    double a_r = H5Easy::load_attr<double>(file, "/path/to/a", "a");
+    int b_r = H5Easy::load_attr<int>(file, "/path/to/a", "b");
+    std::string c_r = H5Easy::load_attr<std::string>(file, "/path/to/a", "c");
+
+    BOOST_CHECK_EQUAL(a == a_r, true);
+    BOOST_CHECK_EQUAL(b == b_r, true);
+    BOOST_CHECK_EQUAL(c == c_r, true);
+}
+
 #ifdef H5_USE_XTENSOR
 BOOST_AUTO_TEST_CASE(H5Easy_extend1d)
 {
@@ -230,6 +253,24 @@ BOOST_AUTO_TEST_CASE(H5Easy_xtensor_compress)
 
     xt::xtensor<double,2> A_r = H5Easy::load<xt::xtensor<double,2>>(file, "/path/to/A");
     xt::xtensor<int, 2> B_r = H5Easy::load<xt::xtensor<int, 2>>(file, "/path/to/B");
+
+    BOOST_CHECK_EQUAL(xt::allclose(A, A_r), true);
+    BOOST_CHECK_EQUAL(xt::all(xt::equal(B, B_r)), true);
+}
+
+BOOST_AUTO_TEST_CASE(H5Easy_Attribute_xtensor)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    xt::xtensor<double, 2> A = 100. * xt::random::randn<double>({20, 5});
+    xt::xtensor<int, 2> B = A;
+
+    H5Easy::dump(file, "/path/to/A", A);
+    H5Easy::dump_attr(file, "/path/to/A", "A", A);
+    H5Easy::dump_attr(file, "/path/to/A", "B", B);
+
+    xt::xtensor<double,2> A_r = H5Easy::load_attr<xt::xtensor<double,2>>(file, "/path/to/A", "A");
+    xt::xtensor<int, 2> B_r = H5Easy::load_attr<xt::xtensor<int, 2>>(file, "/path/to/A", "B");
 
     BOOST_CHECK_EQUAL(xt::allclose(A, A_r), true);
     BOOST_CHECK_EQUAL(xt::all(xt::equal(B, B_r)), true);
@@ -358,5 +399,23 @@ BOOST_AUTO_TEST_CASE(H5Easy_Eigen_Map)
     std::vector<int> A_r = H5Easy::load<std::vector<int>>(file, "/path/to/A");
 
     BOOST_CHECK_EQUAL(A == A_r, true);
+}
+
+BOOST_AUTO_TEST_CASE(H5Easy_Attribute_Eigen_MatrixX)
+{
+    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+
+    Eigen::MatrixXd A = 100. * Eigen::MatrixXd::Random(20, 5);
+    Eigen::MatrixXi B = A.cast<int>();
+
+    H5Easy::dump(file, "/path/to/A", A);
+    H5Easy::dump_attr(file, "/path/to/A", "A", A);
+    H5Easy::dump_attr(file, "/path/to/A", "B", B);
+
+    Eigen::MatrixXd A_r = H5Easy::load_attr<Eigen::MatrixXd>(file, "/path/to/A", "A");
+    Eigen::MatrixXi B_r = H5Easy::load_attr<Eigen::MatrixXi>(file, "/path/to/A", "B");
+
+    BOOST_CHECK_EQUAL(A.isApprox(A_r), true);
+    BOOST_CHECK_EQUAL(B.isApprox(B_r), true);
 }
 #endif


### PR DESCRIPTION
Allows a variable number of dump-settings (in arbitrary order): The original `H5Easy::DumpMode`, the new `H5Easy::Compression`, and other further other options.

Can you give feedback? @spacescientist @eudoxos 

Fixes https://github.com/BlueBrain/HighFive/issues/301
Fixes #340 