### PR TITLE
Bring back default ctors with Deprecation notice

### DIFF
--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -90,8 +90,8 @@ class DataSet : public Object,
         return getSpace().getElementCount();
     }
 
-    // No empty datasets
-    DataSet() = delete;
+    H5_DEPRECATED("Default ctor creates unsafe uninitialized objects")
+    DataSet() = default;
 
   protected:
     using Object::Object;  // bring DataSet(hid_t)

--- a/include/highfive/H5DataSet.hpp
+++ b/include/highfive/H5DataSet.hpp
@@ -90,7 +90,7 @@ class DataSet : public Object,
         return getSpace().getElementCount();
     }
 
-    H5_DEPRECATED("Default ctor creates unsafe uninitialized objects")
+    H5_DEPRECATED("Default constructor creates unsafe uninitialized objects")
     DataSet() = default;
 
   protected:

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -26,8 +26,8 @@ class Group : public Object,
   public:
     const static ObjectType type = ObjectType::Group;
 
-    // No empty groups
-    Group() = delete;
+    H5_DEPRECATED("Default ctor creates unsafe uninitialized objects")
+    Group() = default;
 
   protected:
     using Object::Object;

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -26,7 +26,7 @@ class Group : public Object,
   public:
     const static ObjectType type = ObjectType::Group;
 
-    H5_DEPRECATED("Default ctor creates unsafe uninitialized objects")
+    H5_DEPRECATED("Default constructor creates unsafe uninitialized objects")
     Group() = default;
 
   protected:

--- a/include/highfive/bits/H5Path_traits_misc.hpp
+++ b/include/highfive/bits/H5Path_traits_misc.hpp
@@ -21,8 +21,11 @@ inline PathTraits<Derivate>::PathTraits() {
                   || std::is_same<Derivate, DataSet>::value
                   || std::is_same<Derivate, Attribute>::value,
                   "PathTraits can only be applied to Group, DataSet and Attribute");
-
-    const hid_t file_id = H5Iget_file_id(static_cast<Derivate*>(this)->getId());
+    const auto& obj = static_cast<const Derivate&>(*this);
+    if(!obj.isValid()) {
+        return;
+    }
+    const hid_t file_id = H5Iget_file_id(obj.getId());
     if (file_id < 0) {
         HDF5ErrMapper::ToException<PropertyException>(
             "getFile(): Could not obtain file of object");

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -138,6 +138,21 @@ BOOST_AUTO_TEST_CASE(HighFiveOpenMode) {
     { File file(FILE_NAME, 0); }  // force empty-flags, does open without flags
 }
 
+
+BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSetDefaultCtr) {
+    const std::string FILE_NAME("h5_group_test.h5");
+    const std::string DATASET_NAME("dset");
+    File file(FILE_NAME, File::Truncate);
+    auto ds = file.createDataSet(DATASET_NAME, std::vector<int>{1, 2, 3, 4, 5});
+
+    DataSet d2;  // deprecated as it constructs unsafe objects
+    // d2.getFile();  // runtime error
+    BOOST_CHECK_EQUAL(d2.isValid(), false);
+    d2 = ds;  // copy
+    BOOST_CHECK_EQUAL(d2.isValid(), true);
+}
+
+
 BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSet) {
     const std::string FILE_NAME("h5_group_test.h5");
     const std::string DATASET_NAME("dset");


### PR DESCRIPTION
**Description**

Default constructors are not recommended since it opens more
room for errors, and thus they had been removed in PR 417
However, before completely remove them, let them be well marked
deprecated with a nice compilation notice

**How to test this?**

tests added to `tests_high_five_base`. Use ctest