### PR TITLE
Fix "namespace definition is not allowed here"

### DIFF
--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -386,7 +386,7 @@ class FixedLenStringArray {
 /// \endcode
 #define HIGHFIVE_REGISTER_TYPE(type, function) \
     template<>                                 \
-    HighFive::DataType HighFive::create_datatype<type>() {         \
+    ::HighFive::DataType ::HighFive::create_datatype<type>() {         \
         return function();                     \
     }
 

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -386,7 +386,7 @@ class FixedLenStringArray {
 /// \endcode
 #define HIGHFIVE_REGISTER_TYPE(type, function) \
     template<>                                 \
-    ::HighFive::DataType ::HighFive::create_datatype<type>() {         \
+    HighFive::DataType HighFive::create_datatype<type>() {         \
         return function();                     \
     }
 

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -385,9 +385,8 @@ class FixedLenStringArray {
 /// HIGHFIVE_REGISTER_TYPE(FooBar, create_enum_foobar)
 /// \endcode
 #define HIGHFIVE_REGISTER_TYPE(type, function) \
-    namespace HighFive {                       \
     template<>                                 \
-    DataType create_datatype<type>() {         \
+    HighFive::DataType create_datatype<type>() {         \
         return function();                     \
     }                                          \
     }

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -386,9 +386,8 @@ class FixedLenStringArray {
 /// \endcode
 #define HIGHFIVE_REGISTER_TYPE(type, function) \
     template<>                                 \
-    HighFive::DataType create_datatype<type>() {         \
+    HighFive::DataType HighFive::create_datatype<type>() {         \
         return function();                     \
-    }                                          \
     }
 
 #include "bits/H5DataType_misc.hpp"


### PR DESCRIPTION
I was getting the error "namespace definition is not allowed here" here when calling HIGHFIVE_REGISTER_TYPE. This fixes that error.

- [x ] Issue 1 fixed
- [ ] Issue 2 fixed
- [ ] Feature 1 added
- [ ] Feature 2 added

Fixes #(issue)

**How to test this?**

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce if there is no integration test added with this PR. Please also list any relevant details for your test configuration

```bash
cmake ..
make -j8
make test
```

**Test System**
 - OS: [e.g. Ubuntu 20.04]
 - Compiler: [e.g. clang 12.0.0]
 - Dependency versions: [e.g. hdf5 1.12]
