### PR TITLE
Add a trigger on PR merge

### DIFF
--- a/.github/workflows/integration_trigger.yml
+++ b/.github/workflows/integration_trigger.yml
@@ -1,0 +1,15 @@
+name: Integration Test Trigger
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  merge-PR:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger integration tests on BlueBrain/HighFive-testing
+        run: |
+          curl -X POST https://api.github.com/repos/BlueBrain/HighFive-testing/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.ACCESS_TOKEN }} \
+          --data '{"event_type": "merge", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'


### PR DESCRIPTION
Instead of running integration tests important to BlueBrain only inside this repo, we have moved them into a separate repository. This PR only adds a simple webhook that is triggered whenever a PR is merged to notify the external repo that it should run its CI. This makes BlueBrain integration tests completely independent from development here. The PR is merged regardless. It will be up to BlueBrain devs to fix regressions.
