### PR TITLE
Use std::move in NRVO depending of version of GCC

### DIFF
--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -43,7 +43,11 @@ inline T Reference::dereference(const Object& location) const {
         HDF5ErrMapper::ToException<ReferenceException>(
             "Trying to dereference the wrong type");
     }
+#if defined __GNUC__ && __GNUC__ < 9
     return std::move(obj);
+#else
+    return obj;
+#endif
 }
 
 inline Object Reference::get_ref(const Object& location) const {


### PR DESCRIPTION
Because there is a cast:
- Before version 9, GCC warns if not used.
- After version 9, GCC warns if used.