### PR TITLE
Add SZIP support (#435)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       shell: bash -l {0}  # required to activate conda
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install libboost-all-dev libhdf5-openmpi-dev libeigen3-dev
+        sudo apt-get -qq install libboost-all-dev libhdf5-openmpi-dev libeigen3-dev libsz2
         conda install -y -c conda-forge xtl xsimd xtensor
 
     - name: Build
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: "Install libraries"
-      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev
+      run: sudo apt-get update && sudo apt-get install libboost-all-dev libhdf5-dev libeigen3-dev libsz2
 
     - name: Build
       env: ${{matrix.env}}

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -148,6 +148,21 @@ class Deflate {
     const unsigned _level;
 };
 
+class Szip {
+  public:
+    explicit Szip(unsigned options_mask = H5_SZIP_EC_OPTION_MASK, 
+                  unsigned pixels_per_block = H5_SZIP_MAX_PIXELS_PER_BLOCK)
+        : _options_mask(options_mask)
+        , _pixels_per_block(pixels_per_block)
+    {}
+
+    private:
+      friend DataSetCreateProps;
+      void apply(hid_t hid) const;
+      const unsigned _options_mask;
+      const unsigned _pixels_per_block;
+};
+
 class Shuffle {
   public:
     Shuffle() = default;

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -107,6 +107,18 @@ inline void Deflate::apply(const hid_t hid) const {
     }
 }
 
+inline void Szip::apply(const hid_t hid) const {
+    if (!H5Zfilter_avail(H5Z_FILTER_SZIP)) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting szip property");
+    }
+
+    if (H5Pset_szip(hid, _options_mask, _pixels_per_block) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting szip property");
+    }
+}
+
 inline void Shuffle::apply(const hid_t hid) const {
     if (!H5Zfilter_avail(H5Z_FILTER_SHUFFLE)) {
         HDF5ErrMapper::ToException<PropertyException>(

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1084,6 +1084,69 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteShuffleDeflate, T, numerical_test_types) 
     readWriteShuffleDeflateTest<T>();
 }
 
+template <typename T>
+void readWriteSzipTest() {
+    std::ostringstream filename;
+    filename << "h5_rw_szip_" << typeNameHelper<T>() << "_test.h5";
+    const std::string DATASET_NAME("dset");
+    const size_t x_size = 128;
+    const size_t y_size = 32;
+    const size_t x_chunk = 8;
+    const size_t y_chunk = 4;
+
+    const int options_mask = H5_SZIP_NN_OPTION_MASK;
+    const int pixels_per_block = 8;
+
+    T array[x_size][y_size];
+
+    // write a compressed file
+    {
+        File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
+
+        // Create the data space for the dataset.
+        std::vector<size_t> dims{x_size, y_size};
+
+        DataSpace dataspace(dims);
+
+        // Use chunking
+        DataSetCreateProps props;
+        props.add(Chunking(std::vector<hsize_t>{x_chunk, y_chunk}));
+
+        // Enable szip
+        props.add(Szip(options_mask, pixels_per_block));
+
+        // Create a dataset with arbitrary type
+        DataSet dataset = file.createDataSet<T>(DATASET_NAME, dataspace, props);
+
+        ContentGenerate<T> generator;
+        generate2D(array, x_size, y_size, generator);
+
+        dataset.write(array);
+
+        file.flush();
+    }
+
+    // read it back
+    {
+        File file_read(filename.str(), File::ReadOnly);
+        DataSet dataset_read = file_read.getDataSet("/" + DATASET_NAME);
+
+        T result[x_size][y_size];
+
+        dataset_read.read(result);
+
+        for (size_t i = 0; i < x_size; ++i) {
+            for (size_t j = 0; i < y_size; ++i) {
+                BOOST_CHECK_EQUAL(result[i][j], array[i][j]);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteSzip, T, numerical_test_types) {
+    readWriteSzipTest<T>();
+}
+
 // Broadcasting is supported
 BOOST_AUTO_TEST_CASE(ReadInBroadcastDims) {
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1143,7 +1143,7 @@ void readWriteSzipTest() {
     }
 }
 
-BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteSzip, T, numerical_test_types) {
+BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteSzip, T, dataset_test_types) {
     readWriteSzipTest<T>();
 }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1144,7 +1144,12 @@ void readWriteSzipTest() {
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(ReadWriteSzip, T, dataset_test_types) {
-    readWriteSzipTest<T>();
+    // SZIP is not consistently available across distributions.
+    if (H5Zfilter_avail(H5Z_FILTER_SZIP)) {
+        readWriteSzipTest<T>();
+    } else {
+        BOOST_CHECK_THROW(readWriteSzipTest<T>(), PropertyException);
+    }
 }
 
 // Broadcasting is supported


### PR DESCRIPTION
HDF has default support for SZIP, but commercially licensed.
Using `libaec` SZIP can be used with a permissive license.
This commit allows SZIP to be defined as a property.

The good news is I added a test (which is mostly copy-paste of the shuffle-deflate test). The bad news is I was unable to run the test successfully on my machine (not sure why that is, however compiling succeeds and I've also tested it by using it in my own code). I advise you to run the test yourself. You might want to install https://www.dkrz.de/redmine/projects/aec/wiki/Downloads instead of using the built-in szip for licensing reasons, and there may be some cmake configuration needed.
