### PR TITLE
optional documentation building in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ option(HIGHFIVE_USE_OPENCV "Enable OpenCV testing" ${USE_OPENCV})
 option(HIGHFIVE_UNIT_TESTS "Enable unit tests" ON)
 option(HIGHFIVE_EXAMPLES "Compile examples" ON)
 option(HIGHFIVE_PARALLEL_HDF5 "Enable Parallel HDF5 support" OFF)
-option(HIGHFIVE_DOC "Enable documentation building" ON)
+option(HIGHFIVE_BUILD_DOCS "Enable documentation building" ON)
 
 # In deplomyents we probably don't want/cant have dynamic dependencies
 option(HIGHFIVE_USE_INSTALL_DEPS "End applications by default use detected dependencies here" OFF)
@@ -115,6 +115,6 @@ if(HIGHFIVE_UNIT_TESTS)
   add_subdirectory(tests/unit)
 endif()
 
-if(HIGHFIVE_DOC)
+if(HIGHFIVE_BUILD_DOCS)
   add_subdirectory(doc)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(HIGHFIVE_USE_OPENCV "Enable OpenCV testing" ${USE_OPENCV})
 option(HIGHFIVE_UNIT_TESTS "Enable unit tests" ON)
 option(HIGHFIVE_EXAMPLES "Compile examples" ON)
 option(HIGHFIVE_PARALLEL_HDF5 "Enable Parallel HDF5 support" OFF)
+option(HIGHFIVE_DOC "Enable documentation building" ON)
 
 # In deplomyents we probably don't want/cant have dynamic dependencies
 option(HIGHFIVE_USE_INSTALL_DEPS "End applications by default use detected dependencies here" OFF)
@@ -114,5 +115,6 @@ if(HIGHFIVE_UNIT_TESTS)
   add_subdirectory(tests/unit)
 endif()
 
-add_subdirectory(doc)
-
+if(HIGHFIVE_DOC)
+  add_subdirectory(doc)
+endif()


### PR DESCRIPTION
* **problem**

  I use HighFive in another project with documentation that I build with "make doc".  But cmake complains a target "doc" already exists in HighFive.

* **solution** 

  With this PR one can disable HighFive documentation building with `set(HIGHFIVE_DOC OFF)` just before `add_subdirectory(/path/to/HighFive)`.