### PR TITLE
Unified reading/writing attributes and datasets

### DIFF
--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -23,6 +23,7 @@
 #include <H5Ppublic.h>
 
 #include "H5Converter_misc.hpp"
+#include "H5ReadWrite_misc.hpp"
 #include "H5Utils.hpp"
 
 namespace HighFive {
@@ -56,32 +57,18 @@ inline DataSpace Attribute::getMemSpace() const { return getSpace(); }
 
 template <typename T>
 inline void Attribute::read(T& array) const {
-    static_assert(!std::is_const<typename std::remove_reference<T>::type>::value,
-                  "read() requires a non-const array to read into");
-    using element_type = typename details::inspector<T>::base_type;
-    const size_t dim_array = details::inspector<T>::recursive_ndim;
-    DataSpace space = getSpace();
-    DataSpace mem_space = getMemSpace();
+    const DataSpace& mem_space = getMemSpace();
+    const details::BufferInfo<T> buffer_info(getDataType());
 
-    if (!details::checkDimensions(mem_space, dim_array)) {
+    if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
         std::ostringstream ss;
-        ss << "Impossible to read attribute of dimensions "
+        ss << "Impossible to read DataSet of dimensions "
            << mem_space.getNumberDimensions() << " into arrays of dimensions "
-           << dim_array;
+           << buffer_info.n_dimensions;
         throw DataSpaceException(ss.str());
     }
-
-    const DataType mem_datatype = create_and_check_datatype<element_type>();
-
-    // Apply pre read conversions
     details::data_converter<T> converter(mem_space);
-
-    if (H5Aread(getId(), mem_datatype.getId(),
-                static_cast<void*>(converter.transform_read(array))) < 0) {
-        HDF5ErrMapper::ToException<AttributeException>(
-            "Error during HDF5 Read: ");
-    }
-
+    read(converter.transform_read(array), buffer_info.data_type);
     // re-arrange results
     converter.process_result(array);
 }
@@ -90,7 +77,10 @@ template <typename T>
 inline void Attribute::read(T* array, const DataType& dtype) const {
     static_assert(!std::is_const<T>::value,
                   "read() requires a non-const structure to read data into");
-    const auto& mem_datatype = dtype.empty() ? create_and_check_datatype<T>() : dtype;
+    using element_type = typename details::inspector<T>::base_type;
+    // Auto-detect mem datatype if not provided
+    const DataType& mem_datatype =
+            dtype.empty() ? create_and_check_datatype<element_type>() : dtype;
 
     if (H5Aread(getId(), mem_datatype.getId(),
                 static_cast<void*>(array)) < 0) {
@@ -101,32 +91,24 @@ inline void Attribute::read(T* array, const DataType& dtype) const {
 
 template <typename T>
 inline void Attribute::write(const T& buffer) {
-    using element_type = typename details::inspector<T>::base_type;
-    const size_t dim_buffer = details::inspector<T>::recursive_ndim;
-    DataSpace space = getSpace();
-    DataSpace mem_space = getMemSpace();
+    const DataSpace& mem_space = getMemSpace();
+    const details::BufferInfo<T> buffer_info(getDataType());
 
-    if (!details::checkDimensions(mem_space, dim_buffer)) {
+    if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
         std::ostringstream ss;
-        ss << "Impossible to write buffer of dimensions " << dim_buffer
-           << " into attribute of dimensions "
-           << mem_space.getNumberDimensions();
+        ss << "Impossible to write buffer of dimensions " << buffer_info.n_dimensions
+           << " into dataset of dimensions " << mem_space.getNumberDimensions();
         throw DataSpaceException(ss.str());
     }
-
-    const DataType mem_datatype = create_and_check_datatype<element_type>();
     details::data_converter<T> converter(mem_space);
-
-    if (H5Awrite(getId(), mem_datatype.getId(),
-                 static_cast<const void*>(converter.transform_write(buffer))) < 0) {
-        HDF5ErrMapper::ToException<DataSetException>(
-            "Error during HDF5 Write: ");
-    }
+    write_raw(converter.transform_write(buffer), buffer_info.data_type);
 }
 
 template <typename T>
 inline void Attribute::write_raw(const T* buffer, const DataType& dtype) {
-    const DataType mem_datatype = dtype.empty() ? create_and_check_datatype<T>() : dtype;
+    using element_type = typename details::inspector<T>::base_type;
+    const auto& mem_datatype =
+        dtype.empty() ? create_and_check_datatype<element_type>() : dtype;
 
     if (H5Awrite(getId(), mem_datatype.getId(), buffer) < 0) {
         HDF5ErrMapper::ToException<DataSetException>(

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -417,7 +417,10 @@ inline DataType create_and_check_datatype() {
 
     // Check that the size of the template type matches the size that HDF5 is
     // expecting.
-    if(!t.isReference() && (sizeof(T) != t.getSize())) {
+    if (t.isReference() || t.isFixedLenStr()) {
+        return t;
+    }
+    if (sizeof(T) != t.getSize()) {
         std::ostringstream ss;
         ss << "Size of array type " << sizeof(T)
            << " != that of memory datatype " << t.getSize()

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1691,6 +1691,28 @@ BOOST_AUTO_TEST_CASE(HighFiveFixedLenStringArrayStructure) {
     }
 }
 
+
+BOOST_AUTO_TEST_CASE(HighFiveFixedLenStringArrayAttribute) {
+    const std::string FILE_NAME("fixed_array_attr.h5");
+    // Create a new file using the default property lists.
+    {
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+        FixedLenStringArray<10> arr{"Hello", "world"};
+        file.createAttribute("str", arr);
+    }
+    // Re-read it
+    {
+        File file(FILE_NAME);
+        FixedLenStringArray<8> arr;  // notice the output strings can be smaller
+        file.getAttribute("str").read(arr);
+        BOOST_CHECK_EQUAL(arr.size(), 2);
+        BOOST_CHECK_EQUAL(arr[0], std::string("Hello"));
+        BOOST_CHECK_EQUAL(arr[1], std::string("world"));
+    }
+
+}
+
+
 BOOST_AUTO_TEST_CASE(HighFiveReference) {
     const std::string FILE_NAME("h5_ref_test.h5");
     const std::string DATASET1_NAME("dset1");


### PR DESCRIPTION
**Description**

Reading attributes now uses the same routines as reading datasets.
Besides the smaller code due to reuse, now it support fixed-length
strings

Fixes #322 and #285

**How to test this?**

Tests were added to `tests_high_five_base.cpp` in `HighFiveFixedLenStringArrayAttribute`
