### PR TITLE
Read/Write irregular hyperslab into 1D memspace.

### DIFF
--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -97,8 +97,7 @@ inline Selection SliceTraits<Derivate>::select(const HyperSlab& hyper_slab) cons
         auto memspace = DataSpace(regular_slab.packedDims());
 
         return Selection(memspace, filespace, details::get_dataset(slice));
-    }
-    else {
+    } else {
         auto n_elements = H5Sget_select_npoints(filespace.getId());
         auto memspace = DataSpace(std::array<size_t, 1>{size_t(n_elements)});
 

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1021,6 +1021,7 @@ struct RegularHyperSlabAnswer {
 };
 
 struct RegularHyperSlabTestData {
+    std::string desc;
     HyperSlab slab;
     RegularHyperSlabAnswer answer;
 };
@@ -1067,33 +1068,33 @@ std::vector<RegularHyperSlabTestData> make_regular_hyperslab_test_data() {
     // Union, regular
     auto slab_bc_union = HyperSlab(slabs["b"]) | slabs["c"];
     auto answer_bc_union = RegularHyperSlabAnswer::createRegular({4ul, 3ul}, {3ul, 5ul});
-    test_data.push_back({slab_bc_union, answer_bc_union});
+    test_data.push_back({"b | c", slab_bc_union, answer_bc_union});
 
     // Intersection, always regular
     auto slab_ab_cut = HyperSlab(slabs["a"]) & slabs["b"];
     auto answer_ab_cut = RegularHyperSlabAnswer{{{4ul, 3ul}, {5ul, 3ul}},
                                                 {{0ul, 0ul}, {1ul, 0ul}}};
-    test_data.push_back({slab_ab_cut, answer_ab_cut});
+    test_data.push_back({"a & b", slab_ab_cut, answer_ab_cut});
 
     // Intersection, always regular
     auto slab_bc_cut = HyperSlab(slabs["b"]) & slabs["c"];
     auto answer_bc_cut = RegularHyperSlabAnswer::createRegular({5ul, 3ul}, {1ul, 5ul});
-    test_data.push_back({slab_bc_cut, answer_bc_cut});
+    test_data.push_back({"b & c", slab_bc_cut, answer_bc_cut});
 
     // Xor, regular
     auto slab_ad_xor = HyperSlab(slabs["a"]) ^ slabs["d"];
     auto answer_ad_xor = RegularHyperSlabAnswer::createRegular({1ul, 1ul}, {6ul, 3ul});
-    test_data.push_back({slab_ad_xor, answer_ad_xor});
+    test_data.push_back({"a ^ b", slab_ad_xor, answer_ad_xor});
 
     // (not b) and c, regular
     auto slab_bc_nota = HyperSlab(slabs["b"]).notA(slabs["c"]);
     auto answer_bc_nota = RegularHyperSlabAnswer::createRegular({6ul, 3ul}, {1ul, 5ul});
-    test_data.push_back({slab_bc_nota, answer_bc_nota});
+    test_data.push_back({"b notA a", slab_bc_nota, answer_bc_nota});
 
     // (not c) and b, regular
     auto slab_cb_notb = HyperSlab(slabs["c"]).notB(slabs["b"]);
     auto answer_cb_notb = RegularHyperSlabAnswer::createRegular({6ul, 3ul}, {1ul, 5ul});
-    test_data.push_back({slab_cb_notb, answer_cb_notb});
+    test_data.push_back({"c notB b", slab_cb_notb, answer_cb_notb});
 
     return test_data;
 }
@@ -1137,16 +1138,18 @@ void regularHyperSlabSelectionTest() {
     auto test_cases = make_regular_hyperslab_test_data();
 
     for (const auto& test_case : test_cases) {
-        std::vector<std::vector<T>> result;
+        SECTION(test_case.desc) {
+            std::vector<std::vector<T>> result;
 
-        file.getDataSet(DATASET_NAME).select(test_case.slab).read(result);
+            file.getDataSet(DATASET_NAME).select(test_case.slab).read(result);
 
-        auto n_selected = test_case.answer.global_indices.size();
-        for (size_t i = 0; i < n_selected; ++i) {
-            const auto ig = test_case.answer.global_indices[i];
-            const auto il = test_case.answer.local_indices[i];
+            auto n_selected = test_case.answer.global_indices.size();
+            for (size_t i = 0; i < n_selected; ++i) {
+                const auto ig = test_case.answer.global_indices[i];
+                const auto il = test_case.answer.local_indices[i];
 
-            REQUIRE(result[il[0]][il[1]] == values[ig[0]][ig[1]]);
+                REQUIRE(result[il[0]][il[1]] == values[ig[0]][ig[1]]);
+            }
         }
     }
 }
@@ -1161,6 +1164,7 @@ struct IrregularHyperSlabAnswer {
 };
 
 struct IrregularHyperSlabTestData {
+    std::string desc;
     HyperSlab slab;
     IrregularHyperSlabAnswer answer;
 };
@@ -1196,7 +1200,7 @@ std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
                     {3ul, 1ul}, {3ul, 2ul}
     }};
     // clang-format on
-    test_data.push_back({slab_ab_union, answer_ab_union});
+    test_data.push_back({"a | b", slab_ab_union, answer_ab_union});
 
     // xor, irregular
     auto slab_ab_xor = HyperSlab(slabs["a"]) ^ slabs["b"];
@@ -1207,7 +1211,7 @@ std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
                         {3ul, 1ul}, {3ul, 2ul}
         }};
     // clang-format on
-    test_data.push_back({slab_ab_xor, answer_ab_xor});
+    test_data.push_back({"a xor b", slab_ab_xor, answer_ab_xor});
 
     // (not a) and e, irregular
     auto slab_ab_nota = HyperSlab(slabs["a"]).notA(slabs["b"]);
@@ -1218,7 +1222,7 @@ std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
                         {3ul, 1ul}, {3ul, 2ul}
         }};
     // clang-format on
-    test_data.push_back({slab_ab_nota, answer_ab_nota});
+    test_data.push_back({"a nota b", slab_ab_nota, answer_ab_nota});
 
     // (not a) and e, irregular
     auto slab_ba_notb = HyperSlab(slabs["b"]).notB(slabs["a"]);
@@ -1229,7 +1233,7 @@ std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
                          {3ul, 1ul}, {3ul, 2ul}
         }};
     // clang-format on
-    test_data.push_back({slab_ba_notb, answer_ba_notb});
+    test_data.push_back({"b notb a", slab_ba_notb, answer_ba_notb});
 
     return test_data;
 }
@@ -1251,15 +1255,17 @@ void irregularHyperSlabSelectionReadTest() {
     auto test_cases = make_irregular_hyperslab_test_data();
 
     for (const auto& test_case : test_cases) {
-        std::vector<T> result;
+        SECTION(test_case.desc) {
+            std::vector<T> result;
 
-        file.getDataSet(DATASET_NAME).select(test_case.slab).read(result);
+            file.getDataSet(DATASET_NAME).select(test_case.slab).read(result);
 
-        auto n_selected = test_case.answer.global_indices.size();
-        for (size_t i = 0; i < n_selected; ++i) {
-            const auto ig = test_case.answer.global_indices[i];
+            auto n_selected = test_case.answer.global_indices.size();
+            for (size_t i = 0; i < n_selected; ++i) {
+                const auto ig = test_case.answer.global_indices[i];
 
-            REQUIRE(result[i] == values[ig[0]][ig[1]]);
+                REQUIRE(result[i] == values[ig[0]][ig[1]]);
+            }
         }
     }
 }

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1241,7 +1241,7 @@ std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
 template <typename T>
 void irregularHyperSlabSelectionReadTest() {
     std::ostringstream filename;
-    filename << "h5_rw_select_irregular_hyperslab_test_" << typeNameHelper<T>()
+    filename << "h5_write_select_irregular_hyperslab_test_" << typeNameHelper<T>()
              << "_test.h5";
 
     const std::string DATASET_NAME("dset");
@@ -1270,7 +1270,7 @@ void irregularHyperSlabSelectionReadTest() {
     }
 }
 
-TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelection",
+TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelectionRead",
                         "[template]",
                         numerical_test_types) {
     irregularHyperSlabSelectionReadTest<TestType>();

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1107,34 +1107,42 @@ std::vector<RegularHyperSlabTestData> make_regular_hyperslab_test_data() {
     return test_data;
 }
 
-template <typename T>
-void regularHyperSlabSelectionTest() {
-    std::ostringstream filename;
-    filename << "h5_rw_select_regular_hyperslab_test_" << typeNameHelper<T>() << "_test.h5";
-
-    const size_t x_size = 10;
-    const size_t y_size = 8;
-
-    const std::string DATASET_NAME("dset");
-
-    T values[x_size][y_size];
-
+template <class T, size_t x_size, size_t y_size>
+File setupHyperSlabFile(T (&values)[x_size][y_size],
+                        const std::string& filename,
+                        const std::string& dataset_name) {
     ContentGenerate<T> generator;
     generate2D(values, x_size, y_size, generator);
 
     // Create a new file using the default property lists.
-    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
+    File file(filename, File::ReadWrite | File::Create | File::Truncate);
 
     // Create the data space for the dataset.
     std::vector<size_t> dims{x_size, y_size};
 
     DataSpace dataspace(dims);
     // Create a dataset with arbitrary type
-    DataSet dataset = file.createDataSet<T>(DATASET_NAME, dataspace);
+    DataSet dataset = file.createDataSet<T>(dataset_name, dataspace);
 
     dataset.write(values);
     file.flush();
 
+    return file;
+}
+
+template <typename T>
+void regularHyperSlabSelectionTest() {
+    std::ostringstream filename;
+    filename << "h5_rw_select_regular_hyperslab_test_" << typeNameHelper<T>()
+             << "_test.h5";
+    const std::string DATASET_NAME("dset");
+
+    const size_t x_size = 10;
+    const size_t y_size = 8;
+
+    T values[x_size][y_size];
+
+    auto file = setupHyperSlabFile(values, filename.str(), DATASET_NAME);
     auto test_cases = make_regular_hyperslab_test_data();
 
     for (const auto& test_case : test_cases) {
@@ -1236,33 +1244,18 @@ std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
 }
 
 template <typename T>
-void irregularHyperSlabSelectionTest() {
+void irregularHyperSlabSelectionReadTest() {
     std::ostringstream filename;
     filename << "h5_rw_select_irregular_hyperslab_test_" << typeNameHelper<T>()
              << "_test.h5";
 
+    const std::string DATASET_NAME("dset");
+
     const size_t x_size = 10;
     const size_t y_size = 8;
 
-    const std::string DATASET_NAME("dset");
-
     T values[x_size][y_size];
-
-    ContentGenerate<T> generator;
-    generate2D(values, x_size, y_size, generator);
-
-    // Create a new file using the default property lists.
-    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
-
-    // Create the data space for the dataset.
-    std::vector<size_t> dims{x_size, y_size};
-
-    DataSpace dataspace(dims);
-    // Create a dataset with arbitrary type
-    DataSet dataset = file.createDataSet<T>(DATASET_NAME, dataspace);
-
-    dataset.write(values);
-    file.flush();
+    auto file = setupHyperSlabFile(values, filename.str(), DATASET_NAME);
 
     auto test_cases = make_irregular_hyperslab_test_data();
 
@@ -1283,7 +1276,7 @@ void irregularHyperSlabSelectionTest() {
 TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelection",
                         "[template]",
                         numerical_test_types) {
-    irregularHyperSlabSelectionTest<TestType>();
+    irregularHyperSlabSelectionReadTest<TestType>();
 }
 
 template <typename T>

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -129,7 +129,6 @@ TEST_CASE("Test open modes in HighFive") {
     { File file(FILE_NAME, 0); }  // force empty-flags, does open without flags
 }
 
-
 TEST_CASE("Test file version bounds") {
     const std::string FILE_NAME("h5_version_bounds.h5");
 
@@ -154,7 +153,6 @@ TEST_CASE("Test file version bounds") {
     }
 }
 
-
 TEST_CASE("Test metadata block size assignment") {
     const std::string FILE_NAME("h5_meta_block_size.h5");
 
@@ -176,7 +174,6 @@ TEST_CASE("Test metadata block size assignment") {
     }
 }
 
-
 TEST_CASE("Test group properties") {
     const std::string FILE_NAME("h5_group_properties.h5");
     FileDriver adam;
@@ -194,7 +191,6 @@ TEST_CASE("Test group properties") {
     CHECK(sizes.second == 500);
 }
 
-
 TEST_CASE("Test default constructors") {
     const std::string FILE_NAME("h5_group_test.h5");
     const std::string DATASET_NAME("dset");
@@ -207,7 +203,6 @@ TEST_CASE("Test default constructors") {
     d2 = ds;  // copy
     CHECK(d2.isValid());
 }
-
 
 TEST_CASE("Test groups and datasets") {
     const std::string FILE_NAME("h5_group_test.h5");
@@ -258,16 +253,12 @@ TEST_CASE("Test groups and datasets") {
 
         {
             SilenceHDF5 silencer;
-            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME,
-                                               dataspace,
-                                               AtomicType<double>(),
-                                               badChunking0),
+            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
+                                               AtomicType<double>(), badChunking0),
                             DataSetException);
 
-            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME,
-                                               dataspace,
-                                               AtomicType<double>(),
-                                               badChunking1),
+            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
+                                               AtomicType<double>(), badChunking1),
                             DataSetException);
         }
 
@@ -1608,7 +1599,6 @@ TEST_CASE("HighFiveInspect") {
     CHECK(ds.getInfo().getRefCount() == 1);
 }
 
-
 TEST_CASE("HighFiveGetPath") {
     File file("getpath.h5", File::ReadWrite | File::Create | File::Truncate);
 
@@ -1658,7 +1648,8 @@ TEST_CASE("HighFiveSoftLinks") {
 
     {
         const std::string EXTERNAL_LINK_PATH("/external_link/to_ds");
-        File file2("link_external_to.h5", File::ReadWrite | File::Create | File::Truncate);
+        File file2("link_external_to.h5",
+                   File::ReadWrite | File::Create | File::Truncate);
         file2.createExternalLink(EXTERNAL_LINK_PATH, FILE_NAME, DS_PATH);
 
         std::vector<int> data_out;
@@ -1736,7 +1727,6 @@ TEST_CASE("HighFivePropertyObjects") {
     CHECK(plist_g2.isValid());
 }
 
-
 typedef struct {
     int m1;
     int m2;
@@ -1746,7 +1736,6 @@ typedef struct {
 typedef struct {
     CSL1 csl1;
 } CSL2;
-
 
 CompoundType create_compound_csl1() {
     auto t2 = AtomicType<int>();
@@ -1826,7 +1815,6 @@ TEST_CASE("HighFiveCompounds") {
     CompoundType t2_from_hid(t2);
     CHECK(t2 == t2_from_hid);
 }
-
 
 struct GrandChild {
     uint32_t gcm1;
@@ -1913,7 +1901,6 @@ TEST_CASE("HighFiveCompoundsNested") {
         CHECK(result[1].child.cm1 == 6);
     }
 }
-
 
 enum Position {
     FIRST = 1,
@@ -2006,7 +1993,8 @@ TEST_CASE("HighFiveFixedString") {
     File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
     char raw_strings[][10] = {"abcd", "1234"};
 
-    /// This will not compile - only char arrays - hits static_assert with a nice error
+    /// This will not compile - only char arrays - hits static_assert with a nice
+    /// error
     // file.createDataSet<int[10]>(DS_NAME, DataSpace(2)));
 
     {  // But char should be fine
@@ -2139,7 +2127,6 @@ TEST_CASE("HighFiveFixedLenStringArrayStructure") {
     }
 }
 
-
 TEST_CASE("HighFiveFixedLenStringArrayAttribute") {
     const std::string FILE_NAME("fixed_array_attr.h5");
     // Create a new file using the default property lists.
@@ -2158,7 +2145,6 @@ TEST_CASE("HighFiveFixedLenStringArrayAttribute") {
         CHECK(arr[1] == std::string("world"));
     }
 }
-
 
 TEST_CASE("HighFiveReference") {
     const std::string FILE_NAME("h5_ref_test.h5");

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -253,12 +253,16 @@ TEST_CASE("Test groups and datasets") {
 
         {
             SilenceHDF5 silencer;
-            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
-                                               AtomicType<double>(), badChunking0),
+            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME,
+                                               dataspace,
+                                               AtomicType<double>(),
+                                               badChunking0),
                             DataSetException);
 
-            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME, dataspace,
-                                               AtomicType<double>(), badChunking1),
+            CHECK_THROWS_AS(file.createDataSet(CHUNKED_DATASET_NAME,
+                                               dataspace,
+                                               AtomicType<double>(),
+                                               badChunking1),
                             DataSetException);
         }
 
@@ -1007,8 +1011,7 @@ std::vector<std::array<size_t, 1>> local_indices_1d(const std::vector<size_t>& c
 struct RegularHyperSlabAnswer {
     static RegularHyperSlabAnswer createRegular(const std::vector<size_t>& offset,
                                                 const std::vector<size_t>& count) {
-        return RegularHyperSlabAnswer{global_indices_2d(offset, count),
-                                      local_indices_2d(count)};
+        return RegularHyperSlabAnswer{global_indices_2d(offset, count), local_indices_2d(count)};
     }
 
     // These are the selected indices in the
@@ -1072,8 +1075,7 @@ std::vector<RegularHyperSlabTestData> make_regular_hyperslab_test_data() {
 
     // Intersection, always regular
     auto slab_ab_cut = HyperSlab(slabs["a"]) & slabs["b"];
-    auto answer_ab_cut = RegularHyperSlabAnswer{{{4ul, 3ul}, {5ul, 3ul}},
-                                                {{0ul, 0ul}, {1ul, 0ul}}};
+    auto answer_ab_cut = RegularHyperSlabAnswer{{{4ul, 3ul}, {5ul, 3ul}}, {{0ul, 0ul}, {1ul, 0ul}}};
     test_data.push_back({"a & b", slab_ab_cut, answer_ab_cut});
 
     // Intersection, always regular
@@ -1125,8 +1127,7 @@ File setupHyperSlabFile(T (&values)[x_size][y_size],
 template <typename T>
 void regularHyperSlabSelectionTest() {
     std::ostringstream filename;
-    filename << "h5_rw_select_regular_hyperslab_test_" << typeNameHelper<T>()
-             << "_test.h5";
+    filename << "h5_rw_select_regular_hyperslab_test_" << typeNameHelper<T>() << "_test.h5";
     const std::string DATASET_NAME("dset");
 
     const size_t x_size = 10;
@@ -1137,7 +1138,7 @@ void regularHyperSlabSelectionTest() {
     auto file = setupHyperSlabFile(values, filename.str(), DATASET_NAME);
     auto test_cases = make_regular_hyperslab_test_data();
 
-    for (const auto& test_case : test_cases) {
+    for (const auto& test_case: test_cases) {
         SECTION(test_case.desc) {
             std::vector<std::vector<T>> result;
 
@@ -1241,8 +1242,7 @@ std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
 template <typename T>
 void irregularHyperSlabSelectionReadTest() {
     std::ostringstream filename;
-    filename << "h5_write_select_irregular_hyperslab_test_" << typeNameHelper<T>()
-             << "_test.h5";
+    filename << "h5_write_select_irregular_hyperslab_test_" << typeNameHelper<T>() << "_test.h5";
 
     const std::string DATASET_NAME("dset");
 
@@ -1254,7 +1254,7 @@ void irregularHyperSlabSelectionReadTest() {
 
     auto test_cases = make_irregular_hyperslab_test_data();
 
-    for (const auto& test_case : test_cases) {
+    for (const auto& test_case: test_cases) {
         SECTION(test_case.desc) {
             std::vector<T> result;
 
@@ -1270,17 +1270,14 @@ void irregularHyperSlabSelectionReadTest() {
     }
 }
 
-TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelectionRead",
-                        "[template]",
-                        numerical_test_types) {
+TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelectionRead", "[template]", numerical_test_types) {
     irregularHyperSlabSelectionReadTest<TestType>();
 }
 
 template <typename T>
 void irregularHyperSlabSelectionWriteTest() {
     std::ostringstream filename;
-    filename << "h5_write_select_irregular_hyperslab_test_" << typeNameHelper<T>()
-             << "_test.h5";
+    filename << "h5_write_select_irregular_hyperslab_test_" << typeNameHelper<T>() << "_test.h5";
 
     const std::string DATASET_NAME("dset");
 
@@ -1292,7 +1289,7 @@ void irregularHyperSlabSelectionWriteTest() {
 
     auto test_cases = make_irregular_hyperslab_test_data();
 
-    for (const auto& test_case : test_cases) {
+    for (const auto& test_case: test_cases) {
         SECTION(test_case.desc) {
             auto n_selected = test_case.answer.global_indices.size();
             std::vector<T> changed_values(n_selected);
@@ -1325,9 +1322,7 @@ void irregularHyperSlabSelectionWriteTest() {
     }
 }
 
-TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelectionWrite",
-                        "[template]",
-                        std::tuple<int>) {
+TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelectionWrite", "[template]", std::tuple<int>) {
     irregularHyperSlabSelectionWriteTest<TestType>();
 }
 
@@ -1709,8 +1704,7 @@ TEST_CASE("HighFiveSoftLinks") {
 
     {
         const std::string EXTERNAL_LINK_PATH("/external_link/to_ds");
-        File file2("link_external_to.h5",
-                   File::ReadWrite | File::Create | File::Truncate);
+        File file2("link_external_to.h5", File::ReadWrite | File::Create | File::Truncate);
         file2.createExternalLink(EXTERNAL_LINK_PATH, FILE_NAME, DS_PATH);
 
         std::vector<int> data_out;

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1004,11 +1004,20 @@ std::vector<std::array<size_t, 2>> local_indices_2d(const std::vector<size_t>& c
     return global_indices_2d({0ul, 0ul}, count);
 }
 
-struct HyperSlabAnswer {
-    static HyperSlabAnswer createRegular(const std::vector<size_t>& offset,
-                                         const std::vector<size_t>& count) {
-        return HyperSlabAnswer{global_indices_2d(offset, count),
-                               local_indices_2d(count)};
+std::vector<std::array<size_t, 1>> local_indices_1d(const std::vector<size_t>& count) {
+    std::vector<std::array<size_t, 1>> local_indices;
+    for (size_t i = 0; i < count[0]; ++i) {
+        local_indices.push_back({i});
+    }
+
+    return local_indices;
+}
+
+struct RegularHyperSlabAnswer {
+    static RegularHyperSlabAnswer createRegular(const std::vector<size_t>& offset,
+                                                const std::vector<size_t>& count) {
+        return RegularHyperSlabAnswer{global_indices_2d(offset, count),
+                                      local_indices_2d(count)};
     }
 
     // These are the selected indices in the
@@ -1020,12 +1029,14 @@ struct HyperSlabAnswer {
     std::vector<std::array<size_t, 2>> local_indices;
 };
 
-struct HyperSlabTestData {
+struct RegularHyperSlabTestData {
     HyperSlab slab;
-    HyperSlabAnswer answer;
+    RegularHyperSlabAnswer answer;
 };
 
-std::vector<HyperSlabTestData> make_regular_hyperslab_test_data() {
+std::vector<RegularHyperSlabTestData> make_regular_hyperslab_test_data() {
+    std::vector<RegularHyperSlabTestData> test_data;
+
     // The dataset is 10x8, we define the following regular
     // hyperslabs:
     //  x----------------x
@@ -1045,79 +1056,59 @@ std::vector<HyperSlabTestData> make_regular_hyperslab_test_data() {
     //  ------------------
     //    1    3 4       8
 
-    auto slab_a = RegularHyperSlab(/* offset = */ {1ul, 1ul},
-                                   /* count = */ {8ul, 3ul});
+    std::map<std::string, RegularHyperSlab> slabs;
 
-    auto slab_b = RegularHyperSlab(/* offset = */ {4ul, 3ul},
-                                   /* count = */ {2ul, 5ul});
+    slabs["a"] = RegularHyperSlab(/* offset = */ {1ul, 1ul},
+                                  /* count = */ {8ul, 3ul});
 
-    auto slab_c = RegularHyperSlab(/* offset = */ {5ul, 3ul},
-                                   /* count = */ {2ul, 5ul});
+    slabs["b"] = RegularHyperSlab(/* offset = */ {4ul, 3ul},
+                                  /* count = */ {2ul, 5ul});
 
-    auto slab_d = RegularHyperSlab(/* offset = */ {7ul, 1ul},
-                                   /* count = */ {2ul, 3ul});
+    slabs["c"] = RegularHyperSlab(/* offset = */ {5ul, 3ul},
+                                  /* count = */ {2ul, 5ul});
 
-    auto slab_e = RegularHyperSlab(/* offset = */ {0ul, 0ul},
-                                   /* count = */ {3ul, 8ul});
+    slabs["d"] = RegularHyperSlab(/* offset = */ {7ul, 1ul},
+                                  /* count = */ {2ul, 3ul});
 
-    std::vector<HyperSlabTestData> test_data;
-
-//    // Union, irregular
-//    auto slab_ab_union = HyperSlab(slab_a) | slab_b;
-//    auto answer_ab_union = HyperSlabAnswer::createIrregular();
-//    test_data.push_back({slab_ab_union, answer_ab_union});
+    slabs["e"] = RegularHyperSlab(/* offset = */ {0ul, 0ul},
+                                  /* count = */ {3ul, 8ul});
 
     // Union, regular
-    auto slab_bc_union = HyperSlab(slab_b) | slab_c;
-    auto answer_bc_union = HyperSlabAnswer::createRegular({4ul, 3ul}, {3ul, 5ul});
+    auto slab_bc_union = HyperSlab(slabs["b"]) | slabs["c"];
+    auto answer_bc_union = RegularHyperSlabAnswer::createRegular({4ul, 3ul}, {3ul, 5ul});
     test_data.push_back({slab_bc_union, answer_bc_union});
 
     // Intersection, always regular
-    auto slab_ab_cut = HyperSlab(slab_a) & slab_b;
-    auto answer_ab_cut = HyperSlabAnswer{
-        {{4ul, 3ul}, {5ul, 3ul}}, {{0ul, 0ul}, {1ul, 0ul}}};
+    auto slab_ab_cut = HyperSlab(slabs["a"]) & slabs["b"];
+    auto answer_ab_cut = RegularHyperSlabAnswer{{{4ul, 3ul}, {5ul, 3ul}},
+                                                {{0ul, 0ul}, {1ul, 0ul}}};
     test_data.push_back({slab_ab_cut, answer_ab_cut});
 
     // Intersection, always regular
-    auto slab_bc_cut = HyperSlab(slab_b) & slab_c;
-    auto answer_bc_cut = HyperSlabAnswer::createRegular({5ul, 3ul}, {1ul, 5ul});
+    auto slab_bc_cut = HyperSlab(slabs["b"]) & slabs["c"];
+    auto answer_bc_cut = RegularHyperSlabAnswer::createRegular({5ul, 3ul}, {1ul, 5ul});
     test_data.push_back({slab_bc_cut, answer_bc_cut});
 
     // Xor, regular
-    auto slab_ad_xor = HyperSlab(slab_a) ^ slab_d;
-    auto answer_ad_xor = HyperSlabAnswer::createRegular({1ul, 1ul}, {6ul, 3ul});
+    auto slab_ad_xor = HyperSlab(slabs["a"]) ^ slabs["d"];
+    auto answer_ad_xor = RegularHyperSlabAnswer::createRegular({1ul, 1ul}, {6ul, 3ul});
     test_data.push_back({slab_ad_xor, answer_ad_xor});
 
-//    // Xor, irregular
-//    auto slab_ac_xor = HyperSlab(slab_a) ^ slab_c;
-//    auto answer_ac_xor = HyperSlabAnswer::createIrregular();
-//    test_data.push_back({slab_ac_xor, answer_ac_xor});
-
     // (not b) and c, regular
-    auto slab_bc_nota = HyperSlab(slab_b).notA(slab_c);
-    auto answer_bc_nota = HyperSlabAnswer::createRegular({6ul, 3ul}, {1ul, 5ul});
+    auto slab_bc_nota = HyperSlab(slabs["b"]).notA(slabs["c"]);
+    auto answer_bc_nota = RegularHyperSlabAnswer::createRegular({6ul, 3ul}, {1ul, 5ul});
     test_data.push_back({slab_bc_nota, answer_bc_nota});
 
-//    // (not a) and e, irregular
-//    auto slab_ae_nota = HyperSlab(slab_a).notA(slab_e);
-//    auto answer_ae_nota = HyperSlabAnswer::createIrregular();
-//    test_data.push_back({slab_ae_nota, answer_ae_nota});
-
     // (not c) and b, regular
-    auto slab_cb_notb = HyperSlab(slab_c).notB(slab_b);
-    auto answer_cb_notb = HyperSlabAnswer::createRegular({6ul, 3ul}, {1ul, 5ul});
+    auto slab_cb_notb = HyperSlab(slabs["c"]).notB(slabs["b"]);
+    auto answer_cb_notb = RegularHyperSlabAnswer::createRegular({6ul, 3ul}, {1ul, 5ul});
     test_data.push_back({slab_cb_notb, answer_cb_notb});
-
-//    // (not a) and e, irregular
-//    auto slab_ea_notb = HyperSlab(slab_e).notB(slab_a);
-//    auto answer_ea_notb = HyperSlabAnswer::createIrregular();
-//    test_data.push_back({slab_ea_notb, answer_ea_notb});
 
     return test_data;
 }
 
 template <typename T>
-void hyperSlabSelectionTest() {
+void regularHyperSlabSelectionTest() {
     std::ostringstream filename;
     filename << "h5_rw_select_regular_hyperslab_test_" << typeNameHelper<T>() << "_test.h5";
 
@@ -1162,7 +1153,137 @@ void hyperSlabSelectionTest() {
 }
 
 TEMPLATE_LIST_TEST_CASE("hyperSlabSelection", "[template]", numerical_test_types) {
-    hyperSlabSelectionTest<TestType>();
+    regularHyperSlabSelectionTest<TestType>();
+}
+
+struct IrregularHyperSlabAnswer {
+    // These are the selected indices in the outer (larger) array.
+    std::vector<std::array<size_t, 2>> global_indices;
+};
+
+struct IrregularHyperSlabTestData {
+    HyperSlab slab;
+    IrregularHyperSlabAnswer answer;
+};
+
+std::vector<IrregularHyperSlabTestData> make_irregular_hyperslab_test_data() {
+    // The dataset is 10x8, with two regular hyperslabs:
+    //  x----------------x
+    //  |                |
+    //  |    bbbb        |
+    //  |    bbbb        |
+    //  |  aaaabb        |
+    //  |  aaaabb        |
+    //  |    bbbb        |
+    //  |    bbbb        |
+    //  |                |
+    //  |                |
+    //  |                |
+    //  |                |
+    //  ------------------
+
+    auto slabs = std::map<std::string, RegularHyperSlab>{};
+    slabs["a"] = RegularHyperSlab{{2ul, 0ul}, {1ul, 2ul}};
+    slabs["b"] = RegularHyperSlab{{1ul, 1ul}, {3ul, 2ul}};
+
+    std::vector<IrregularHyperSlabTestData> test_data;
+
+    // Union, irregular
+    auto slab_ab_union = HyperSlab(slabs["a"]) | slabs["b"];
+    // clang-format off
+    auto answer_ab_union = IrregularHyperSlabAnswer{{
+                    {1ul, 1ul}, {1ul, 2ul},
+        {2ul, 0ul}, {2ul, 1ul}, {2ul, 2ul},
+                    {3ul, 1ul}, {3ul, 2ul}
+    }};
+    // clang-format on
+    test_data.push_back({slab_ab_union, answer_ab_union});
+
+    // xor, irregular
+    auto slab_ab_xor = HyperSlab(slabs["a"]) ^ slabs["b"];
+    // clang-format off
+        auto answer_ab_xor = IrregularHyperSlabAnswer{{
+                        {1ul, 1ul}, {1ul, 2ul},
+            {2ul, 0ul},             {2ul, 2ul},
+                        {3ul, 1ul}, {3ul, 2ul}
+        }};
+    // clang-format on
+    test_data.push_back({slab_ab_xor, answer_ab_xor});
+
+    // (not a) and e, irregular
+    auto slab_ab_nota = HyperSlab(slabs["a"]).notA(slabs["b"]);
+    // clang-format off
+        auto answer_ab_nota = IrregularHyperSlabAnswer{{
+                        {1ul, 1ul}, {1ul, 2ul},
+                                    {2ul, 2ul},
+                        {3ul, 1ul}, {3ul, 2ul}
+        }};
+    // clang-format on
+    test_data.push_back({slab_ab_nota, answer_ab_nota});
+
+    // (not a) and e, irregular
+    auto slab_ba_notb = HyperSlab(slabs["b"]).notB(slabs["a"]);
+    // clang-format off
+        auto answer_ba_notb = IrregularHyperSlabAnswer{{
+                         {1ul, 1ul}, {1ul, 2ul},
+                                     {2ul, 2ul},
+                         {3ul, 1ul}, {3ul, 2ul}
+        }};
+    // clang-format on
+    test_data.push_back({slab_ba_notb, answer_ba_notb});
+
+    return test_data;
+}
+
+template <typename T>
+void irregularHyperSlabSelectionTest() {
+    std::ostringstream filename;
+    filename << "h5_rw_select_irregular_hyperslab_test_" << typeNameHelper<T>()
+             << "_test.h5";
+
+    const size_t x_size = 10;
+    const size_t y_size = 8;
+
+    const std::string DATASET_NAME("dset");
+
+    T values[x_size][y_size];
+
+    ContentGenerate<T> generator;
+    generate2D(values, x_size, y_size, generator);
+
+    // Create a new file using the default property lists.
+    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate);
+
+    // Create the data space for the dataset.
+    std::vector<size_t> dims{x_size, y_size};
+
+    DataSpace dataspace(dims);
+    // Create a dataset with arbitrary type
+    DataSet dataset = file.createDataSet<T>(DATASET_NAME, dataspace);
+
+    dataset.write(values);
+    file.flush();
+
+    auto test_cases = make_irregular_hyperslab_test_data();
+
+    for (const auto& test_case : test_cases) {
+        std::vector<T> result;
+
+        file.getDataSet(DATASET_NAME).select(test_case.slab).read(result);
+
+        auto n_selected = test_case.answer.global_indices.size();
+        for (size_t i = 0; i < n_selected; ++i) {
+            const auto ig = test_case.answer.global_indices[i];
+
+            REQUIRE(result[i] == values[ig[0]][ig[1]]);
+        }
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("irregularHyperSlabSelection",
+                        "[template]",
+                        numerical_test_types) {
+    irregularHyperSlabSelectionTest<TestType>();
 }
 
 template <typename T>


### PR DESCRIPTION
Expanding on the work in #538 this PR enables reading and writing to and from irregular hyperslabs from and to 1D memory. Note that the dataset can have any dimension. Therefore, any selection in filespace is now possible. Currently, no selection in memspace is supported. Therefore the API can cleanly support reading and writing to 1D memory.

Why is only 1D memory supported? The issue lies with non-contiguous memory such a `std::vector<std::vector<double>>` in order to read the selection back into the correct location in memory either substantial indexing logic would need to be re-implemented; or the entire array would first need to be written to the flat temporary buffer passed to HDF5 for reading/writing.

Since the general case is substantially more complex than ad hoc solutions for special cases, this PR suggest leaving the (un)packing of the 1D memory to the user.

Why are only simple dataspaces supported in memspace? The problem is similar to the issue which prevents reading/writing irregular dataspaces into multi-dimensional memory. Further, this isn't supported by the elementary selections present before the introduction of hyperslabs.

Both issues will become easier to tackle when the `inspector`-approach has been adopted more completely.

This change only affects the overload `SliceTraits<D>::select(const HyperSlab&)` but none of the preexisting selection mechanisms. Therefore, I don't think it can affect current behaviour.