### PR TITLE
Fixes dataspace typo (datascape)

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -43,8 +43,8 @@ class DataSpace : public Object {
 
     /// dataspace type
     enum DataspaceType {
-        datascape_scalar,
-        datascape_null
+        dataspace_scalar,
+        dataspace_null
         // simple dataspace are handle directly from their dimensions
     };
 

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -67,15 +67,15 @@ inline DataSpace::DataSpace(const std::vector<size_t>& dims,
 inline DataSpace::DataSpace(DataSpace::DataspaceType dtype) {
     H5S_class_t h5_dataspace_type;
     switch (dtype) {
-    case DataSpace::datascape_scalar:
+    case DataSpace::dataspace_scalar:
         h5_dataspace_type = H5S_SCALAR;
         break;
-    case DataSpace::datascape_null:
+    case DataSpace::dataspace_null:
         h5_dataspace_type = H5S_NULL;
         break;
     default:
         throw DataSpaceException("Invalid dataspace type: should be "
-                                 "datascape_scalar or datascape_null");
+                                 "dataspace_scalar or dataspace_null");
     }
 
     if ((_hid = H5Screate(h5_dataspace_type)) < 0) {

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1003,7 +1003,7 @@ BOOST_AUTO_TEST_CASE(HighFiveOutofDimension) {
         // Create a new file using the default property lists.
         File file(filename, File::ReadWrite | File::Create | File::Truncate);
 
-        DataSpace d_null(DataSpace::DataspaceType::datascape_null);
+        DataSpace d_null(DataSpace::DataspaceType::dataspace_null);
 
         DataSet d1 = file.createDataSet<double>(DATASET_NAME, d_null);
 


### PR DESCRIPTION
**Description**

Fixes typo in `enum DataspaceType` from datascape to dataspace.


[!] This might break some projects that uses the enum directly. 
