### PR TITLE
Support for half-precision (16-bit) floating-point datasets

### DIFF
--- a/CMake/HighFiveTargetDeps.cmake
+++ b/CMake/HighFiveTargetDeps.cmake
@@ -30,6 +30,15 @@ if(NOT TARGET libdeps)
     target_compile_definitions(libdeps INTERFACE BOOST_ALL_NO_LIB H5_USE_BOOST)
   endif()
 
+  # Half
+  if(HIGHFIVE_USE_HALF_FLOAT)
+    find_file(FOUND_HALF half.hpp)
+    if (NOT FOUND_HALF)
+      message(FATAL_ERROR "Half-precision floating-point support requested but file half.hpp not found")
+    endif()
+    target_compile_definitions(libdeps INTERFACE H5_USE_HALF_FLOAT)
+  endif()
+
   # Eigen
   if(HIGHFIVE_USE_EIGEN)
     if (NOT EIGEN3_INCLUDE_DIRS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(HIGHFIVE_UNIT_TESTS AUTO CACHE STRING "Enable unit tests (requires Catch2 to
 set_property(CACHE HIGHFIVE_UNIT_TESTS PROPERTY STRINGS AUTO ON OFF)
 
 option(HIGHFIVE_USE_BOOST "Enable Boost Support" ${USE_BOOST})
+option(HIGHFIVE_USE_HALF_FLOAT "Enable half-precision floats" ${USE_HALF_FLOAT})
 option(HIGHFIVE_USE_EIGEN "Enable Eigen testing" ${USE_EIGEN})
 option(HIGHFIVE_USE_OPENCV "Enable OpenCV testing" ${USE_OPENCV})
 option(HIGHFIVE_USE_XTENSOR "Enable xtensor testing" ${USE_XTENSOR})

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ It integrates nicely with other CMake projects by defining (and exporting) a Hig
 - selection() / slice support
 - parallel Read/Write operations from several nodes with Parallel HDF5
 - Advanced types: Compound, Enum, Arrays of Fixed-length strings, References
+- half-precision (16-bit) floating-point datasets
 - etc... (see [ChangeLog](./CHANGELOG.md))
 
 ### Dependencies
@@ -40,6 +41,7 @@ It integrates nicely with other CMake projects by defining (and exporting) a Hig
 - boost >= 1.41 (recommended, opt-out with -D*HIGHFIVE_USE_BOOST*=OFF)
 - eigen3 (optional, opt-in with -D*HIGHFIVE_USE_EIGEN*=ON)
 - xtensor (optional, opt-in with -D*HIGHFIVE_USE_XTENSOR*=ON)
+- half (optional, opt-in with -D*HIGHFIVE_USE_HALF_FLOAT*=ON)
 
 
 ## Examples

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -133,11 +133,13 @@ inline AtomicType<unsigned long long>::AtomicType() {
 using float16_t = half_float::half;
 
 template <>
-inline AtomicType<float16_t>::AtomicType()
-{
+inline AtomicType<float16_t>::AtomicType() {
     _hid = H5Tcopy(H5T_NATIVE_FLOAT);
+    // Sign position, exponent position, exponent size, mantissa position, mantissa size
     H5Tset_fields(_hid, 15, 10, 5, 0, 10);
+    // Total datatype size (in bytes)
     H5Tset_size(_hid, 2);
+    // Floating point exponent bias
     H5Tset_ebias(_hid, 15);
 }
 #endif

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -16,6 +16,9 @@
 #include <H5Ppublic.h>
 #include <H5Tpublic.h>
 
+#ifdef H5_USE_HALF_FLOAT
+#include <half.hpp>
+#endif
 
 namespace HighFive {
 
@@ -125,7 +128,20 @@ inline AtomicType<unsigned long long>::AtomicType() {
     _hid = H5Tcopy(H5T_NATIVE_ULLONG);
 }
 
-// float, double and long double mapping
+// half-float, float, double and long double mapping
+#ifdef H5_USE_HALF_FLOAT
+using float16_t = half_float::half;
+
+template <>
+inline AtomicType<float16_t>::AtomicType()
+{
+    _hid = H5Tcopy(H5T_NATIVE_FLOAT);
+    H5Tset_fields(_hid, 15, 10, 5, 0, 10);
+    H5Tset_size(_hid, 2);
+    H5Tset_ebias(_hid, 15);
+}
+#endif
+
 template <>
 inline AtomicType<float>::AtomicType() {
     _hid = H5Tcopy(H5T_NATIVE_FLOAT);

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -23,6 +23,12 @@ function(compile_example exemple_source)
         endif()
     endif()
 
+    if(${example_filename} MATCHES ".*half_float.*")
+        if(NOT HIGHFIVE_USE_HALF_FLOAT)
+            return()
+        endif()
+    endif()
+
     add_executable(${example_name} ${exemple_source})
     target_link_libraries(${example_name} HighFive)
 

--- a/src/examples/create_dataset_half_float.cpp
+++ b/src/examples/create_dataset_half_float.cpp
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c), 2022, Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+
+#ifdef H5_USE_HALF_FLOAT
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <highfive/H5DataSet.hpp>
+#include <highfive/H5DataSpace.hpp>
+#include <highfive/H5File.hpp>
+
+const std::string FILE_NAME("create_dataset_half_float_example.h5");
+const std::string DATASET_NAME("dset");
+
+// Create a dataset name "dset", size 4x6, and type float16_t (i.e., 16-bit half-precision floating-point format)
+//
+int main(void) {
+    using namespace HighFive;
+    try {
+        // Create a new file using the default property lists.
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+
+        // Define the size of our dataset: 4x6
+        std::vector<size_t> dims{4, 6};
+
+        // Create the dataset
+        DataSet dataset = file.createDataSet<float16_t>(DATASET_NAME, DataSpace(dims));
+
+        std::vector<std::vector<float16_t>> data;
+        for (size_t i = 0; i < 4; ++i)
+        {
+            data.emplace_back();
+            for (size_t j = 0; j < 6; ++j)
+                data[i].emplace_back((i + 1) * (j + 1));
+        }
+
+        // write it
+        dataset.write(data);
+
+    } catch (Exception& err) {
+        // catch and print any HDF5 error
+        std::cerr << err.what() << std::endl;
+    }
+
+    return 0;  // successfully terminated
+}
+
+#endif
+

--- a/src/examples/create_dataset_half_float.cpp
+++ b/src/examples/create_dataset_half_float.cpp
@@ -20,7 +20,8 @@
 const std::string FILE_NAME("create_dataset_half_float_example.h5");
 const std::string DATASET_NAME("dset");
 
-// Create a dataset name "dset", size 4x6, and type float16_t (i.e., 16-bit half-precision floating-point format)
+// Create a dataset name "dset", size 4x6, and type float16_t (i.e., 16-bit half-precision
+// floating-point format)
 //
 int main(void) {
     using namespace HighFive;
@@ -35,8 +36,7 @@ int main(void) {
         DataSet dataset = file.createDataSet<float16_t>(DATASET_NAME, DataSpace(dims));
 
         std::vector<std::vector<float16_t>> data;
-        for (size_t i = 0; i < 4; ++i)
-        {
+        for (size_t i = 0; i < 4; ++i) {
             data.emplace_back();
             for (size_t j = 0; j < 6; ++j)
                 data[i].emplace_back((i + 1) * (j + 1));
@@ -54,4 +54,3 @@ int main(void) {
 }
 
 #endif
-

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -35,7 +35,8 @@ using base_test_types = std::tuple<int,
 #include <half.hpp>
 
 using float16_t = half_float::half;
-using numerical_test_types = decltype(std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
+using numerical_test_types = decltype(
+    std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
 #else
 using numerical_test_types = base_test_types;
 #endif

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -11,26 +11,34 @@
 #include <random>
 #include <string>
 #include <vector>
+#include <tuple>
 
 using ldcomplex = std::complex<long double>;
 using dcomplex = std::complex<double>;
 using fcomplex = std::complex<float>;
 
-using floating_numerics_test_types = std::tuple<float, double>;
+using base_test_types = std::tuple<int,
+                                   unsigned int,
+                                   long,
+                                   unsigned long,
+                                   unsigned char,
+                                   char,
+                                   float,
+                                   double,
+                                   long long,
+                                   unsigned long long,
+                                   ldcomplex,
+                                   dcomplex,
+                                   fcomplex>;
 
-using numerical_test_types = std::tuple<int,
-                                        unsigned int,
-                                        long,
-                                        unsigned long,
-                                        unsigned char,
-                                        char,
-                                        float,
-                                        double,
-                                        long long,
-                                        unsigned long long,
-                                        ldcomplex,
-                                        dcomplex,
-                                        fcomplex>;
+#ifdef H5_USE_HALF_FLOAT
+#include <half.hpp>
+
+using float16_t = half_float::half;
+using numerical_test_types = decltype(std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
+#else
+using numerical_test_types = base_test_types;
+#endif
 
 using dataset_test_types =
     std::tuple<int, unsigned int, long, unsigned long, unsigned char, char, float, double>;

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -35,8 +35,8 @@ using base_test_types = std::tuple<int,
 #include <half.hpp>
 
 using float16_t = half_float::half;
-using numerical_test_types =
-    decltype(std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
+using numerical_test_types = decltype(
+    std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
 #else
 using numerical_test_types = base_test_types;
 #endif

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -35,8 +35,8 @@ using base_test_types = std::tuple<int,
 #include <half.hpp>
 
 using float16_t = half_float::half;
-using numerical_test_types = decltype(
-    std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
+using numerical_test_types =
+    decltype(std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
 #else
 using numerical_test_types = base_test_types;
 #endif


### PR DESCRIPTION
**Description**

Although 16-bit float is not a native C++ type, it is widely used to save runtime and disk space in situations where high precision is not needed, most notably in deep-learning applications. Python's `h5py` trivially supports the creation of `float16` datasets (`type "<f2"`). This PR adds optional support for half-precision in HighFive.

**Code change summary**

- The main code change is in `include/highfive/bits/H5DataType_misc.hpp`, where the `AtomicType` constructor was specialized for `float16_t`
- The type list `numerical_test_types` was augmented by adding `float16_t` (if enabled)
- Added example code `create_dataset_half_float.cpp` in `src/examples`
- A few makefile changes

**How to test this?**

Download the (single-header) `Half` library from http://half.sourceforge.net/, and copy `half.hpp` into `/usr/local/include/`.
Then build and run unit tests:
 
```bash
cmake .. -DHIGHFIVE_USE_HALF_FLOAT=ON
make -j8
make test
```
You should see tests with `numerical_test_types - 13`, which corresponds to `float16_t`

**Test System**
 - OS: Ubuntu 18.04
 - Compiler: GNU g++ 10.3.0
 - Dependency versions: tested with HDF5 1.10.5, boost 1.65.1, and Half 2.2.0
