### PR TITLE
Fix UB when passing std::vector with size zero

### DIFF
--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -80,8 +80,10 @@ struct inspector<std::vector<T>> {
     static std::array<size_t, recursive_ndim> getDimensions(const type& val) {
         std::array<size_t, recursive_ndim> sizes{val.size()};
         size_t index = ndim;
-        for (const auto& s: inspector<value_type>::getDimensions(val[0])) {
-            sizes[index++] = s;
+        if(!val.empty()) {
+            for (const auto& s: inspector<value_type>::getDimensions(val[0])) {
+                sizes[index++] = s;
+            }
         }
         return sizes;
     }


### PR DESCRIPTION
**Description**

As described in [this comment](https://github.com/BlueBrain/HighFive/issues/172#issuecomment-988148646), when passing an `std::vector` of zero size, the current code invokes undefined behavior, because `val[0]` accesses a nonexistent element. This may cause some unexpected (but valid) complaints by some compilers.

Fixes #172.

**How to test this?**

Tested using the following commands.

```bash
cmake ..
make -j8
make test
```

**Test System**
 - OS: Ubuntu 20.04.1 LTS (WSL)
 - Compiler: GCC 9.3.0
 - Dependency versions: hdf5 1.10.4+repack-11ubuntu1
