### PR TITLE
Undefine max macro on windows in order to compile with msvc

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -16,6 +16,10 @@
 #include <H5Ppublic.h>
 #include <H5Tpublic.h>
 
+// undefine the macro on windows platform
+#ifdef _WIN32
+#undef max
+#endif
 
 namespace HighFive {
 


### PR DESCRIPTION
Windows MSVC may have max defined as a macro, undefine this macro to use the max function in std