### PR TITLE
Refactor and move file related property list stuff

### DIFF
--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -18,61 +18,17 @@ namespace HighFive {
 ///
 class FileDriver : public FileAccessProps {};
 
+#ifdef H5_HAVE_PARALLEL
 ///
 /// \brief MPIIO Driver for Parallel HDF5
 ///
 class MPIOFileDriver : public FileAccessProps {
   public:
-    template <typename Comm, typename Info>
-    inline MPIOFileDriver(Comm mpi_comm, Info mpi_info);
+    inline MPIOFileDriver(MPI_Comm mpi_comm, MPI_Info mpi_info);
 
   private:
 };
-
-///
-/// \brief Configure the version bounds for the file
-///
-/// Used to define the compatibility of objects created within HDF5 files,
-/// and affects the format of groups stored in the file.
-///
-/// See also the documentation of \c H5P_SET_LIBVER_BOUNDS in HDF5.
-///
-/// Possible values for \c low and \c high are:
-/// * \c H5F_LIBVER_EARLIEST
-/// * \c H5F_LIBVER_V18
-/// * \c H5F_LIBVER_V110
-/// * \c H5F_LIBVER_NBOUNDS
-/// * \c H5F_LIBVER_LATEST currently defined as \c H5F_LIBVER_V110 within
-///   HDF5
-///
-class FileVersionBounds {
-  public:
-    FileVersionBounds(H5F_libver_t low, H5F_libver_t high)
-        : _low(low)
-        , _high(high)
-    {}
-  private:
-    friend FileAccessProps;
-    void apply(const hid_t list) const;
-    const H5F_libver_t _low;
-    const H5F_libver_t _high;
-};
-
-///
-/// \brief Configure the metadata block size to use writing to files
-///
-/// \param size Metadata block size in bytes
-///
-class MetadataBlockSize {
-  public:
-    MetadataBlockSize(hsize_t size)
-        : _size(size)
-    {}
-  private:
-    friend FileAccessProps;
-    void apply(const hid_t list) const;
-    const hsize_t _size;
-};
+#endif
 
 }  // namespace HighFive
 

--- a/include/highfive/bits/H5FileDriver_misc.hpp
+++ b/include/highfive/bits/H5FileDriver_misc.hpp
@@ -10,56 +10,13 @@
 #ifndef H5FILEDRIVER_MISC_HPP
 #define H5FILEDRIVER_MISC_HPP
 
-#include <H5Ppublic.h>
-
-#ifdef H5_HAVE_PARALLEL
-#include <H5FDmpi.h>
-#endif
-
 namespace HighFive {
 
-namespace {
-
-template <typename Comm, typename Info>
-class MPIOFileAccess
-{
-public:
-  MPIOFileAccess(Comm comm, Info info)
-      : _comm(comm)
-      , _info(info)
-  {}
-
-  void apply(const hid_t list) const {
-    if (H5Pset_fapl_mpio(list, _comm, _info) < 0) {
-        HDF5ErrMapper::ToException<FileException>(
-            "Unable to set-up MPIO Driver configuration");
-    }
-  }
-private:
-  Comm _comm;
-  Info _info;
-};
-
-}  //namespace
-
-template <typename Comm, typename Info>
-inline MPIOFileDriver::MPIOFileDriver(Comm comm, Info info) {
-    add(MPIOFileAccess<Comm, Info>(comm, info));
+#ifdef H5_HAVE_PARALLEL
+inline MPIOFileDriver::MPIOFileDriver(MPI_Comm comm, MPI_Info info) {
+    add(MPIOFileAccess(comm, info));
 }
-
-inline void FileVersionBounds::apply(const hid_t list) const {
-    if (H5Pset_libver_bounds(list, _low, _high) < 0) {
-        HDF5ErrMapper::ToException<PropertyException>(
-            "Error setting file version bounds");
-    }
-}
-
-inline void MetadataBlockSize::apply(const hid_t list) const {
-    if (H5Pset_meta_block_size(list, _size) < 0) {
-        HDF5ErrMapper::ToException<PropertyException>(
-            "Error setting metadata block size");
-    }
-}
+#endif
 
 } // namespace HighFive
 

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -61,8 +61,9 @@ void selectionArraySimpleTestParallel() {
     std::generate(values.begin(), values.end(), generator);
 
     // Create a new file using the default property lists.
-    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate,
-              MPIOFileDriver(MPI_COMM_WORLD, MPI_INFO_NULL));
+    FileDriver adam;
+    adam.add(MPIOFileAccess(MPI_COMM_WORLD, MPI_INFO_NULL));
+    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate, adam);
 
     DataSet dataset =
         file.createDataSet<T>(DATASET_NAME, DataSpace::From(values));


### PR DESCRIPTION
Follow-up to #500, moves the property list manipulation relating to
files into H5PropertyList.hpp, while also removing the template for MPI
file opening and moving to preprocessor conditionals.

IMO this is a bit cleaner and feels more natural when using the
modifier.
