### PR TITLE
GHA: drop previous runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: HighFive_CI
 
+concurrency:
+  group: ${{ github.workflow }}#${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
* drop previous runs for subsequent updates 
* make use of new GHA concurrency feature
* concurrency group consists of workflow_name#github_ref
* see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
