### PR TITLE
Adding compound types example

### DIFF
--- a/src/examples/compound_types.cpp
+++ b/src/examples/compound_types.cpp
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c), 2021, Blue Brain Project, EPFL
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+// Compound datatype test :: May 2021
+// //////////////////////////////////
+
+#include <highfive/H5File.hpp>
+
+
+typedef struct {
+    double width;
+    double height;
+} Size2D;
+
+
+HighFive::CompoundType create_compound_Size2D() {
+    return {{ "width",  HighFive::AtomicType<double>{} },
+            { "height", HighFive::AtomicType<double>{} }};
+}
+
+HIGHFIVE_REGISTER_TYPE(Size2D, create_compound_Size2D)
+
+int main() {
+    const std::string FILE_NAME("compounds_test.h5");
+    const std::string DATASET_NAME("dims");
+
+    HighFive::File file(FILE_NAME, HighFive::File::Truncate);
+
+    auto t1 = create_compound_Size2D();
+    t1.commit(file, "Size2D");
+
+    std::vector<Size2D> dims = {{1., 2.5}, {3., 4.5}};
+    auto dataset = file.createDataSet(DATASET_NAME, dims);
+
+    auto g1 = file.createGroup("group1");
+    g1.createAttribute(DATASET_NAME, dims);
+
+}


### PR DESCRIPTION
**Description**

This example shows all the steps for using compund datatypes. Compound attribute writing is also tested here.

**Testing**

Examples are automatically picked up by our CI.
Also checked locally for validity of output
```
Size2D                   Type
    Location:  1:800
    Links:     1
    Type:      shared-1:800struct {
                   "width"            +0    native double
                   "height"           +8    native double
               } 16 bytes
dims                     Dataset {2/2}
    Location:  1:1280
    Links:     1
    Storage:   32 logical bytes, 32 allocated bytes, 100.00% utilization
    Type:      struct {
                   "width"            +0    native double
                   "height"           +8    native double
               } 16 bytes
group1                   Group
    Attribute: dims {2}
        Type:      struct {
                   "width"            +0    native double
                   "height"           +8    native double
               } 16 bytes
    Location:  1:1552
    Links:     1
```

Closes #454 