### PR TITLE
Support complex float

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -169,8 +169,9 @@ class AtomicType<FixedLenStringArray<StrLen>>: public DataType {
         : DataType(create_string(StrLen)) {}
 };
 
-template <> inline AtomicType<std::complex<float>>::AtomicType() {
-    static struct ComplexType : public Object {
+template <>
+inline AtomicType<std::complex<float>>::AtomicType() {
+    static struct ComplexType: public Object {
         ComplexType() {
             _hid = H5Tcreate(H5T_COMPOUND, sizeof(std::complex<float>));
             // h5py/numpy compatible datatype

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -169,6 +169,18 @@ class AtomicType<FixedLenStringArray<StrLen>>: public DataType {
         : DataType(create_string(StrLen)) {}
 };
 
+template <> inline AtomicType<std::complex<float>>::AtomicType() {
+    static struct ComplexType : public Object {
+        ComplexType() {
+            _hid = H5Tcreate(H5T_COMPOUND, sizeof(std::complex<float>));
+            // h5py/numpy compatible datatype
+            H5Tinsert(_hid, "r", 0, H5T_NATIVE_FLOAT);
+            H5Tinsert(_hid, "i", sizeof(float), H5T_NATIVE_FLOAT);
+        };
+    } complexType;
+    _hid = H5Tcopy(complexType.getId());
+}
+
 template <>
 inline AtomicType<std::complex<double>>::AtomicType() {
     static struct ComplexType: public Object {

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -12,7 +12,8 @@
 #include <string>
 #include <vector>
 
-using complex = std::complex<double>;
+using dcomplex = std::complex<double>;
+using fcomplex = std::complex<float>;
 
 using floating_numerics_test_types = std::tuple<float, double>;
 
@@ -26,7 +27,8 @@ using numerical_test_types = std::tuple<int,
                                         double,
                                         long long,
                                         unsigned long long,
-                                        complex>;
+                                        dcomplex,
+                                        fcomplex>;
 
 using dataset_test_types =
     std::tuple<int, unsigned int, long, unsigned long, unsigned char, char, float, double>;
@@ -90,9 +92,14 @@ struct ContentGenerate {
 };
 
 template <>
-ContentGenerate<complex>::ContentGenerate()
+ContentGenerate<dcomplex>::ContentGenerate()
     : _init(0, 0)
-    , _inc(complex(1, 1) + complex(1, 1) / complex(10)) {}
+    , _inc(dcomplex(1, 1) + dcomplex(1, 1) / dcomplex(10)) {}
+
+template <>
+ContentGenerate<fcomplex>::ContentGenerate()
+    : _init(0, 0)
+    , _inc(fcomplex(1, 1) + fcomplex(1, 1) / fcomplex(10)) {}
 
 template <>
 struct ContentGenerate<char> {


### PR DESCRIPTION
**Description**

This MR introduces support for `std::complex<float>`. 


**How to test this?**

I added the `std::complex<float>` type to the `numerical_test_types` (as `fcomplex` and renamed `complex` to `dcomplex`) and added a corresponding generator.


**Test System**
 - OS: MacOS 12.3.1
 - Compiler: clang 13.0.1
 - Dependency versions: hdf5 1.12.1
