### PR TITLE
Implementing getting the filename dynamically

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -78,7 +78,7 @@ class File : public Object,
  private:
     using Object::Object;
 
-    std::string _filename;
+    mutable std::string _filename{};
 
     template <typename> friend class PathTraits;
 };

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -14,6 +14,7 @@
 #include <H5Fpublic.h>
 
 #include "../H5Utility.hpp"
+#include "H5Utils.hpp"
 
 namespace HighFive {
 
@@ -39,9 +40,7 @@ inline unsigned convert_open_flag(unsigned openFlags) {
 
 
 inline File::File(const std::string& filename, unsigned openFlags,
-                  const FileAccessProps& fileAccessProps)
-    : _filename(filename) {
-
+                  const FileAccessProps& fileAccessProps) {
     openFlags = convert_open_flag(openFlags);
 
     unsigned createMode = openFlags & (H5F_ACC_TRUNC | H5F_ACC_EXCL);
@@ -56,7 +55,7 @@ inline File::File(const std::string& filename, unsigned openFlags,
         std::unique_ptr<SilenceHDF5> silencer;
         if (openOrCreate) silencer.reset(new SilenceHDF5());
 
-        _hid = H5Fopen(_filename.c_str(), openMode, fileAccessProps.getId());
+        _hid = H5Fopen(filename.c_str(), openMode, fileAccessProps.getId());
 
         if (isValid()) return;  // Done
 
@@ -65,25 +64,30 @@ inline File::File(const std::string& filename, unsigned openFlags,
             createMode = H5F_ACC_EXCL;
         } else {
             HDF5ErrMapper::ToException<FileException>(
-                std::string("Unable to open file " + _filename));
+                std::string("Unable to open file " + filename));
         }
     }
 
-    if ((_hid = H5Fcreate(_filename.c_str(), createMode, H5P_DEFAULT,
+    if ((_hid = H5Fcreate(filename.c_str(), createMode, H5P_DEFAULT,
                           fileAccessProps.getId())) < 0) {
         HDF5ErrMapper::ToException<FileException>(
-            std::string("Unable to create file " + _filename));
+            std::string("Unable to create file " + filename));
     }
 }
 
 inline const std::string& File::getName() const noexcept {
+    if (_filename.empty()) {
+        _filename = details::get_name([this](char* buffer, hsize_t length) {
+            return H5Fget_name(getId(), buffer, length);
+        });
+    }
     return _filename;
 }
 
 inline void File::flush() {
     if (H5Fflush(_hid, H5F_SCOPE_GLOBAL) < 0) {
         HDF5ErrMapper::ToException<FileException>(
-            std::string("Unable to flush file " + _filename));
+            std::string("Unable to flush file " + getName()));
     }
 }
 


### PR DESCRIPTION
**Description**

This enables recreating file objects and still being able to
call getName()
_filename becomes a cache variable, so we dont change API nor ABI

**Fixes**
Issue when recreating file object from any dataset/group ->getFile()

**How to test this?**
ctest (already covered, just reimplemented)
