### PR TITLE
Improve EnumType API

### DIFF
--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -224,6 +224,11 @@ class EnumType: public DataType {
 
     EnumType(const std::vector<member_def>& t_members)
         : members(t_members) {
+        static_assert(std::is_enum<T>::value, "EnumType<T>::create takes only enum");
+        if (members.empty()) {
+            HDF5ErrMapper::ToException<DataTypeException>(
+                "Could not create an enum without members");
+        }
         create();
     }
 

--- a/src/examples/compound_types.cpp
+++ b/src/examples/compound_types.cpp
@@ -20,7 +20,8 @@ typedef struct {
 
 
 HighFive::CompoundType create_compound_Size2D() {
-    return {{"width", HighFive::AtomicType<double>{}}, {"height", HighFive::AtomicType<double>{}}};
+    return {{"width", HighFive::create_datatype<double>()},
+            {"height", HighFive::create_datatype<double>()}};
 }
 
 HIGHFIVE_REGISTER_TYPE(Size2D, create_compound_Size2D)

--- a/src/examples/create_attribute_string_integer.cpp
+++ b/src/examples/create_attribute_string_integer.cpp
@@ -31,7 +31,7 @@ int main(void) {
         File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
         // Create a dummy dataset of one single integer
-        DataSet dataset = file.createDataSet(DATASET_NAME, DataSpace(1), AtomicType<int>());
+        DataSet dataset = file.createDataSet(DATASET_NAME, DataSpace(1), create_datatype<int>());
 
         // Now let's add a attribute on this dataset
         // This attribute will be named "note"

--- a/src/examples/create_datatype.cpp
+++ b/src/examples/create_datatype.cpp
@@ -27,9 +27,9 @@ bool operator!=(csl x, csl y) {
 // Tell HighFive how to create the HDF5 datatype for this base type by
 // using the HIGHFIVE_REGISTER_TYPE macro
 CompoundType create_compound_csl() {
-    return {{"u1", AtomicType<unsigned char>{}},
-            {"u2", AtomicType<short>{}},
-            {"u3", AtomicType<unsigned long long>{}}};
+    return {{"u1", create_datatype<unsigned char>()},
+            {"u2", create_datatype<short>()},
+            {"u3", create_datatype<unsigned long long>()}};
 }
 HIGHFIVE_REGISTER_TYPE(csl, create_compound_csl)
 
@@ -40,19 +40,19 @@ int main(void) {
         // Create a simple compound type with automatic alignment of the
         // members. For this the type alignment is trivial.
         std::vector<CompoundType::member_def> t_members(
-            {{"real", AtomicType<int>{}}, {"imag", AtomicType<int>{}}});
+            {{"real", create_datatype<int>()}, {"imag", create_datatype<int>()}});
         CompoundType t(t_members);
         t.commit(file, "new_type1");
 
         // Create a complex nested datatype with manual alignment
-        CompoundType u({{"u1", t, 0}, {"u2", t, 9}, {"u3", AtomicType<int>{}, 20}}, 26);
+        CompoundType u({{"u1", t, 0}, {"u2", t, 9}, {"u3", create_datatype<int>(), 20}}, 26);
         u.commit(file, "new_type3");
 
         // Create a more complex type with automatic alignment. For this the
         // type alignment is more complex.
-        CompoundType v_aligned{{"u1", AtomicType<unsigned char>{}},
-                               {"u2", AtomicType<short>{}},
-                               {"u3", AtomicType<unsigned long long>{}}};
+        CompoundType v_aligned{{"u1", create_datatype<unsigned char>()},
+                               {"u2", create_datatype<short>()},
+                               {"u3", create_datatype<unsigned long long>()}};
         // introspect the compound type
         std::cout << "v_aligned size: " << v_aligned.getSize();
         for (const auto& member: v_aligned.getMembers()) {
@@ -64,9 +64,9 @@ int main(void) {
         // Create a more complex type with a fully packed alignment. The
         // equivalent type is created with a standard struct alignment in the
         // implementation of HighFive::create_datatype above
-        CompoundType v_packed({{"u1", AtomicType<unsigned char>{}, 0},
-                               {"u2", AtomicType<short>{}, 1},
-                               {"u3", AtomicType<unsigned long long>{}, 3}},
+        CompoundType v_packed({{"u1", create_datatype<unsigned char>(), 0},
+                               {"u2", create_datatype<short>(), 1},
+                               {"u3", create_datatype<unsigned long long>(), 3}},
                               11);
         v_packed.commit(file, "new_type2_packed");
 

--- a/src/examples/create_extensible_dataset.cpp
+++ b/src/examples/create_extensible_dataset.cpp
@@ -33,7 +33,8 @@ int main(void) {
         props.add(Chunking(std::vector<hsize_t>{2, 2}));
 
         // Create the dataset
-        DataSet dataset = file.createDataSet(DATASET_NAME, dataspace, AtomicType<double>(), props);
+        DataSet dataset =
+            file.createDataSet(DATASET_NAME, dataspace, create_datatype<double>(), props);
 
         // Write into the initial part of the dataset
         double t1[3][1] = {{2.0}, {2.0}, {4.0}};

--- a/src/examples/renaming_objects.cpp
+++ b/src/examples/renaming_objects.cpp
@@ -23,7 +23,7 @@ int main(void) {
     Group group = file.createGroup("group");
 
     // Create a dummy dataset of one single integer
-    DataSet dataset = group.createDataSet("data", DataSpace(1), AtomicType<int>());
+    DataSet dataset = group.createDataSet("data", DataSpace(1), create_datatype<int>());
     dataset.write(100);
 
     // Let's also add a attribute to this dataset


### PR DESCRIPTION
* block creation of empty Enum (hdf5 segfault with them)
* fix examples to use create_datatype instead of AtomicType (more idiomatic)
