### PR TITLE
Add an example for Eigen.

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -5,6 +5,12 @@ function(compile_example exemple_source)
     get_filename_component(example_filename ${exemple_source} NAME)
     string(REPLACE ".cpp" "_bin" example_name ${example_filename})
 
+    if(${example_filename} MATCHES ".*eigen.*")
+        if(NOT HIGHFIVE_USE_EIGEN)
+            return()
+        endif()
+    endif()
+
     if(${example_filename} MATCHES ".*boost.*")
         if(NOT HIGHFIVE_USE_BOOST)
             return()

--- a/src/examples/eigen_matrix.cpp
+++ b/src/examples/eigen_matrix.cpp
@@ -37,7 +37,7 @@ int main(void) {
         // we create a new hdf5 file
         File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // let's create our dataset of the size of the boost::multi_array
+        // let's create our dataset of the size of the eigen matrix
         file.createDataSet(DATASET_NAME, matrix);
 
     } catch (Exception& err) {

--- a/src/examples/eigen_matrix.cpp
+++ b/src/examples/eigen_matrix.cpp
@@ -1,4 +1,5 @@
 /*
+ *  Copyright (c), 2017, Adrien Devresse
  *  Copyright (c), 2022, Blue Brain Project
  *
  *  Distributed under the Boost Software License, Version 1.0.

--- a/src/examples/eigen_matrix.cpp
+++ b/src/examples/eigen_matrix.cpp
@@ -20,7 +20,7 @@ const std::string DATASET_NAME("dset");
 const int nrows = 10;
 const int ncols = 3;
 
-// Create a 2D dataset 10x3 of double with boost multi array
+// Create a 2D dataset 10x3 of double with eigen matrix
 // and write it to a file
 int main(void) {
 

--- a/src/examples/eigen_matrix.cpp
+++ b/src/examples/eigen_matrix.cpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c), 2022, Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#include <iostream>
+
+#ifdef H5_USE_EIGEN
+
+#include <Eigen/Dense>
+#include <highfive/H5File.hpp>
+
+using namespace HighFive;
+
+const std::string FILE_NAME("eigen_matrix_example.h5");
+const std::string DATASET_NAME("dset");
+const int nrows = 10;
+const int ncols = 3;
+
+// Create a 2D dataset 10x3 of double with boost multi array
+// and write it to a file
+int main(void) {
+
+    try {
+
+        Eigen::MatrixXd matrix(nrows, ncols);
+
+        for (int i = 0; i < nrows; ++i) {
+            for (int j = 0; j < ncols; ++j) {
+                matrix(i, j) = double(j + i * 100);
+            }
+        }
+
+        // we create a new hdf5 file
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+
+        // let's create our dataset of the size of the boost::multi_array
+        file.createDataSet(DATASET_NAME, matrix);
+
+    } catch (Exception& err) {
+        // catch and print any HDF5 error
+        std::cerr << err.what() << std::endl;
+    }
+
+    return 0; // successfully terminated
+}
+
+#endif


### PR DESCRIPTION
This PR adds one example of writing an `Eigen::MatrixXd` to disk using `File::createDataset` directly.

It also adds to the build-system to exclude Eigen examples if H5 is being built without Eigen.