### PR TITLE
Generalizing getPath and adding getFile as PathTraits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,30 +18,6 @@ addons: &gcc7
     sources:
       - ubuntu-toolchain-r-test
 
-addons: &clang6
-  apt:
-    packages:
-      - clang-6.0
-      - libboost-all-dev
-      - libhdf5-openmpi-dev
-      - libeigen3-dev
-      - ninja-build
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-xenial-6.0
-
-addons: &clang7
-  apt:
-    packages:
-      - clang-7
-      - libboost-all-dev
-      - libhdf5-openmpi-dev
-      - libeigen3-dev
-      - ninja-build
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-xenial-7
-
 matrix:
   include:
     # Older linux (trusty) with default gcc
@@ -72,26 +48,6 @@ matrix:
         - HIGHFIVE_PARALLEL_HDF5=True
       addons: *gcc7
 
-    # Linux clang-6.0
-    # Install parallel hdf5 + build serial
-    - os: linux
-      dist: xenial
-      env:
-        - CLANG_VERSION=6.0
-        - HIGHFIVE_PARALLEL_HDF5=False
-      addons: *clang6
-
-    # Linux clang-7
-    # Install parallel hdf5, build parallel
-    - os: linux
-      dist: xenial
-      env:
-        - CLANG_VERSION=7
-        - HIGHFIVE_USE_XTENSOR=True
-        - HIGHFIVE_USE_OPENCV=False
-        - HIGHFIVE_PARALLEL_HDF5=True
-      addons: *clang7
-
     # Mac OSX XCode 10
     - os: osx
       osx_image: xcode10.3
@@ -99,15 +55,6 @@ matrix:
         - HIGHFIVE_USE_XTENSOR=True
         - HIGHFIVE_USE_OPENCV=True
         - HIGHFIVE_PARALLEL_HDF5=False
-
-    # Mac OSX XCode 11
-    - os: osx
-      osx_image: xcode11.3
-      env:
-        - HIGHFIVE_USE_XTENSOR=True
-        - HIGHFIVE_USE_OPENCV=True
-        - HIGHFIVE_PARALLEL_HDF5=False
-        - BREW_USE_LATEST=1
 
     # Windows
     - os: windows

--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -85,10 +85,11 @@ class Attribute : public Object,
     template <typename T>
     void write_raw(const T* buffer, const DataType& dtype = DataType());
 
+    // No empty attributes
+    Attribute() = delete;
+
   private:
     using Object::Object;
-
-    Attribute() = default;
 
     template <typename Derivate> friend class ::HighFive::AnnotateTraits;
 };

--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -14,13 +14,15 @@
 #include "H5DataSpace.hpp"
 #include "H5DataType.hpp"
 #include "H5Object.hpp"
+#include "bits/H5Path_traits.hpp"
 
 namespace HighFive {
 
 ///
 /// \brief Class representing an attribute of a dataset or group
 ///
-class Attribute : public Object {
+class Attribute : public Object,
+                  public PathTraits<Attribute> {
   public:
 
     const static ObjectType type = ObjectType::Attribute;
@@ -84,6 +86,8 @@ class Attribute : public Object {
     void write_raw(const T* buffer, const DataType& dtype = DataType());
 
   private:
+    using Object::Object;
+
     Attribute() = default;
 
     template <typename Derivate> friend class ::HighFive::AnnotateTraits;

--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -17,6 +17,7 @@
 #include "bits/H5_definitions.hpp"
 #include "bits/H5Annotate_traits.hpp"
 #include "bits/H5Slice_traits.hpp"
+#include "bits/H5Path_traits.hpp"
 #include "bits/H5_definitions.hpp"
 
 namespace HighFive {
@@ -26,15 +27,11 @@ namespace HighFive {
 ///
 class DataSet : public Object,
                 public SliceTraits<DataSet>,
-                public AnnotateTraits<DataSet> {
+                public AnnotateTraits<DataSet>,
+                public PathTraits<DataSet> {
   public:
 
     const static ObjectType type = ObjectType::Dataset;
-
-    ///
-    /// \brief return the path to the current dataset
-    /// \return the path to the dataset
-    std::string getPath() const;
 
     ///
     /// \brief getStorageSize

--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -90,10 +90,13 @@ class DataSet : public Object,
         return getSpace().getElementCount();
     }
 
-  protected:
-    using Object::Object;
+    // No empty datasets
+    DataSet() = delete;
 
-    inline DataSet(Object&& o) noexcept : Object(std::move(o)) {}
+  protected:
+    using Object::Object;  // bring DataSet(hid_t)
+
+    DataSet(Object&& o) noexcept : Object(std::move(o)) {}
 
     friend class Reference;
     template <typename Derivate> friend class NodeTraits;

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -62,6 +62,12 @@ class File : public Object,
     ///
     const std::string& getName() const noexcept;
 
+
+    /// \bried Object path of a File is always "/"
+    std::string getPath() const noexcept {
+        return "/";
+    }
+
     ///
     /// \brief flush
     ///
@@ -70,7 +76,11 @@ class File : public Object,
     void flush();
 
  private:
+    using Object::Object;
+
     std::string _filename;
+
+    template <typename> friend class PathTraits;
 };
 
 }  // namespace HighFive
@@ -79,5 +89,6 @@ class File : public Object,
 #include "bits/H5Annotate_traits_misc.hpp"
 #include "bits/H5File_misc.hpp"
 #include "bits/H5Node_traits_misc.hpp"
+#include "bits/H5Path_traits_misc.hpp"
 
 #endif  // H5FILE_HPP

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -13,6 +13,7 @@
 #include "bits/H5_definitions.hpp"
 #include "bits/H5Annotate_traits.hpp"
 #include "bits/H5Node_traits.hpp"
+#include "bits/H5Path_traits.hpp"
 
 namespace HighFive {
 
@@ -20,7 +21,8 @@ namespace HighFive {
 /// \brief Represents an hdf5 group
 class Group : public Object,
               public NodeTraits<Group>,
-              public AnnotateTraits<Group> {
+              public AnnotateTraits<Group>,
+              public PathTraits<Group> {
   public:
     const static ObjectType type = ObjectType::Group;
 

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -26,10 +26,13 @@ class Group : public Object,
   public:
     const static ObjectType type = ObjectType::Group;
 
+    // No empty groups
+    Group() = delete;
+
   protected:
     using Object::Object;
 
-    inline Group(Object&& o) noexcept : Object(std::move(o)) {};
+    Group(Object&& o) noexcept : Object(std::move(o)) {};
 
     friend class File;
     friend class Reference;

--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -63,6 +63,11 @@ class Object {
     ///
     ObjectType getType() const;
 
+    // Check if refer to same object
+    bool operator==(const Object& other) const noexcept {
+        return _hid == other._hid;
+    }
+
   protected:
     // empty constructor
     Object();
@@ -76,6 +81,7 @@ class Object {
     // Init with an low-level object id
     explicit Object(hid_t);
 
+    // Copy-Assignment operator
     Object& operator=(const Object& other);
 
     hid_t _hid;

--- a/include/highfive/bits/H5Annotate_traits_misc.hpp
+++ b/include/highfive/bits/H5Annotate_traits_misc.hpp
@@ -25,14 +25,14 @@ inline Attribute
 AnnotateTraits<Derivate>::createAttribute(const std::string& attribute_name,
                                           const DataSpace& space,
                                           const DataType& dtype) {
-    Attribute attribute;
-    if ((attribute._hid = H5Acreate2(
-             static_cast<Derivate*>(this)->getId(), attribute_name.c_str(),
-             dtype._hid, space._hid, H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+    auto attr_id = H5Acreate2(static_cast<Derivate*>(this)->getId(),
+                              attribute_name.c_str(),
+                              dtype._hid, space._hid, H5P_DEFAULT, H5P_DEFAULT);
+    if (attr_id < 0) {
         HDF5ErrMapper::ToException<AttributeException>(
             std::string("Unable to create the attribute \"") + attribute_name + "\":");
     }
-    return attribute;
+    return Attribute(attr_id);
 }
 
 template <typename Derivate>
@@ -49,7 +49,7 @@ inline Attribute
 AnnotateTraits<Derivate>::createAttribute(const std::string& attribute_name,
                                           const T& data) {
     Attribute att = createAttribute(
-        attribute_name, 
+        attribute_name,
         DataSpace::From(data),
         create_and_check_datatype<typename details::inspector<T>::base_type>());
     att.write(data);
@@ -68,14 +68,13 @@ AnnotateTraits<Derivate>::deleteAttribute(const std::string& attribute_name) {
 template <typename Derivate>
 inline Attribute AnnotateTraits<Derivate>::getAttribute(
     const std::string& attribute_name) const {
-    Attribute attribute;
-    if ((attribute._hid = H5Aopen(static_cast<const Derivate*>(this)->getId(),
-                                  attribute_name.c_str(), H5P_DEFAULT)) < 0) {
+    const auto attr_id = H5Aopen(static_cast<const Derivate*>(this)->getId(),
+                                 attribute_name.c_str(), H5P_DEFAULT);
+    if (attr_id < 0) {
         HDF5ErrMapper::ToException<AttributeException>(
-            std::string("Unable to open the attribute \"") + attribute_name +
-            "\":");
+            std::string("Unable to open the attribute \"") + attribute_name + "\":");
     }
-    return attribute;
+    return Attribute(attr_id);
 }
 
 template <typename Derivate>

--- a/include/highfive/bits/H5DataSet_misc.hpp
+++ b/include/highfive/bits/H5DataSet_misc.hpp
@@ -26,12 +26,6 @@
 
 namespace HighFive {
 
-inline std::string DataSet::getPath() const {
-    return details::get_name([&](char *buffer, hsize_t length) {
-        return H5Iget_name(_hid, buffer, length);
-    });
-}
-
 inline uint64_t DataSet::getStorageSize() const {
     return H5Dget_storage_size(_hid);
 }

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -113,11 +113,6 @@ class NodeTraits {
     std::string getObjectName(size_t index) const;
 
     ///
-    /// \brief return the path to the current object
-    /// \return the path to the object
-    std::string getPath() const;
-
-    ///
     /// \brief moves an object and its content within an HDF5 file.
     /// \param src_path relative path of the object to current File/Group
     /// \param dest_path new relative path of the object to current File/Group

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -151,13 +151,6 @@ inline std::string NodeTraits<Derivate>::getObjectName(size_t index) const {
 }
 
 template <typename Derivate>
-inline std::string NodeTraits<Derivate>::getPath() const {
-    return details::get_name([&](char* buffer, hsize_t length) {
-        return H5Iget_name(static_cast<const Derivate*>(this)->getId(), buffer, length);
-    });
-}
-
-template <typename Derivate>
 inline bool NodeTraits<Derivate>::rename(const std::string& src_path,
                                          const std::string& dst_path, bool parents) const {
     RawPropertyList<PropertyType::LINK_CREATE> lcpl;

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -38,15 +38,14 @@ NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                     const DataType& dtype,
                                     const DataSetCreateProps& createProps,
                                     const DataSetAccessProps& accessProps) {
-    DataSet ds{H5Dcreate2(static_cast<Derivate*>(this)->getId(),
-                          dataset_name.c_str(), dtype._hid, space._hid,
-                          H5P_DEFAULT, createProps.getId(), accessProps.getId())};
-    if (ds._hid  < 0) {
+    const auto hid = H5Dcreate2(static_cast<Derivate*>(this)->getId(),
+                                dataset_name.c_str(), dtype._hid, space._hid,
+                                H5P_DEFAULT, createProps.getId(), accessProps.getId());
+    if (hid < 0) {
         HDF5ErrMapper::ToException<DataSetException>(
-            std::string("Unable to create the dataset \"") + dataset_name +
-            "\":");
+            std::string("Unable to create the dataset \"") + dataset_name + "\":");
     }
-    return ds;
+    return DataSet(hid);
 }
 
 template <typename Derivate>
@@ -55,8 +54,7 @@ inline DataSet
 NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                     const DataSpace& space,
                                     const DataSetCreateProps& createProps,
-                                    const DataSetAccessProps& accessProps)
-{
+                                    const DataSetAccessProps& accessProps) {
     return createDataSet(dataset_name, space,
                          create_and_check_datatype<Type>(),
                          createProps, accessProps);
@@ -94,13 +92,13 @@ template <typename Derivate>
 inline DataSet
 NodeTraits<Derivate>::getDataSet(const std::string& dataset_name,
                                  const DataSetAccessProps& accessProps) const {
-    DataSet ds{H5Dopen2(static_cast<const Derivate*>(this)->getId(),
-                        dataset_name.c_str(), accessProps.getId())};
-    if (ds._hid < 0) {
+    const auto hid = H5Dopen2(static_cast<const Derivate*>(this)->getId(),
+                              dataset_name.c_str(), accessProps.getId());
+    if (hid < 0) {
         HDF5ErrMapper::ToException<DataSetException>(
             std::string("Unable to open the dataset \"") + dataset_name + "\":");
     }
-    return ds;
+    return DataSet(hid);
 }
 
 template <typename Derivate>
@@ -110,25 +108,25 @@ inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name,
     if (parents) {
         lcpl.add(H5Pset_create_intermediate_group, 1u);
     }
-    Group group{H5Gcreate2(static_cast<Derivate*>(this)->getId(),
-                           group_name.c_str(), lcpl.getId(), H5P_DEFAULT, H5P_DEFAULT)};
-    if (group._hid < 0) {
+    const auto hid = H5Gcreate2(static_cast<Derivate*>(this)->getId(),
+                                group_name.c_str(), lcpl.getId(), H5P_DEFAULT, H5P_DEFAULT);
+    if (hid < 0) {
         HDF5ErrMapper::ToException<GroupException>(
             std::string("Unable to create the group \"") + group_name + "\":");
     }
-    return group;
+    return Group(hid);
 }
 
 template <typename Derivate>
 inline Group
 NodeTraits<Derivate>::getGroup(const std::string& group_name) const {
-    Group group{H5Gopen2(static_cast<const Derivate*>(this)->getId(),
-                         group_name.c_str(), H5P_DEFAULT)};
-    if (group._hid < 0) {
+    const auto hid = H5Gopen2(static_cast<const Derivate*>(this)->getId(),
+                              group_name.c_str(), H5P_DEFAULT);
+    if (hid < 0) {
         HDF5ErrMapper::ToException<GroupException>(
             std::string("Unable to open the group \"") + group_name + "\":");
     }
-    return group;
+    return Group(hid);
 }
 
 template <typename Derivate>
@@ -271,9 +269,9 @@ inline ObjectType NodeTraits<Derivate>::getObjectType(const std::string& node_na
 template <typename Derivate>
 inline Object NodeTraits<Derivate>::_open(const std::string& node_name,
                                           const DataSetAccessProps& accessProps) const {
-    hid_t id = H5Oopen(static_cast<const Derivate*>(this)->getId(),
-                       node_name.c_str(),
-                       accessProps.getId());
+   const auto id = H5Oopen(static_cast<const Derivate*>(this)->getId(),
+                           node_name.c_str(),
+                           accessProps.getId());
     if (id < 0) {
         HDF5ErrMapper::ToException<GroupException>(
             std::string("Unable to open \"") + node_name + "\":");

--- a/include/highfive/bits/H5Path_traits.hpp
+++ b/include/highfive/bits/H5Path_traits.hpp
@@ -1,0 +1,31 @@
+
+#pragma once
+
+#include "H5_definitions.hpp"
+
+
+namespace HighFive {
+
+template <typename Derivate>
+class PathTraits {
+
+public:
+    PathTraits();
+
+    ///
+    /// \brief return the path to the current object
+    /// \return the path to the object
+    std::string getPath() const;
+
+    ///
+    /// \brief Return a reference to the File object this object belongs
+    /// \return the File object ref
+    File& getFile() const noexcept;
+
+
+protected:
+    std::shared_ptr<File> _file_obj;  // keep a ref to file so we keep its ref count > 0
+
+};
+
+} // namespace HighFive

--- a/include/highfive/bits/H5Path_traits.hpp
+++ b/include/highfive/bits/H5Path_traits.hpp
@@ -1,8 +1,14 @@
-
+/*
+ *  Copyright (c), 2020, EPFL - Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
 #pragma once
 
 #include "H5_definitions.hpp"
-
 
 namespace HighFive {
 

--- a/include/highfive/bits/H5Path_traits_misc.hpp
+++ b/include/highfive/bits/H5Path_traits_misc.hpp
@@ -1,0 +1,29 @@
+#include <H5Ipublic.h>
+
+#include "H5Utils.hpp"
+#include "H5Path_traits.hpp"
+
+namespace HighFive{
+
+template <typename Derivate>
+inline PathTraits<Derivate>::PathTraits() {
+    const hid_t hid = static_cast<Derivate*>(this)->getId();
+    hid_t file_id = H5Iget_file_id(hid);
+    if (file_id > 0 and file_id != hid) {
+        _file_obj.reset(new File(file_id));
+    }
+}
+
+template <typename Derivate>
+inline std::string PathTraits<Derivate>::getPath() const {
+    return details::get_name([this](char* buffer, hsize_t length) {
+        return H5Iget_name(static_cast<const Derivate*>(this)->getId(), buffer, length);
+    });
+}
+
+template <typename Derivate>
+inline File& PathTraits<Derivate>::getFile() const noexcept {
+    return *_file_obj;
+}
+
+}  // namespace HighFive

--- a/include/highfive/bits/H5Path_traits_misc.hpp
+++ b/include/highfive/bits/H5Path_traits_misc.hpp
@@ -1,3 +1,13 @@
+/*
+ *  Copyright (c), 2020, EPFL - Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#pragma once
+
 #include <H5Ipublic.h>
 
 #include "H5Utils.hpp"

--- a/include/highfive/bits/H5Path_traits_misc.hpp
+++ b/include/highfive/bits/H5Path_traits_misc.hpp
@@ -7,11 +7,17 @@ namespace HighFive{
 
 template <typename Derivate>
 inline PathTraits<Derivate>::PathTraits() {
-    const hid_t hid = static_cast<Derivate*>(this)->getId();
-    hid_t file_id = H5Iget_file_id(hid);
-    if (file_id > 0 and file_id != hid) {
-        _file_obj.reset(new File(file_id));
+    static_assert(std::is_same<Derivate, Group>::value
+                  || std::is_same<Derivate, DataSet>::value
+                  || std::is_same<Derivate, Attribute>::value,
+                  "PathTraits can only be applied to Group, DataSet and Attribute");
+
+    const hid_t file_id = H5Iget_file_id(static_cast<Derivate*>(this)->getId());
+    if (file_id < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "getFile(): Could not obtain file of object");
     }
+    _file_obj.reset(new File(file_id));
 }
 
 template <typename Derivate>

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1226,6 +1226,17 @@ BOOST_AUTO_TEST_CASE(HighFiveGetPath) {
     BOOST_CHECK_EQUAL("/group", group.getPath());
     BOOST_CHECK_EQUAL("/group/data", dataset.getPath());
     BOOST_CHECK_EQUAL("attribute", attribute.getName());
+    BOOST_CHECK_EQUAL("/group/data", attribute.getPath());
+
+    BOOST_CHECK(file == dataset.getFile());
+    BOOST_CHECK(file == attribute.getFile());
+
+    // Destroy file early (it should live inside Dataset/Group)
+    std::unique_ptr<File> f2(new File("getpath.h5"));
+    const auto& d2 = f2->getDataSet("/group/data");
+    f2.reset(nullptr);
+    BOOST_CHECK_EQUAL(d2.getFile().getPath(), "/");
+
 }
 
 BOOST_AUTO_TEST_CASE(HighFiveRename) {


### PR DESCRIPTION
**Problem**
1. `getFile()` would be useful to get back the file object from any Group/Dataset/Attribute.
2. `getPath` was duplicated in some entities.
3. With MPI-IO, closing a file invalidates open objects.

**This PR**
Addresses all three problems by creating a PathTraits class and applying it to Group, Dataset and Attribute.
Trait keeps a file obj ref so that it's count never drops to 0.

*Extra Required fixes*:
 - Impl `operator==` in object
 - Annotate Traits to not construct an empty `Attribute`, but use `Object(hid)` ctr instead
 - Drop Clang tests in Travis since we'r covering all of them in the new GitHub Actions CI. Kept only the very old systems tests 
