### PR TITLE
Add Reference and std::string inside inspector

### DIFF
--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -21,6 +21,9 @@
 
 namespace HighFive {
 
+template <typename T>
+struct inspector {};
+
 ///
 /// \brief An HDF5 (object) reference type
 ///

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -72,7 +72,7 @@ class Reference {
     std::string obj_name{};
     hid_t parent_id{};
 
-    friend details::inspector<Reference>;
+    friend class details::inspector<Reference>;
 };
 
 }  // namespace HighFive

--- a/include/highfive/H5Reference.hpp
+++ b/include/highfive/H5Reference.hpp
@@ -72,7 +72,7 @@ class Reference {
     std::string obj_name{};
     hid_t parent_id{};
 
-    friend details::data_converter<std::vector<Reference>>;
+    friend details::inspector<Reference>;
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -64,6 +64,33 @@ inline Object Reference::get_ref(const Object& location) const {
     return Object(res);
 }
 
+namespace details {
+template <>
+struct inspector<Reference> {
+    using type = Reference;
+    using base_type = type;
+    using element_type = hobj_ref_t;
+
+    static constexpr size_t ndim = 0;
+    static constexpr size_t recursive_ndim = ndim;
+
+    static void to_file(const type& from, element_type* to) {
+        from.create_ref(to);
+    }
+
+    static void from_file(const element_type* from, type& to) {
+        to = Reference(*from);
+    }
+
+    static void resize(type&, const std::vector<size_t>&) {
+    }
+
+    static std::array<size_t, recursive_ndim> getDimensions(const type& /* val */) {
+        return std::array<size_t, recursive_ndim>();
+    }
+};
+}  // namespace details
+
 }  // namespace HighFive
 
 #endif  // H5REFERENCE_MISC_HPP


### PR DESCRIPTION
On this PR I will try to reduce the power of `data_converter`.

### Types inside inspector
I firstly have to add `element_type` for `std::string`.
Inside `inspector`:
* `type`: the type inspector is taking care.
* `value_type` (for container only), the next type to inspect.
* `base_type`: the type that will be given to `create_and_check_datatype`.
* `element_type`: the type that HDF5 want to manage.

`base_type` and `element_type` are recursive.

Example why we need `base_type` and `element_type`:
`std::string` is converted to Variable-length string inside HDF-5 by `create_and_check_datatype`, but to `read` or `write` them we need to give `const char*` variable.
So `base_type` is `std::string` and `element_type` is `const char*`.

### Storage
I add a class `storage` because in some `data_converter` (those which are not handling contiguous types) we need to store a continuous vector of `element_type`. All `data_converter` are handling those vectors differently so it's hard to write a generic `data_converter` based on `inspector`. This storage class will disappear in future.

### Inspectors and Storage
Currently we have specialization of `data_converter` for **each** type! (e.g.: `H5::Reference`, `std::vector<T>` and `std::vector<H5::Reference>`).
So this PR is trying to remove things from `data_converter` (not recursive) to put them inside `inspector` (recursive).
With the new storage we add members inside inspectors to move from type to the storage and from the storage to the type.