### PR TITLE
Fix for unexpected issue in HDF5 with ASCII reading

### DIFF
--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -42,9 +42,9 @@ inline static DataType getDataType(const DataType& element_type, const DataType&
     // TEMP. CHANGE: Ensure that the character set is properly configured to prevent
     // converter issues on HDF5 <=v1.12.0 when loading ASCII strings first.
     // See https://github.com/HDFGroup/hdf5/issues/544 for further information.
-    const auto dtype_cset = H5Tget_cset(dtype.getId());
-    if (H5Tget_class(element_type.getId()) == H5T_STRING && dtype_cset == H5T_CSET_ASCII) {
-        H5Tset_cset(element_type.getId(), dtype_cset);
+    if (H5Tget_class(element_type.getId()) == H5T_STRING &&
+        H5Tget_cset(dtype.getId()) == H5T_CSET_ASCII) {
+        H5Tset_cset(element_type.getId(), H5T_CSET_ASCII);
     }
     return element_type;
 }};
@@ -54,9 +54,8 @@ struct string_type_checker<char[FixedLen]> {
 inline static DataType getDataType(const DataType& element_type, const DataType& dtype) {
     DataType return_type = (dtype.isFixedLenStr()) ? AtomicType<char[FixedLen]>() : element_type;
     // TEMP. CHANGE: See string_type_checker<void> definition
-    const auto dtype_cset = H5Tget_cset(dtype.getId());
-    if (dtype_cset == H5T_CSET_ASCII) {
-        H5Tset_cset(return_type.getId(), dtype_cset);
+    if (H5Tget_cset(dtype.getId()) == H5T_CSET_ASCII) {
+        H5Tset_cset(return_type.getId(), H5T_CSET_ASCII);
     }
     return return_type;
 }};
@@ -68,9 +67,8 @@ inline static DataType getDataType(const DataType&, const DataType& dtype) {
         throw DataSetException("Can't output variable-length to fixed-length strings");
     // TEMP. CHANGE: See string_type_checker<void> definition
     DataType return_type = AtomicType<std::string>();
-    const auto dtype_cset = H5Tget_cset(dtype.getId());
-    if (dtype_cset == H5T_CSET_ASCII) {
-        H5Tset_cset(return_type.getId(), dtype_cset);
+    if (H5Tget_cset(dtype.getId()) == H5T_CSET_ASCII) {
+        H5Tset_cset(return_type.getId(), H5T_CSET_ASCII);
     }
     return return_type;
 }};

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -46,19 +46,19 @@ inline static DataType getDataType(const DataType& element_type, const DataType&
     if (H5Tget_class(element_type.getId()) == H5T_STRING && dtype_cset == H5T_CSET_ASCII) {
         H5Tset_cset(element_type.getId(), dtype_cset);
     }
-    return std::move(element_type);
+    return element_type;
 }};
 
 template <std::size_t FixedLen>
 struct string_type_checker<char[FixedLen]> {
 inline static DataType getDataType(const DataType& element_type, const DataType& dtype) {
-    auto return_type = (dtype.isFixedLenStr()) ? AtomicType<char[FixedLen]>() : element_type;
+    DataType return_type = (dtype.isFixedLenStr()) ? AtomicType<char[FixedLen]>() : element_type;
     // TEMP. CHANGE: See string_type_checker<void> definition
     const auto dtype_cset = H5Tget_cset(dtype.getId());
     if (dtype_cset == H5T_CSET_ASCII) {
         H5Tset_cset(return_type.getId(), dtype_cset);
     }
-    return std::move(return_type);
+    return return_type;
 }};
 
 template <>
@@ -67,12 +67,12 @@ inline static DataType getDataType(const DataType&, const DataType& dtype) {
     if (dtype.isFixedLenStr())
         throw DataSetException("Can't output variable-length to fixed-length strings");
     // TEMP. CHANGE: See string_type_checker<void> definition
-    auto return_type = AtomicType<std::string>();
+    DataType return_type = AtomicType<std::string>();
     const auto dtype_cset = H5Tget_cset(dtype.getId());
     if (dtype_cset == H5T_CSET_ASCII) {
         H5Tset_cset(return_type.getId(), dtype_cset);
     }
-    return std::move(return_type);
+    return return_type;
 }};
 
 template <typename T>

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include "H5Tpublic.h"
 #include "H5Utils.hpp"
 
 namespace HighFive {
@@ -32,27 +33,46 @@ struct BufferInfo {
 // details implementation
 template <typename SrcStrT>
 struct string_type_checker {
-    static DataType getDataType(const DataType&, bool);
+    static DataType getDataType(const DataType&, const DataType&);
 };
 
 template <>
 struct string_type_checker<void> {
-inline static DataType getDataType(const DataType& element_type, bool) {
-    return element_type;
+inline static DataType getDataType(const DataType& element_type, const DataType& dtype) {
+    // TEMP. CHANGE: Ensure that the character set is properly configured to prevent
+    // converter issues on HDF5 <=v1.12.0 when loading ASCII strings first.
+    // See https://github.com/HDFGroup/hdf5/issues/544 for further information.
+    const auto dtype_cset = H5Tget_cset(dtype.getId());
+    if (H5Tget_class(element_type.getId()) == H5T_STRING && dtype_cset == H5T_CSET_ASCII) {
+        H5Tset_cset(element_type.getId(), dtype_cset);
+    }
+    return std::move(element_type);
 }};
 
 template <std::size_t FixedLen>
 struct string_type_checker<char[FixedLen]> {
-inline static DataType getDataType(const DataType& element_type, bool ds_fixed_str) {
-    return ds_fixed_str ? AtomicType<char[FixedLen]>() : element_type;
+inline static DataType getDataType(const DataType& element_type, const DataType& dtype) {
+    auto return_type = (dtype.isFixedLenStr()) ? AtomicType<char[FixedLen]>() : element_type;
+    // TEMP. CHANGE: See string_type_checker<void> definition
+    const auto dtype_cset = H5Tget_cset(dtype.getId());
+    if (dtype_cset == H5T_CSET_ASCII) {
+        H5Tset_cset(return_type.getId(), dtype_cset);
+    }
+    return std::move(return_type);
 }};
 
 template <>
 struct string_type_checker<char*> {
-inline static DataType getDataType(const DataType&, bool ds_fixed_str) {
-    if (ds_fixed_str)
+inline static DataType getDataType(const DataType&, const DataType& dtype) {
+    if (dtype.isFixedLenStr())
         throw DataSetException("Can't output variable-length to fixed-length strings");
-    return AtomicType<std::string>();
+    // TEMP. CHANGE: See string_type_checker<void> definition
+    auto return_type = AtomicType<std::string>();
+    const auto dtype_cset = H5Tget_cset(dtype.getId());
+    if (dtype_cset == H5T_CSET_ASCII) {
+        H5Tset_cset(return_type.getId(), dtype_cset);
+    }
+    return std::move(return_type);
 }};
 
 template <typename T>
@@ -62,7 +82,7 @@ BufferInfo<T>::BufferInfo(const DataType& dtype)
     , n_dimensions(details::inspector<type_no_const>::recursive_ndim -
                    ((is_fixed_len_string && is_char_array) ? 1 : 0))
     , data_type(string_type_checker<char_array_t>::getDataType(
-            create_datatype<elem_type>(), is_fixed_len_string)) {
+            create_datatype<elem_type>(), dtype)) {
     if (is_fixed_len_string && std::is_same<elem_type, std::string>::value) {
         throw DataSetException("Can't output std::string as fixed-length. "
                                "Use raw arrays or FixedLenStringArray");


### PR DESCRIPTION
**Description**

When reading ASCII-based datasets without first accessing other datasets, HDF5 produces unexpected converter issues. The patch provides the following fixes:

- [x] Hides HDF5 string converter issues when memory and dataset types do not match, by forcing the character set of the strings to the one available in the dataset.

The issue was reported here https://github.com/BlueBrain/libsonata/issues/139.

**How to test this?**
Through `libsonata`, it can be easily tested with Python:

```python
import libsonata
filename = "/gpfs/bbp.cscs.ch/project/proj12/jenkins/cellular/circuit-1k/nodes.h5"
pop = libsonata.NodeStorage(filename).open_population("All")
pop.get_attribute('region', libsonata.Selection((1,2)) )
```

Alternatively, the following C++ source code example can be compiled as well:

```C++
vector<std::string> buffer;
HighFive::File file("/gpfs/bbp.cscs.ch/project/proj12/jenkins/cellular/circuit-1k/nodes.h5");
file.getDataSet("/nodes/All/0/@library/region").read(buffer);
```

Without the fix, HighFive will throw several exceptions.

**Test System**
 - OS: RHEL v7.6
 - Compiler: GCC 9.3.0
 - Dependency versions: Tested with HDF5 v1.10.7 and v1.12.0
