### PR TITLE
Add more file and group property list modifiers 

### DIFF
--- a/CMake/HighFiveTargetDeps.cmake
+++ b/CMake/HighFiveTargetDeps.cmake
@@ -18,7 +18,7 @@ if(NOT TARGET libdeps)
   endif()
 
   target_include_directories(libdeps SYSTEM INTERFACE ${HDF5_INCLUDE_DIRS})
-  target_link_libraries(libdeps INTERFACE ${HDF5_C_LIBRARIES})
+  target_link_libraries(libdeps INTERFACE ${HDF5_LIBRARIES})
   target_compile_definitions(libdeps INTERFACE ${HDF5_DEFINITIONS})
 
   # Boost

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -68,6 +68,9 @@ class File : public Object,
         return "/";
     }
 
+    /// \brief Returns the HDF5 version compatibility bounds
+    std::pair<H5F_libver_t, H5F_libver_t> getVersionBounds() const;
+
     ///
     /// \brief flush
     ///

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -68,6 +68,9 @@ class File : public Object,
         return "/";
     }
 
+    /// \brief Returns the block size for metadata in bytes
+    hsize_t getMetadataBlockSize() const;
+
     /// \brief Returns the HDF5 version compatibility bounds
     std::pair<H5F_libver_t, H5F_libver_t> getVersionBounds() const;
 

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -29,6 +29,34 @@ class MPIOFileDriver : public FileAccessProps {
   private:
 };
 
+///
+/// \brief Configure the version bounds for the file
+///
+/// Used to define the compatibility of objects created within HDF5 files,
+/// and affects the format of groups stored in the file.
+///
+/// See also the documentation of \c H5P_SET_LIBVER_BOUNDS in HDF5.
+///
+/// Possible values for \c low and \c high are:
+/// * \c H5F_LIBVER_EARLIEST
+/// * \c H5F_LIBVER_V18
+/// * \c H5F_LIBVER_V110
+/// * \c H5F_LIBVER_NBOUNDS
+/// * \c H5F_LIBVER_LATEST currently defined as \c H5F_LIBVER_V110 within
+///   HDF5
+class FileVersionBounds {
+  public:
+    FileVersionBounds(H5F_libver_t low, H5F_libver_t high)
+        : _low(low)
+        , _high(high)
+    {}
+  private:
+    friend FileAccessProps;
+    void apply(const hid_t list) const;
+    const H5F_libver_t _low;
+    const H5F_libver_t _high;
+};
+
 }  // namespace HighFive
 
 #include "bits/H5FileDriver_misc.hpp"

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -44,6 +44,7 @@ class MPIOFileDriver : public FileAccessProps {
 /// * \c H5F_LIBVER_NBOUNDS
 /// * \c H5F_LIBVER_LATEST currently defined as \c H5F_LIBVER_V110 within
 ///   HDF5
+///
 class FileVersionBounds {
   public:
     FileVersionBounds(H5F_libver_t low, H5F_libver_t high)
@@ -57,6 +58,11 @@ class FileVersionBounds {
     const H5F_libver_t _high;
 };
 
+///
+/// \brief Configure the metadata block size to use writing to files
+///
+/// \param size Metadata block size in bytes
+///
 class MetadataBlockSize {
   public:
     MetadataBlockSize(hsize_t size)

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -57,6 +57,17 @@ class FileVersionBounds {
     const H5F_libver_t _high;
 };
 
+class MetadataBlockSize {
+  public:
+    MetadataBlockSize(hsize_t size)
+        : _size(size)
+    {}
+  private:
+    friend FileAccessProps;
+    void apply(const hid_t list) const;
+    const hsize_t _size;
+};
+
 }  // namespace HighFive
 
 #include "bits/H5FileDriver_misc.hpp"

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -29,6 +29,8 @@ class Group : public Object,
     H5_DEPRECATED("Default constructor creates unsafe uninitialized objects")
     Group() = default;
 
+    std::pair<unsigned int, unsigned int> getEstimatedLinkInfo() const;
+
   protected:
     using Object::Object;
 
@@ -38,6 +40,20 @@ class Group : public Object,
     friend class Reference;
     template <typename Derivate> friend class ::HighFive::NodeTraits;
 };
+
+#include <H5Gpublic.h>
+
+std::pair<unsigned int, unsigned int> Group::getEstimatedLinkInfo() const {
+    unsigned int est_num_entries;
+    unsigned int est_name_len;
+
+    auto gid_gcpl = H5Gget_create_plist(getId());
+    if (H5Pget_est_link_info(gid_gcpl, &est_num_entries, &est_name_len) < 0) {
+        HDF5ErrMapper::ToException<GroupException>(
+            std::string("Unable to access group link size property"));
+    }
+    return std::make_pair(est_num_entries, est_name_len);
+}
 
 }  // namespace HighFive
 

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -114,7 +114,6 @@ class RawPropertyList : public PropertyList<T> {
     void add(const F& funct, const Args&... args);
 };
 
-
 class EstimatedLinkInfo {
   public:
     explicit EstimatedLinkInfo(unsigned entries, unsigned length)

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -115,6 +115,20 @@ class RawPropertyList : public PropertyList<T> {
 };
 
 
+class EstimatedLinkInfo {
+  public:
+    explicit EstimatedLinkInfo(unsigned entries, unsigned length)
+        : _entries(entries)
+        , _length(length)
+    {}
+  private:
+    friend GroupCreateProps;
+    void apply(hid_t hid) const;
+    const unsigned _entries;
+    const unsigned _length;
+};
+
+
 class Chunking {
   public:
     explicit Chunking(const std::vector<hsize_t>& dims)

--- a/include/highfive/bits/H5FileDriver_misc.hpp
+++ b/include/highfive/bits/H5FileDriver_misc.hpp
@@ -47,6 +47,13 @@ inline MPIOFileDriver::MPIOFileDriver(Comm comm, Info info) {
     add(MPIOFileAccess<Comm, Info>(comm, info));
 }
 
+inline void FileVersionBounds::apply(const hid_t list) const {
+    if (H5Pset_libver_bounds(list, _low, _high) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting file version bounds");
+    }
+}
+
 } // namespace HighFive
 
 #endif // H5FILEDRIVER_MISC_HPP

--- a/include/highfive/bits/H5FileDriver_misc.hpp
+++ b/include/highfive/bits/H5FileDriver_misc.hpp
@@ -54,6 +54,13 @@ inline void FileVersionBounds::apply(const hid_t list) const {
     }
 }
 
+inline void MetadataBlockSize::apply(const hid_t list) const {
+    if (H5Pset_meta_block_size(list, _size) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting metadata block size");
+    }
+}
+
 } // namespace HighFive
 
 #endif // H5FILEDRIVER_MISC_HPP

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -84,6 +84,17 @@ inline const std::string& File::getName() const noexcept {
     return _filename;
 }
 
+std::pair<H5F_libver_t, H5F_libver_t> File::getVersionBounds() const {
+    H5F_libver_t low;
+    H5F_libver_t high;
+    auto fid_fapl = H5Fget_access_plist(getId());
+    if (H5Pget_libver_bounds(fid_fapl, &low, &high) < 0) {
+        HDF5ErrMapper::ToException<FileException>(
+            std::string("Unable to access file version bounds"));
+    }
+    return std::make_pair(low, high);
+}
+
 inline void File::flush() {
     if (H5Fflush(_hid, H5F_SCOPE_GLOBAL) < 0) {
         HDF5ErrMapper::ToException<FileException>(

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -84,6 +84,16 @@ inline const std::string& File::getName() const noexcept {
     return _filename;
 }
 
+hsize_t File::getMetadataBlockSize() const {
+    hsize_t size;
+    auto fid_fapl = H5Fget_access_plist(getId());
+    if (H5Pget_meta_block_size(fid_fapl, &size) < 0) {
+        HDF5ErrMapper::ToException<FileException>(
+            std::string("Unable to access file metadata block size"));
+    }
+    return size;
+}
+
 std::pair<H5F_libver_t, H5F_libver_t> File::getVersionBounds() const {
     H5F_libver_t low;
     H5F_libver_t high;

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -101,6 +101,14 @@ class NodeTraits {
     Group createGroup(const std::string& group_name, bool parents = true);
 
     ///
+    /// \brief create a new group, and eventually intermediate groups
+    /// \param group_name
+    /// \param createProps A property list with group creation properties
+    /// \param parents Create intermediate groups if needed. Default: true.
+    /// \return the group object
+    Group createGroup(const std::string& group_name, const GroupCreateProps& createProps, bool parents = true);
+
+    ///
     /// \brief open an existing group with the name group_name
     /// \param group_name
     /// \return the group object

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -123,6 +123,25 @@ inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name,
 }
 
 template <typename Derivate>
+inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name,
+                                               const GroupCreateProps& createProps,
+                                               bool parents) {
+
+    LinkCreateProps lcpl;
+    lcpl.add(CreateIntermediateGroup(parents));
+    const auto hid = H5Gcreate2(static_cast<Derivate*>(this)->getId(),
+                                group_name.c_str(),
+                                lcpl.getId(),
+                                createProps.getId(),
+                                H5P_DEFAULT);
+    if (hid < 0) {
+        HDF5ErrMapper::ToException<GroupException>(
+            std::string("Unable to create the group \"") + group_name + "\":");
+    }
+    return Group(hid);
+}
+
+template <typename Derivate>
 inline Group
 NodeTraits<Derivate>::getGroup(const std::string& group_name) const {
     const auto hid = H5Gopen2(static_cast<const Derivate*>(this)->getId(),

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -92,6 +92,13 @@ inline void RawPropertyList<T>::add(const F& funct, const Args&... args) {
 
 // Specific options to be added to Property Lists
 
+inline void EstimatedLinkInfo::apply(const hid_t hid) const {
+    if (H5Pset_est_link_info(hid, _entries, _length) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting estimated link info");
+    }
+}
+
 inline void Chunking::apply(const hid_t hid) const {
     if (H5Pset_chunk(hid, static_cast<int>(_dims.size()), _dims.data()) < 0) {
         HDF5ErrMapper::ToException<PropertyException>(

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -159,13 +159,13 @@ BOOST_AUTO_TEST_CASE(HighFiveFileVersioning) {
 
     {
         FileDriver driver;
-        driver.add(FileVersionBounds(H5F_LIBVER_V110, H5F_LIBVER_V110));
+        driver.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
         File file(FILE_NAME, File::Truncate, driver);
         auto fid_fapl = H5Fget_access_plist(file.getId());
         auto res = H5Pget_libver_bounds(fid_fapl, &low, &high);
         BOOST_ASSERT(res == 0);
-        BOOST_ASSERT(low == H5F_LIBVER_V110);
-        BOOST_ASSERT(high == H5F_LIBVER_V110);
+        BOOST_ASSERT(low == H5F_LIBVER_LATEST);
+        BOOST_ASSERT(high == H5F_LIBVER_LATEST);
     }
 }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -189,7 +189,9 @@ BOOST_AUTO_TEST_CASE(HighFiveMetadataBlockSize) {
 BOOST_AUTO_TEST_CASE(HighFiveGroupProperties) {
     const std::string FILE_NAME("h5_group_properties.h5");
     FileDriver adam;
-    adam.add(FileVersionBounds(H5F_LIBVER_V18, H5F_LIBVER_LATEST));
+    // When using hdf5 1.10.2 and later, the lower bound may be set to
+    // H5F_LIBVER_V18
+    adam.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
     File file(FILE_NAME, File::Truncate, adam);
 
     GroupCreateProps props;

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -141,18 +141,14 @@ BOOST_AUTO_TEST_CASE(HighFiveOpenMode) {
 
 BOOST_AUTO_TEST_CASE(HighFiveFileVersioning) {
     const std::string FILE_NAME("h5_version_bounds.h5");
-    H5F_libver_t low;
-    H5F_libver_t high;
 
     std::remove(FILE_NAME.c_str());
 
     {
         File file(FILE_NAME, File::Truncate);
-        auto fid_fapl = H5Fget_access_plist(file.getId());
-        auto res = H5Pget_libver_bounds(fid_fapl, &low, &high);
-        BOOST_ASSERT(res == 0);
-        BOOST_ASSERT(low == H5F_LIBVER_EARLIEST);
-        BOOST_ASSERT(high == H5F_LIBVER_LATEST);
+        auto bounds = file.getVersionBounds();
+        BOOST_ASSERT(bounds.first == H5F_LIBVER_EARLIEST);
+        BOOST_ASSERT(bounds.second == H5F_LIBVER_LATEST);
     }
 
     std::remove(FILE_NAME.c_str());
@@ -161,11 +157,9 @@ BOOST_AUTO_TEST_CASE(HighFiveFileVersioning) {
         FileDriver driver;
         driver.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
         File file(FILE_NAME, File::Truncate, driver);
-        auto fid_fapl = H5Fget_access_plist(file.getId());
-        auto res = H5Pget_libver_bounds(fid_fapl, &low, &high);
-        BOOST_ASSERT(res == 0);
-        BOOST_ASSERT(low == H5F_LIBVER_LATEST);
-        BOOST_ASSERT(high == H5F_LIBVER_LATEST);
+        auto bounds = file.getVersionBounds();
+        BOOST_ASSERT(bounds.first == H5F_LIBVER_LATEST);
+        BOOST_ASSERT(bounds.second == H5F_LIBVER_LATEST);
     }
 }
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -186,6 +186,22 @@ BOOST_AUTO_TEST_CASE(HighFiveMetadataBlockSize) {
 }
 
 
+BOOST_AUTO_TEST_CASE(HighFiveGroupProperties) {
+    const std::string FILE_NAME("h5_group_properties.h5");
+    FileDriver adam;
+    adam.add(FileVersionBounds(H5F_LIBVER_V18, H5F_LIBVER_LATEST));
+    File file(FILE_NAME, File::Truncate, adam);
+
+    GroupCreateProps props;
+    props.add(EstimatedLinkInfo(1000, 500));
+    auto group = file.createGroup("g", props);
+    auto sizes = group.getEstimatedLinkInfo();
+
+    BOOST_ASSERT(sizes.first == 1000);
+    BOOST_ASSERT(sizes.second == 500);
+}
+
+
 BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSetDefaultCtr) {
     const std::string FILE_NAME("h5_group_test.h5");
     const std::string DATASET_NAME("dset");

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -164,6 +164,28 @@ BOOST_AUTO_TEST_CASE(HighFiveFileVersioning) {
 }
 
 
+BOOST_AUTO_TEST_CASE(HighFiveMetadataBlockSize) {
+    const std::string FILE_NAME("h5_meta_block_size.h5");
+
+    std::remove(FILE_NAME.c_str());
+
+    {
+        File file(FILE_NAME, File::Truncate);
+        // Default for HDF5
+        BOOST_ASSERT(file.getMetadataBlockSize() == 2048);
+    }
+
+    std::remove(FILE_NAME.c_str());
+
+    {
+        FileDriver driver;
+        driver.add(MetadataBlockSize(10240));
+        File file(FILE_NAME, File::Truncate, driver);
+        BOOST_ASSERT(file.getMetadataBlockSize() == 10240);
+    }
+}
+
+
 BOOST_AUTO_TEST_CASE(HighFiveGroupAndDataSetDefaultCtr) {
     const std::string FILE_NAME("h5_group_test.h5");
     const std::string DATASET_NAME("dset");


### PR DESCRIPTION
Added property list modifiers for file creation:

* `FileVersionBounds`
* `MetadataBlockSize`

also added functions to retrieve these settings from the `File` objects.

Added property list modifiers for groups:

* `EstimatedLinkInfo`

also added a new function for group creation to be able to use this modifier, and to retrieve settings. This requires creating a file that has a lower version bound for HDF5 1.8.