### PR TITLE
Sliced XTensor IO

### DIFF
--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -136,6 +136,11 @@ inline DataSet dump(File& file,
 }
 
 template <class T>
+inline T load(const File& file, const std::string& path, const std::vector<size_t>& idx, const std::vector<size_t>& sizes) {
+    return detail::io_impl<T>::load_part(file, path, idx, sizes);
+}
+
+template <class T>
 inline T load(const File& file, const std::string& path, const std::vector<size_t>& idx) {
     return detail::io_impl<T>::load_part(file, path, idx);
 }

--- a/include/highfive/h5easy_bits/H5Easy_public.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_public.hpp
@@ -136,7 +136,10 @@ inline DataSet dump(File& file,
 }
 
 template <class T>
-inline T load(const File& file, const std::string& path, const std::vector<size_t>& idx, const std::vector<size_t>& sizes) {
+inline T load(const File& file,
+              const std::string& path,
+              const std::vector<size_t>& idx,
+              const std::vector<size_t>& sizes) {
     return detail::io_impl<T>::load_part(file, path, idx, sizes);
 }
 

--- a/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
+++ b/include/highfive/h5easy_bits/H5Easy_xtensor.hpp
@@ -38,6 +38,14 @@ struct io_impl<T, typename std::enable_if<xt::is_xexpression<T>::value>::type> {
         return dataset;
     }
 
+    inline static DataSet dump_extend(File& file,
+                                      const std::string& path,
+                                      const T& data,
+                                      const std::vector<size_t>& idx,
+                                      const DumpOptions& options) {
+        return dump(file, path, data, options);
+    }
+
     inline static T load(const File& file, const std::string& path) {
         static_assert(
             xt::has_data_interface<T>::value,
@@ -47,6 +55,19 @@ struct io_impl<T, typename std::enable_if<xt::is_xexpression<T>::value>::type> {
         T data = T::from_shape(dims);
         dataset.read(data.data());
         return data;
+    }
+
+    inline static T load_part(const File& file,
+                              const std::string& path,
+                              const std::vector<size_t>& idx) {
+        return load(file, path);
+    }
+
+    inline static T load_part(const File& file,
+                              const std::string& path,
+                              const std::vector<size_t>& idx,
+                              const std::vector<size_t>& sizes) {
+        return load(file, path);
     }
 
     inline static Attribute dumpAttribute(File& file,


### PR DESCRIPTION
**Description**

Implemented load_part and dump_extend for XTensor data types.

This requires a new public load API that accepts a vector of sizes as a parameter, to define how many elements should be read in each dimension.

Fixes #596 

**How to test this?**

Have added tests to tests_high_five_easy.cpp to exercise this feature:
- Loading a single value into an XTensor/XArray (no sizes argument)
- Loading a subset of a dataset into an XTensor/XArray (normal sizes argument)
- Load a subset that exceeds the bounds of a dataset into an XTensor/XArray (index + size > dataset dimension)
- Dumping an XTensor/XArray/XView to a non-zero index of a Dataset. 

```bash
cmake ..
make -j8
make test
```

**Test System**
 - OS: Ubuntu 22.04
 - Compiler: gcc 11.2.0
 - Dependency versions: hdf5 1.12
