### PR TITLE
Remove CI with ubuntu 16.04 as github no more support it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This platform has been remove 20th september 2021
See: https://github.com/actions/virtual-environments/issues/3287