### PR TITLE
bugfix: always refer to the proper signed type for `signed char`

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -74,7 +74,7 @@ inline AtomicType<char>::AtomicType() {
 
 template <>
 inline AtomicType<signed char>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_CHAR);
+    _hid = H5Tcopy(H5T_NATIVE_SCHAR);
 }
 
 template <>


### PR DESCRIPTION
The previous usage of H5T_NATIVE_CHAR for `signed char` fails on
Fedora/aarch64.  Needed for BlueBrain/libsonata#184.
