### PR TITLE
Add option *parents* to createDataSet

### DIFF
--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -37,7 +37,8 @@ class NodeTraits {
                   const DataSpace& space,
                   const DataType& type,
                   const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps());
+                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  bool parents = true);
 
     ///
     /// \brief createDataSet create a new dataset in the current file with a
@@ -53,7 +54,8 @@ class NodeTraits {
     createDataSet(const std::string& dataset_name,
                   const DataSpace& space,
                   const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps());
+                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  bool parents = true);
 
     ///
     /// \brief createDataSet create a new dataset in the current file and
@@ -69,7 +71,8 @@ class NodeTraits {
     createDataSet(const std::string& dataset_name,
                   const T& data,
                   const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps());
+                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  bool parents = true);
 
 
     template <std::size_t N>
@@ -77,7 +80,8 @@ class NodeTraits {
     createDataSet(const std::string& dataset_name,
                   const FixedLenStringArray<N>& data,
                   const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps());
+                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  bool parents = true);
 
     ///
     /// \brief get an existing dataset in the current file

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -37,10 +37,13 @@ NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                     const DataSpace& space,
                                     const DataType& dtype,
                                     const DataSetCreateProps& createProps,
-                                    const DataSetAccessProps& accessProps) {
+                                    const DataSetAccessProps& accessProps,
+                                    bool parents) {
+    LinkCreateProps lcpl;
+    lcpl.add(CreateIntermediateGroup(parents));
     const auto hid = H5Dcreate2(static_cast<Derivate*>(this)->getId(),
                                 dataset_name.c_str(), dtype._hid, space._hid,
-                                H5P_DEFAULT, createProps.getId(), accessProps.getId());
+                                lcpl.getId(), createProps.getId(), accessProps.getId());
     if (hid < 0) {
         HDF5ErrMapper::ToException<DataSetException>(
             std::string("Unable to create the dataset \"") + dataset_name + "\":");
@@ -54,10 +57,11 @@ inline DataSet
 NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                     const DataSpace& space,
                                     const DataSetCreateProps& createProps,
-                                    const DataSetAccessProps& accessProps) {
+                                    const DataSetAccessProps& accessProps,
+                                    bool parents) {
     return createDataSet(dataset_name, space,
                          create_and_check_datatype<Type>(),
-                         createProps, accessProps);
+                         createProps, accessProps, parents);
 }
 
 template <typename Derivate>
@@ -66,11 +70,12 @@ inline DataSet
 NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                     const T& data,
                                     const DataSetCreateProps& createProps,
-                                    const DataSetAccessProps& accessProps) {
+                                    const DataSetAccessProps& accessProps,
+                                    bool parents) {
     DataSet ds = createDataSet(
         dataset_name, DataSpace::From(data),
         create_and_check_datatype<typename details::inspector<T>::base_type>(),
-        createProps, accessProps);
+        createProps, accessProps, parents);
     ds.write(data);
     return ds;
 }
@@ -81,9 +86,10 @@ inline DataSet
 NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                     const FixedLenStringArray<N>& data,
                                     const DataSetCreateProps& createProps,
-                                    const DataSetAccessProps& accessProps) {
+                                    const DataSetAccessProps& accessProps,
+                                    bool parents) {
     DataSet ds = createDataSet<char[N]>(
-        dataset_name, DataSpace(data.size()), createProps, accessProps);
+        dataset_name, DataSpace(data.size()), createProps, accessProps, parents);
     ds.write(data);
     return ds;
 }

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -15,25 +15,6 @@ namespace H5Easy {
 
 namespace detail {
 
-///
-/// Get the parent of a path.
-/// For example for ``path = "/path/to/dataset"`` this function returns
-/// ``"/path/to"``.
-///
-/// \param path path to a DataSet
-///
-/// \return group the path of the group above the DataSet
-inline std::string getParentName(const std::string& path) {
-    std::size_t idx = path.find_last_of("/\\");
-    if (idx == std::string::npos) {
-        return "/";
-    } else if (idx == 0) {
-        return "/";
-    } else {
-        return path.substr(0, idx);
-    }
-}
-
 // Generate error-stream and return "Exception" (not yet thrown).
 inline Exception error(const File& file,
                        const std::string& path,

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -41,6 +41,7 @@ inline std::string getParentName(const std::string& path) {
 /// \param file opened File
 /// \param path path of the DataSet
 ///
+H5_DEPRECATED("Deprecated since HighFive 2.3, use `parents` argument now.")
 inline void createGroupsToDataSet(File& file, const std::string& path) {
     std::string group_name = getParentName(path);
     if (!file.exist(group_name)) {
@@ -80,9 +81,8 @@ inline DataSet initDataset(File& file,
                            const DumpOptions& options)
 {
     if (!file.exist(path)) {
-        detail::createGroupsToDataSet(file, path);
         if (!options.compress() && !options.isChunked()) {
-            return file.createDataSet<T>(path, DataSpace(shape));
+            return file.createDataSet<T>(path, DataSpace(shape), {}, {}, true);
         } else {
             std::vector<hsize_t> chunks(shape.begin(), shape.end());
             if (options.isChunked()) {
@@ -97,7 +97,7 @@ inline DataSet initDataset(File& file,
                 props.add(Shuffle());
                 props.add(Deflate(options.getCompressionLevel()));
             }
-            return file.createDataSet<T>(path, DataSpace(shape), props);
+            return file.createDataSet<T>(path, DataSpace(shape), props, {}, true);
         }
     } else if (options.overwrite() && file.getObjectType(path) == ObjectType::Dataset) {
         DataSet dataset = file.getDataSet(path);
@@ -117,8 +117,7 @@ inline DataSet initScalarDataset(File& file,
                                  const DumpOptions& options)
 {
     if (!file.exist(path)) {
-        detail::createGroupsToDataSet(file, path);
-        return file.createDataSet<T>(path, DataSpace::From(data));
+        return file.createDataSet<T>(path, DataSpace::From(data), {}, {}, true);
     } else if (options.overwrite() && file.getObjectType(path) == ObjectType::Dataset) {
         DataSet dataset = file.getDataSet(path);
         if (dataset.getElementCount() != 1) {

--- a/include/highfive/h5easy_bits/H5Easy_misc.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_misc.hpp
@@ -34,21 +34,6 @@ inline std::string getParentName(const std::string& path) {
     }
 }
 
-///
-/// \brief Recursively create groups in an open HDF5 file such that a
-/// \a DataSet can be created (see ``getParentName``).
-///
-/// \param file opened File
-/// \param path path of the DataSet
-///
-H5_DEPRECATED("Deprecated since HighFive 2.3, use `parents` argument now.")
-inline void createGroupsToDataSet(File& file, const std::string& path) {
-    std::string group_name = getParentName(path);
-    if (!file.exist(group_name)) {
-        file.createGroup(group_name);
-    }
-}
-
 // Generate error-stream and return "Exception" (not yet thrown).
 inline Exception error(const File& file,
                        const std::string& path,

--- a/include/highfive/h5easy_bits/H5Easy_scalar.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_scalar.hpp
@@ -93,7 +93,6 @@ struct io_impl {
             return dataset;
         }
 
-        detail::createGroupsToDataSet(file, path);
         std::vector<size_t> shape = idx;
         const size_t unlim = DataSpace::UNLIMITED;
         std::vector<size_t> unlim_shape(idx.size(), unlim);
@@ -110,7 +109,7 @@ struct io_impl {
         DataSpace dataspace = DataSpace(shape, unlim_shape);
         DataSetCreateProps props;
         props.add(Chunking(chunks));
-        DataSet dataset = file.createDataSet(path, dataspace, AtomicType<T>(), props);
+        DataSet dataset = file.createDataSet(path, dataspace, AtomicType<T>(), props, {}, true);
         dataset.select(idx, ones).write(data);
         if (options.flush()) {
             file.flush();


### PR DESCRIPTION
This way the parents group can be created automatically if they don't exist.

Deprecate the function *createGroupsToDataSet* inside the easy part and stop using it internally