### PR TITLE
Add property CreateIntermediateGroup

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -74,11 +74,13 @@ class PropertyList {
     hid_t _hid;
 };
 
+typedef PropertyList<PropertyType::OBJECT_CREATE> ObjectCreateProps;
 typedef PropertyList<PropertyType::FILE_CREATE> FileCreateProps;
 typedef PropertyList<PropertyType::FILE_ACCESS> FileAccessProps ;
 typedef PropertyList<PropertyType::DATASET_CREATE> DataSetCreateProps;
 typedef PropertyList<PropertyType::DATASET_ACCESS> DataSetAccessProps;
 typedef PropertyList<PropertyType::DATASET_XFER> DataTransferProps;
+typedef PropertyList<PropertyType::LINK_CREATE> LinkCreateProps;
 
 ///
 /// RawPropertieLists are to be used when advanced H5 properties
@@ -153,6 +155,19 @@ class Caching {
     const size_t _numSlots;
     const size_t _cacheSize;
     const double _w0;
+};
+
+class CreateIntermediateGroup {
+  public:
+    explicit CreateIntermediateGroup(bool create)
+        : _create(create)
+    {}
+
+  private:
+    friend ObjectCreateProps;
+    friend LinkCreateProps;
+    void apply(hid_t hid) const;
+    const bool _create;
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -104,10 +104,9 @@ NodeTraits<Derivate>::getDataSet(const std::string& dataset_name,
 template <typename Derivate>
 inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name,
                                                bool parents) {
-    RawPropertyList<PropertyType::LINK_CREATE> lcpl;
-    if (parents) {
-        lcpl.add(H5Pset_create_intermediate_group, 1u);
-    }
+
+    LinkCreateProps lcpl;
+    lcpl.add(CreateIntermediateGroup(parents));
     const auto hid = H5Gcreate2(static_cast<Derivate*>(this)->getId(),
                                 group_name.c_str(), lcpl.getId(), H5P_DEFAULT, H5P_DEFAULT);
     if (hid < 0) {
@@ -151,10 +150,8 @@ inline std::string NodeTraits<Derivate>::getObjectName(size_t index) const {
 template <typename Derivate>
 inline bool NodeTraits<Derivate>::rename(const std::string& src_path,
                                          const std::string& dst_path, bool parents) const {
-    RawPropertyList<PropertyType::LINK_CREATE> lcpl;
-    if (parents) {
-        lcpl.add(H5Pset_create_intermediate_group, 1u);
-    }
+    LinkCreateProps lcpl;
+    lcpl.add(CreateIntermediateGroup(parents));
     herr_t status = H5Lmove(static_cast<const Derivate*>(this)->getId(), src_path.c_str(),
                             static_cast<const Derivate*>(this)->getId(), dst_path.c_str(), lcpl.getId(), H5P_DEFAULT);
     if (status < 0) {

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -149,6 +149,13 @@ inline void Caching::apply(const hid_t hid) const {
     }
 }
 
+inline void CreateIntermediateGroup::apply(const hid_t hid) const {
+    if (H5Pset_create_intermediate_group(hid, _create ? 1 : 0) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting property for create intermediate groups");
+    }
+}
+
 }  // namespace HighFive
 
 #endif  // H5PROPERTY_LIST_HPP


### PR DESCRIPTION
Add a new property in the high level class of properties.
As documented in https://support.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetCreateIntermediateGroup
This property let you decide if missing parent's groups should be created when creating a group or a dataset.
As it is already use internally, I though it was a good idea to add it.

This is to complete a bit : #419