### PR TITLE
Fix bigobj issue when compiling tests on MSVC (#474)

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,6 +7,10 @@ if(NOT Boost_USE_STATIC_LIBS)
   add_definitions(-DBOOST_TEST_DYN_LINK=TRUE)
 endif()
 
+if(MSVC)
+  add_definitions(/bigobj)
+endif()
+
 ## Base tests
 foreach(test_name tests_high_five_base tests_high_five_multi_dims tests_high_five_easy)
   add_executable(${test_name} "${test_name}.cpp")


### PR DESCRIPTION
**Description**

Fixes #474 

**How to test this?**

```bash
mkdir build
cmake ..
cmake --build .
```

**Test System**
 - OS: Windows
 - Compiler: MSVC 16.10.1+2fd48ab73
