### PR TITLE
Build fix for Visual Studio 2017 with c++17 or later

### DIFF
--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -93,6 +93,8 @@ class Object {
     friend class AnnotateTraits;
     friend class Reference;
     friend class CompoundType;
+    template <typename Derivate>
+    friend class PathTraits;
 };
 
 


### PR DESCRIPTION
PathTraits added as friend of object

**Description**

Fixes #577

**How to test this?**

Build master with cmake Visual Studio 15 2017 generator, arch x64, on windows 10
Change the C++ language standard to c++17 (or later) in the Visual Studio UI (Configuration Properties -> C/C++ -> Language -> C++ Language Standard) in one of the examples or tests, and then try to build.  The code should now build correctly.

**Test System**
 - OS: Windows 10
 - Compiler: Visual Studio 15 2017
