### PR TITLE
Cleaning up and improving property lists

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -55,7 +55,7 @@ class File : public Object,
     ///
     /// Open or create a new HDF5 file
     explicit File(const std::string& filename, unsigned openFlags = ReadOnly,
-                  const FileAccessProps& fileAccessProps = FileDriver());
+                  const FileAccessProps& fileAccessProps = FileAccessProps::Default());
 
     ///
     /// \brief Return the name of the file

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -21,7 +21,7 @@ class FileDriver : public FileAccessProps {};
 ///
 /// \brief MPIIO Driver for Parallel HDF5
 ///
-class MPIOFileDriver : public FileDriver {
+class MPIOFileDriver : public FileAccessProps {
   public:
     template <typename Comm, typename Info>
     inline MPIOFileDriver(Comm mpi_comm, Info mpi_info);

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -75,7 +75,7 @@ class PropertyList : public PropertyListBase {
     void add(const P& property);
 
     /// Return always the same Default property type object
-    static const auto& Default() {
+    static const PropertyList<T>& Default() {
         return static_cast<const PropertyList<T>&>(h5p_default);
     }
 

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -39,26 +39,32 @@ enum class PropertyType : int {
     LINK_ACCESS,
 };
 
+
 ///
-/// \brief Base HDF5 property List
+/// \brief Class Base for Property lists
+class PropertyListBase : public Object {
+
+  public:
+    PropertyListBase() noexcept;
+
+  protected:
+    static const PropertyListBase h5p_default;
+
+};
+
+
+///
+/// \brief HDF5 property Lists
 ///
 template <PropertyType T>
-class PropertyList {
+class PropertyList : public PropertyListBase {
   public:
-    ~PropertyList();
 
-    PropertyList(const PropertyList<T>&) = delete;
-    PropertyList& operator=(const PropertyList<T>&) = delete;
-    PropertyList(PropertyList&& other) noexcept;
-    PropertyList& operator=(PropertyList&& other) noexcept;
-    constexpr PropertyType getType() const { return T; }
-
-    hid_t getId() const { return _hid; }
-
-    PropertyList() noexcept;
-
-    template <typename P>
-    PropertyList(const std::initializer_list<P>&);
+    ///
+    /// \brief return the type of this PropertyList
+    constexpr PropertyType getType() const noexcept {
+        return T;
+    }
 
     ///
     /// Add a property to this property list.
@@ -68,10 +74,14 @@ class PropertyList {
     template <typename P>
     void add(const P& property);
 
+    /// Return always the same Default property type object
+    static const auto& Default() {
+        return static_cast<const PropertyList<T>&>(h5p_default);
+    }
+
   protected:
     void _initializeIfNeeded();
 
-    hid_t _hid;
 };
 
 typedef PropertyList<PropertyType::OBJECT_CREATE> ObjectCreateProps;
@@ -167,7 +177,7 @@ class Caching {
 
 class CreateIntermediateGroup {
   public:
-    explicit CreateIntermediateGroup(bool create)
+    explicit CreateIntermediateGroup(bool create=true)
         : _create(create)
     {}
 

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -41,14 +41,16 @@ enum class PropertyType : int {
 
 
 ///
-/// \brief Class Base for Property lists
+/// \brief Base Class for Property lists, providing global default
 class PropertyListBase : public Object {
 
   public:
     PropertyListBase() noexcept;
 
-  protected:
-    static const PropertyListBase h5p_default;
+    static const PropertyListBase& Default() noexcept {
+        static const PropertyListBase plist{};
+        return plist;
+    }
 
 };
 
@@ -74,9 +76,10 @@ class PropertyList : public PropertyListBase {
     template <typename P>
     void add(const P& property);
 
-    /// Return always the same Default property type object
-    static const PropertyList<T>& Default() {
-        return static_cast<const PropertyList<T>&>(h5p_default);
+    ///
+    /// Return the Default property type object
+    static const PropertyList<T>& Default() noexcept {
+        return static_cast<const PropertyList<T>&>(PropertyListBase::Default());
     }
 
   protected:

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -36,8 +36,8 @@ class NodeTraits {
     createDataSet(const std::string& dataset_name,
                   const DataSpace& space,
                   const DataType& type,
-                  const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  const DataSetCreateProps& createProps = DataSetCreateProps::Default(),
+                  const DataSetAccessProps& accessProps = DataSetAccessProps::Default(),
                   bool parents = true);
 
     ///
@@ -53,8 +53,8 @@ class NodeTraits {
     DataSet
     createDataSet(const std::string& dataset_name,
                   const DataSpace& space,
-                  const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  const DataSetCreateProps& createProps = DataSetCreateProps::Default(),
+                  const DataSetAccessProps& accessProps = DataSetAccessProps::Default(),
                   bool parents = true);
 
     ///
@@ -70,8 +70,8 @@ class NodeTraits {
     DataSet
     createDataSet(const std::string& dataset_name,
                   const T& data,
-                  const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  const DataSetCreateProps& createProps = DataSetCreateProps::Default(),
+                  const DataSetAccessProps& accessProps = DataSetAccessProps::Default(),
                   bool parents = true);
 
 
@@ -79,8 +79,8 @@ class NodeTraits {
     DataSet
     createDataSet(const std::string& dataset_name,
                   const FixedLenStringArray<N>& data,
-                  const DataSetCreateProps& createProps = DataSetCreateProps(),
-                  const DataSetAccessProps& accessProps = DataSetAccessProps(),
+                  const DataSetCreateProps& createProps = DataSetCreateProps::Default(),
+                  const DataSetAccessProps& accessProps = DataSetAccessProps::Default(),
                   bool parents = true);
 
     ///
@@ -90,7 +90,7 @@ class NodeTraits {
     /// \return return the named dataset, or throw exception if not found
     DataSet getDataSet(
         const std::string& dataset_name,
-        const DataSetAccessProps& accessProps = DataSetAccessProps()) const;
+        const DataSetAccessProps& accessProps = DataSetAccessProps::Default()) const;
 
     ///
     /// \brief create a new group, and eventually intermediate groups
@@ -162,7 +162,7 @@ class NodeTraits {
 
     // Opens an arbitrary object to obtain info
     Object _open(const std::string& node_name,
-                 const DataSetAccessProps& accessProps = DataSetAccessProps()) const;
+                 const DataSetAccessProps& accessProps = DataSetAccessProps::Default()) const;
 };
 
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -56,7 +56,6 @@ inline hid_t convert_plist_type(PropertyType propertyType) {
 
 }  // namespace
 
-const PropertyListBase PropertyListBase::h5p_default{};
 
 inline PropertyListBase::PropertyListBase() noexcept
     : Object(H5P_DEFAULT) {}

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -56,32 +56,11 @@ inline hid_t convert_plist_type(PropertyType propertyType) {
 
 }  // namespace
 
-template <PropertyType T>
-inline PropertyList<T>::PropertyList() noexcept
-    : _hid(H5P_DEFAULT) {}
+const PropertyListBase PropertyListBase::h5p_default{};
 
-template <PropertyType T>
-inline PropertyList<T>::PropertyList(PropertyList<T>&& other) noexcept
-    : _hid(other._hid) {
-    other._hid = H5P_DEFAULT;
-}
+inline PropertyListBase::PropertyListBase() noexcept
+    : Object(H5P_DEFAULT) {}
 
-template <PropertyType T>
-inline PropertyList<T>& PropertyList<T>::operator=(PropertyList<T>&& other) noexcept {
-    // This code handles self-assignment without ifs
-    const auto hid = other._hid;
-    other._hid = H5P_DEFAULT;
-    _hid = hid;
-    return *this;
-}
-
-template <PropertyType T>
-inline PropertyList<T>::~PropertyList() {
-    // H5P_DEFAULT and H5I_INVALID_HID are not the same Ensuring that ~Object
-    if (_hid != H5P_DEFAULT) {
-        H5Pclose(_hid);
-    }
-}
 
 template <PropertyType T>
 inline void PropertyList<T>::_initializeIfNeeded() {
@@ -111,6 +90,9 @@ inline void RawPropertyList<T>::add(const F& funct, const Args&... args) {
     }
 }
 
+
+// Specific options to be added to Property Lists
+
 inline void Chunking::apply(const hid_t hid) const {
     if (H5Pset_chunk(hid, static_cast<int>(_dims.size()), _dims.data()) < 0) {
         HDF5ErrMapper::ToException<PropertyException>(
@@ -119,12 +101,8 @@ inline void Chunking::apply(const hid_t hid) const {
 }
 
 inline void Deflate::apply(const hid_t hid) const {
-    if (!H5Zfilter_avail(H5Z_FILTER_DEFLATE)) {
-        HDF5ErrMapper::ToException<PropertyException>(
-            "Error setting deflate property");
-    }
-
-    if (H5Pset_deflate(hid, _level) < 0) {
+    if (!H5Zfilter_avail(H5Z_FILTER_DEFLATE) ||
+            H5Pset_deflate(hid, _level) < 0) {
         HDF5ErrMapper::ToException<PropertyException>(
             "Error setting deflate property");
     }

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1200,15 +1200,6 @@ BOOST_AUTO_TEST_CASE(HighFiveInspect) {
     BOOST_CHECK(ds.getInfo().getRefCount() == 1);
 }
 
-typedef struct {
-    int m1;
-    int m2;
-    int m3;
-} CSL1;
-
-typedef struct {
-    CSL1 csl1;
-} CSL2;
 
 BOOST_AUTO_TEST_CASE(HighFiveGetPath) {
 
@@ -1288,6 +1279,39 @@ BOOST_AUTO_TEST_CASE(HighFiveRenameRelative) {
         BOOST_CHECK_EQUAL(number, read);
     }
 }
+
+BOOST_AUTO_TEST_CASE(HighFivePropertyObjects) {
+    const auto& plist1 = FileCreateProps::Default();  // get const-ref, otherwise copies
+    BOOST_CHECK_EQUAL(plist1.getId(), H5P_DEFAULT);
+    BOOST_CHECK_EQUAL(plist1.isValid(), false);       // not valid -> no inc_ref
+    auto plist2 = plist1;  // copy  (from Object)
+    BOOST_CHECK_EQUAL(plist2.getId(), H5P_DEFAULT);
+
+    // Underlying object is same (singleton holder of H5P_DEFAULT)
+    const auto& other_plist_type = LinkCreateProps::Default();
+    BOOST_CHECK_EQUAL((void*)&plist1, (void*)&other_plist_type);
+
+    LinkCreateProps plist_g;
+    BOOST_CHECK_EQUAL(plist_g.getId(), H5P_DEFAULT);
+    BOOST_CHECK_EQUAL(plist_g.isValid(), false);
+
+    plist_g.add(CreateIntermediateGroup());
+    BOOST_CHECK(plist_g.isValid());
+    auto plist_g2 = plist_g;
+    BOOST_CHECK(plist_g2.isValid());
+}
+
+
+typedef struct {
+    int m1;
+    int m2;
+    int m3;
+} CSL1;
+
+typedef struct {
+    CSL1 csl1;
+} CSL2;
+
 
 CompoundType create_compound_csl1() {
     auto t2 = AtomicType<int>();


### PR DESCRIPTION
**Description**
This PR implements improvements on property lists, as a follow up to #427, namely:
 -  Property lists inherit from object so they can be copied and moved and their ref-count properly managed.
 -  Introduce a shared DefaultPropList singleton to avoid always creating the default objects
 -  Some code cleanup


**How to test this?**
Added to `tests_high_five_base`. Run with `ctest`