### PR TITLE
Move array_dims in the future manipulator

### DIFF
--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -59,7 +59,7 @@ inline void Attribute::read(T& array) const {
     static_assert(!std::is_const<typename std::remove_reference<T>::type>::value,
                   "read() requires a non-const array to read into");
     using element_type = typename details::type_of_array<T>::type;
-    const size_t dim_array = details::manipulator<T>::r_n_dims;
+    const size_t dim_array = details::inspector<T>::recursive_number_dimensions;
     DataSpace space = getSpace();
     DataSpace mem_space = getMemSpace();
 
@@ -102,7 +102,7 @@ inline void Attribute::read(T* array, const DataType& dtype) const {
 template <typename T>
 inline void Attribute::write(const T& buffer) {
     using element_type = typename details::type_of_array<T>::type;
-    const size_t dim_buffer = details::manipulator<T>::r_n_dims;
+    const size_t dim_buffer = details::inspector<T>::recursive_number_dimensions;
     DataSpace space = getSpace();
     DataSpace mem_space = getMemSpace();
 

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -59,7 +59,7 @@ inline void Attribute::read(T& array) const {
     static_assert(!std::is_const<typename std::remove_reference<T>::type>::value,
                   "read() requires a non-const array to read into");
     using element_type = typename details::type_of_array<T>::type;
-    const size_t dim_array = details::array_dims<T>::value;
+    const size_t dim_array = details::manipulator<T>::r_n_dims;
     DataSpace space = getSpace();
     DataSpace mem_space = getMemSpace();
 
@@ -102,7 +102,7 @@ inline void Attribute::read(T* array, const DataType& dtype) const {
 template <typename T>
 inline void Attribute::write(const T& buffer) {
     using element_type = typename details::type_of_array<T>::type;
-    const size_t dim_buffer = details::array_dims<T>::value;
+    const size_t dim_buffer = details::manipulator<T>::r_n_dims;
     DataSpace space = getSpace();
     DataSpace mem_space = getMemSpace();
 

--- a/include/highfive/bits/H5ConverterEigen_misc.hpp
+++ b/include/highfive/bits/H5ConverterEigen_misc.hpp
@@ -18,16 +18,13 @@ namespace details {
 //compute size for single Eigen Matrix
 template <typename T, int M, int N>
 inline size_t compute_total_size(const Eigen::Matrix<T,M,N>& matrix) {
-    return matrix.rows() * matrix.cols();
+    return static_cast<size_t>(matrix.rows()) * static_cast<size_t>(matrix.cols());
 }
 
 //compute size for  std::vector of Eigens
 template <typename T, int M, int N>
 inline size_t compute_total_size(const std::vector<Eigen::Matrix<T,M,N>>& vec) {
-    return std::accumulate(vec.begin(), vec.end(), size_t{0u},
-        [](size_t so_far, const Eigen::Matrix<T,M,N>& v) {
-            return so_far + static_cast<size_t>(v.rows()) * static_cast<size_t>(v.cols());
-        });
+    return vec.size() * compute_total_size(vec[0]);
 }
 
 #ifdef H5_USE_BOOST
@@ -40,16 +37,6 @@ inline size_t compute_total_size(const boost::multi_array<T, Dims>& vec) {
         });
 }
 #endif
-
-//compute total row size for std::vector of Eigens
-template <typename T, int M, int N>
-inline size_t compute_total_row_size(const std::vector<Eigen::Matrix<T,M,N>>& vec) {
-    return std::accumulate(vec.begin(), vec.end(), size_t{0u},
-        [](size_t so_far, const Eigen::Matrix<T,M,N>& v) {
-            return so_far + static_cast<size_t>(v.rows());
-        });
-}
-
 
 // apply conversion to eigen matrix
 template <typename T, int M, int N>
@@ -87,7 +74,7 @@ inline void vectors_to_single_buffer(const std::vector<Eigen::Matrix<T,M,N>>& ve
                                      const size_t current_dim,
                                      std::vector<T>& buffer) {
 
-    check_dimensions_vector(compute_total_row_size(vec), dims[current_dim], current_dim);
+    check_dimensions_vector(vec.size(), dims[current_dim], current_dim);
     for (const auto& k : vec) {
         std::copy(k.data(), k.data() + k.size(), std::back_inserter(buffer));
     }
@@ -101,7 +88,7 @@ struct data_converter<std::vector<Eigen::Matrix<T,M,N>>, void> {
 
     inline data_converter(const DataSpace& space)
         : _dims(space.getDimensions()), _space(space) {
-        assert(_dims.size() == 2);
+        assert(_dims.size() == 3);
     }
 
     inline T * transform_read(std::vector<MatrixTMN>& /* vec */) {
@@ -131,7 +118,7 @@ struct data_converter<std::vector<Eigen::Matrix<T,M,N>>, void> {
             throw DataSetException(ss.str());
         }
         else {
-            for (size_t i = 0; i < _dims[0] / static_cast<size_t>(M); ++i) {
+            for (size_t i = 0; i < _dims[0]; ++i) {
                 vec.emplace_back(Eigen::Map<MatrixTMN>(start, M, N));
                 start += M * N;
             }
@@ -151,7 +138,7 @@ struct data_converter<boost::multi_array<Eigen::Matrix<T, M, N>, Dims>, void> {
     inline data_converter(const DataSpace& space)
         : _dims(space.getDimensions())
         , _space(space) {
-        assert(_dims.size() == Dims);
+        assert(_dims.size() == Dims + 2);
     }
 
     inline T* transform_read(const MultiArrayEigen& /*array*/) {

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -179,9 +179,9 @@ inline AtomicType<std::complex<double> >::AtomicType() {
 // Other cases not supported. Fail early with a user message
 template <typename T>
 AtomicType<T>::AtomicType() {
-    static_assert(details::array_dims<T>::value == 0,
+    static_assert(details::manipulator<T>::r_n_dims == 0,
                   "Atomic types cant be arrays, except for char[] (fixed-len strings)");
-    static_assert(details::array_dims<T>::value > 0, "Type not supported");
+    static_assert(details::manipulator<T>::r_n_dims > 0, "Type not supported");
 }
 
 

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -179,9 +179,9 @@ inline AtomicType<std::complex<double> >::AtomicType() {
 // Other cases not supported. Fail early with a user message
 template <typename T>
 AtomicType<T>::AtomicType() {
-    static_assert(details::manipulator<T>::r_n_dims == 0,
+    static_assert(details::inspector<T>::recursive_number_dimensions == 0,
                   "Atomic types cant be arrays, except for char[] (fixed-len strings)");
-    static_assert(details::manipulator<T>::r_n_dims > 0, "Type not supported");
+    static_assert(details::inspector<T>::recursive_number_dimensions > 0, "Type not supported");
 }
 
 

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -199,12 +199,9 @@ DataSpace::From(const Eigen::Matrix<Value, M, N>&  mat ) {
 template <typename Value, int M, int N>
 inline DataSpace
 DataSpace::From(const std::vector<Eigen::Matrix<Value, M, N>>& vec) {
-    using elem_t = Eigen::Matrix<Value, M, N>;
     std::vector<size_t> dims{
-        std::accumulate(vec.begin(), vec.end(), size_t{0u},
-                        [](size_t so_far, const elem_t& v) {
-                            return so_far + static_cast<size_t>(v.rows());
-                        }),
+        vec.size(),
+        static_cast<size_t>(vec[0].rows()),
         static_cast<size_t>(vec[0].cols())};
     return DataSpace(dims);
 }
@@ -214,7 +211,8 @@ template <typename Value, int M, int N, size_t Dims>
 inline DataSpace DataSpace::
 From(const boost::multi_array<Eigen::Matrix<Value, M, N>, Dims>& vec) {
     std::vector<size_t> dims(vec.shape(), vec.shape() + Dims);
-    dims[Dims - 1] *= static_cast<size_t>(vec.origin()->rows() * vec.origin()->cols());
+    dims.push_back(static_cast<size_t>(vec.origin()->rows()));
+    dims.push_back(static_cast<size_t>(vec.origin()->cols()));
     return DataSpace(dims);
 }
 #endif

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -59,7 +59,7 @@ template <typename T>
 BufferInfo<T>::BufferInfo(const DataType& dtype)
     : is_fixed_len_string(dtype.isFixedLenStr())
     // In case we are using Fixed-len strings we need to subtract one dimension
-    , n_dimensions(details::array_dims<type_no_const>::value -
+    , n_dimensions(details::manipulator<type_no_const>::r_n_dims -
                    ((is_fixed_len_string && is_char_array) ? 1 : 0))
     , data_type(string_type_checker<char_array_t>::getDataType(
             create_datatype<elem_type>(), is_fixed_len_string)) {

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -59,7 +59,7 @@ template <typename T>
 BufferInfo<T>::BufferInfo(const DataType& dtype)
     : is_fixed_len_string(dtype.isFixedLenStr())
     // In case we are using Fixed-len strings we need to subtract one dimension
-    , n_dimensions(details::manipulator<type_no_const>::r_n_dims -
+    , n_dimensions(details::inspector<type_no_const>::recursive_number_dimensions -
                    ((is_fixed_len_string && is_char_array) ? 1 : 0))
     , data_type(string_type_checker<char_array_t>::getDataType(
             create_datatype<elem_type>(), is_fixed_len_string)) {

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -38,62 +38,89 @@ class FixedLenStringArray;
 
 
 namespace details {
-
-// determine at compile time number of dimensions of in memory datasets
 template <typename T>
-struct array_dims {
-    static constexpr size_t value = 0;
+struct manipulator {
+    using type = T;
+
+    static const size_t n_dims = 0;
+    static const size_t r_n_dims = n_dims;
 };
 
-template <std::size_t N>
-struct array_dims<FixedLenStringArray<N>> {
-    static constexpr size_t value = 1;
-};
+template <size_t N>
+struct manipulator<FixedLenStringArray<N>> {
+    using type = FixedLenStringArray<N>;
 
-template <typename T>
-struct array_dims<std::vector<T> > {
-    static constexpr size_t value = 1 + array_dims<T>::value;
-};
-
-template <typename T>
-struct array_dims<T*> {
-    static constexpr size_t value = 1 + array_dims<T>::value;
-};
-
-template <typename T, std::size_t N>
-struct array_dims<T[N]> {
-    static constexpr size_t value = 1 + array_dims<T>::value;
-};
-
-// Only supporting 1D arrays at the moment
-template<typename T, std::size_t N>
-struct array_dims<std::array<T,N>> {
-    static constexpr size_t value = 1 + array_dims<T>::value;
-};
-
-#ifdef H5_USE_BOOST
-template <typename T, std::size_t Dims>
-struct array_dims<boost::multi_array<T, Dims> > {
-    static constexpr size_t value = Dims;
+    static const size_t n_dims = 1;
+    static const size_t r_n_dims = n_dims;
 };
 
 template <typename T>
-struct array_dims<boost::numeric::ublas::matrix<T> > {
-    static constexpr size_t value = 2;
+struct manipulator<std::vector<T>> {
+    using type = std::vector<T>;
+    using value_type = T;
+
+    static const size_t n_dims = 1;
+    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
 };
-#endif
+
+template <typename T>
+struct manipulator<T*> {
+    using type = T*;
+    using value_type = T;
+
+    static const size_t n_dims = 1;
+    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+};
+
+template <typename T, size_t N>
+struct manipulator<T[N]> {
+    using type = T[N];
+    using value_type = T;
+
+    static const size_t n_dims = 1;
+    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+};
+
+template <typename T, size_t N>
+struct manipulator<std::array<T, N>> {
+    using type = std::array<T, N>;
+    using value_type = T;
+
+    static const size_t n_dims = 1;
+    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+};
 
 #ifdef H5_USE_EIGEN
-template<typename T, int M, int N>
-struct array_dims<Eigen::Matrix<T, M, N>> {
-    static constexpr size_t value = 2;
-};
+template <typename T, int M, int N>
+struct manipulator<Eigen::Matrix<T, M, N>> {
+    using type = Eigen::Matrix<T, M, N>;
+    using value_type = T;
 
-template<typename T, int M, int N>
-struct array_dims<std::vector<Eigen::Matrix<T, M, N>>> {
-    static constexpr size_t value = 2;
+    static const size_t n_dims = 2;
+    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
 };
 #endif
+
+#ifdef H5_USE_BOOST
+template <typename T, size_t Dims>
+struct manipulator<boost::multi_array<T, Dims>> {
+    using type = boost::multi_array<T, Dims>;
+    using value_type = T;
+
+    static const size_t n_dims = Dims;
+    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+};
+
+template <typename T>
+struct manipulator<boost::numeric::ublas::matrix<T>> {
+    using type = boost::numeric::ublas::matrix<T>;
+    using value_type = T;
+
+    static const size_t n_dims = 2;
+    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+};
+#endif
+
 
 // determine recursively the size of each dimension of a N dimension vector
 template <typename T>

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -39,85 +39,85 @@ class FixedLenStringArray;
 
 namespace details {
 template <typename T>
-struct manipulator {
+struct inspector {
     using type = T;
 
-    static const size_t n_dims = 0;
-    static const size_t r_n_dims = n_dims;
+    static constexpr size_t number_dimensions = 0;
+    static constexpr size_t recursive_number_dimensions = number_dimensions;
 };
 
 template <size_t N>
-struct manipulator<FixedLenStringArray<N>> {
+struct inspector<FixedLenStringArray<N>> {
     using type = FixedLenStringArray<N>;
 
-    static const size_t n_dims = 1;
-    static const size_t r_n_dims = n_dims;
+    static constexpr size_t number_dimensions = 1;
+    static constexpr size_t recursive_number_dimensions = number_dimensions;
 };
 
 template <typename T>
-struct manipulator<std::vector<T>> {
+struct inspector<std::vector<T>> {
     using type = std::vector<T>;
     using value_type = T;
 
-    static const size_t n_dims = 1;
-    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+    static constexpr size_t number_dimensions = 1;
+    static constexpr size_t recursive_number_dimensions = number_dimensions + inspector<value_type>::recursive_number_dimensions;
 };
 
 template <typename T>
-struct manipulator<T*> {
+struct inspector<T*> {
     using type = T*;
     using value_type = T;
 
-    static const size_t n_dims = 1;
-    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+    static constexpr size_t number_dimensions = 1;
+    static constexpr size_t recursive_number_dimensions = number_dimensions + inspector<value_type>::recursive_number_dimensions;
 };
 
 template <typename T, size_t N>
-struct manipulator<T[N]> {
+struct inspector<T[N]> {
     using type = T[N];
     using value_type = T;
 
-    static const size_t n_dims = 1;
-    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+    static constexpr size_t number_dimensions = 1;
+    static constexpr size_t recursive_number_dimensions = number_dimensions + inspector<value_type>::recursive_number_dimensions;
 };
 
 template <typename T, size_t N>
-struct manipulator<std::array<T, N>> {
+struct inspector<std::array<T, N>> {
     using type = std::array<T, N>;
     using value_type = T;
 
-    static const size_t n_dims = 1;
-    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+    static constexpr size_t number_dimensions = 1;
+    static constexpr size_t recursive_number_dimensions = number_dimensions + inspector<value_type>::recursive_number_dimensions;
 };
 
 #ifdef H5_USE_EIGEN
 template <typename T, int M, int N>
-struct manipulator<Eigen::Matrix<T, M, N>> {
+struct inspector<Eigen::Matrix<T, M, N>> {
     using type = Eigen::Matrix<T, M, N>;
     using value_type = T;
 
-    static const size_t n_dims = 2;
-    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+    static constexpr size_t number_dimensions = 2;
+    static constexpr size_t recursive_number_dimensions = number_dimensions + inspector<value_type>::recursive_number_dimensions;
 };
 #endif
 
 #ifdef H5_USE_BOOST
 template <typename T, size_t Dims>
-struct manipulator<boost::multi_array<T, Dims>> {
+struct inspector<boost::multi_array<T, Dims>> {
     using type = boost::multi_array<T, Dims>;
     using value_type = T;
 
-    static const size_t n_dims = Dims;
-    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+    static constexpr size_t number_dimensions = Dims;
+    static constexpr size_t recursive_number_dimensions = number_dimensions + inspector<value_type>::recursive_number_dimensions;
 };
 
 template <typename T>
-struct manipulator<boost::numeric::ublas::matrix<T>> {
+struct inspector<boost::numeric::ublas::matrix<T>> {
     using type = boost::numeric::ublas::matrix<T>;
     using value_type = T;
 
-    static const size_t n_dims = 2;
-    static const size_t r_n_dims = n_dims + manipulator<value_type>::r_n_dims;
+    static constexpr size_t number_dimensions = 2;
+    static constexpr size_t recursive_number_dimensions = number_dimensions + inspector<value_type>::recursive_number_dimensions;
 };
 #endif
 


### PR DESCRIPTION
Fix vector<Eigen::Matrix> and boost::multi_array<Eigen::Matrix>, from now
Eigen::Matrix has 2 dimensions and no more 1 with hackish things.