### PR TITLE
Implement file space strategies.

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -85,6 +85,14 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
     /// \brief Returns the HDF5 version compatibility bounds
     std::pair<H5F_libver_t, H5F_libver_t> getVersionBounds() const;
 
+#if H5_VERSION_GE(1, 10, 1)
+    /// \brief Returns the HDF5 file space strategy.
+    H5F_fspace_strategy_t getFileSpaceStrategy() const;
+
+    /// \brief Returns the page size, if paged allocation is used.
+    hsize_t getFileSpacePageSize() const;
+#endif
+
     ///
     /// \brief flush
     ///
@@ -94,6 +102,7 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
 
   protected:
     hid_t getAccessPList() const;
+    hid_t getCreatePList() const;
 
   private:
     using Object::Object;

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -193,7 +193,59 @@ class MetadataBlockSize {
     const hsize_t _size;
 };
 
+#if H5_VERSION_GE(1, 10, 1)
 ///
+/// \brief Configure the file space strategy.
+///
+/// See the upstream documentation of `H5Pget_file_space_strategy` for more details. Essentially,
+/// it enables configuring how space is allocate in the file.
+///
+class FileSpaceStrategy {
+  public:
+    ///
+    /// \brief Create a file space strategy property.
+    ///
+    /// \param strategy  The HDF5 free space strategy.
+    /// \param perist Should free space managers be persisted across file closing and reopening.
+    /// \param threshold The free-space manager wont track sections small than this threshold.
+    FileSpaceStrategy(H5F_fspace_strategy_t strategy, hbool_t persist, hsize_t threshold);
+
+  private:
+    friend FileCreateProps;
+
+    void apply(const hid_t list) const;
+
+    H5F_fspace_strategy_t _strategy;
+    hbool_t _persist;
+    hsize_t _threshold;
+};
+
+///
+/// \brief Configure the page size for paged allocation.
+///
+/// See the upstream documentation of `H5Pset_file_space_page_size` for more details. Essentially,
+/// it enables configuring the page size when paged allocation is used.
+///
+/// General information about paged allocation can be found in the upstream documentation "RFC: Page
+/// Buffering".
+///
+class FileSpacePageSize {
+  public:
+    ///
+    /// \brief Create a file space strategy property.
+    ///
+    /// \param page_size The page size in bytes.
+    explicit FileSpacePageSize(hsize_t page_size);
+
+  private:
+    friend FileCreateProps;
+
+    void apply(const hid_t list) const;
+
+    hsize_t _page_size;
+};
+#endif
+
 /// \brief Set hints as to how many links to expect and their average length
 ///
 class EstimatedLinkInfo {

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -205,8 +205,8 @@ class FileSpaceStrategy {
     ///
     /// \brief Create a file space strategy property.
     ///
-    /// \param strategy  The HDF5 free space strategy.
-    /// \param perist Should free space managers be persisted across file closing and reopening.
+    /// \param strategy The HDF5 free space strategy.
+    /// \param persist Should free space managers be persisted across file closing and reopening.
     /// \param threshold The free-space manager wont track sections small than this threshold.
     FileSpaceStrategy(H5F_fspace_strategy_t strategy, hbool_t persist, hsize_t threshold);
 

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -135,7 +135,7 @@ inline hsize_t File::getFileSpacePageSize() const {
 
     if (getFileSpaceStrategy() != H5F_FSPACE_STRATEGY_PAGE) {
         HDF5ErrMapper::ToException<FileException>(
-            std::string("Cannot obtain page size, because not using paged allocation."));
+            std::string("Cannot obtain page size as paged allocation is not used."));
     }
 
     if (H5Pget_file_space_page_size(fcpl, &page_size) < 0) {

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -113,10 +113,54 @@ inline std::pair<H5F_libver_t, H5F_libver_t> File::getVersionBounds() const {
     return std::make_pair(low, high);
 }
 
+#if H5_VERSION_GE(1, 10, 1)
+inline H5F_fspace_strategy_t File::getFileSpaceStrategy() const {
+    auto fcpl = getCreatePList();
+
+    H5F_fspace_strategy_t strategy;
+    hbool_t persist;
+    hsize_t threshold;
+
+    if (H5Pget_file_space_strategy(fcpl, &strategy, &persist, &threshold) < 0) {
+        HDF5ErrMapper::ToException<FileException>(std::string("Unable to get file space strategy"));
+    }
+
+    H5Pclose(fcpl);
+    return strategy;
+}
+
+inline hsize_t File::getFileSpacePageSize() const {
+    auto fcpl = getCreatePList();
+    hsize_t page_size;
+
+    if (getFileSpaceStrategy() != H5F_FSPACE_STRATEGY_PAGE) {
+        HDF5ErrMapper::ToException<FileException>(
+            std::string("Cannot obtain page size, because not using paged allocation."));
+    }
+
+    if (H5Pget_file_space_page_size(fcpl, &page_size) < 0) {
+        HDF5ErrMapper::ToException<FileException>(
+            std::string("Unable to get file space page size"));
+    }
+
+    H5Pclose(fcpl);
+    return page_size;
+}
+#endif
+
 inline hid_t File::getAccessPList() const {
     auto fapl = H5Fget_access_plist(getId());
     if (fapl < 0) {
         HDF5ErrMapper::ToException<FileException>(std::string("Unable to get access plist."));
+    }
+
+    return fapl;
+}
+
+inline hid_t File::getCreatePList() const {
+    auto fapl = H5Fget_create_plist(getId());
+    if (fapl < 0) {
+        HDF5ErrMapper::ToException<FileException>(std::string("Unable to get create plist."));
     }
 
     return fapl;

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -88,6 +88,30 @@ inline void RawPropertyList<T>::add(const F& funct, const Args&... args) {
 
 
 // Specific options to be added to Property Lists
+#if H5_VERSION_GE(1, 10, 1)
+void FileSpaceStrategy::apply(const hid_t list) const {
+    if (H5Pset_file_space_strategy(list, _strategy, _persist, _threshold) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>("Error setting file space strategy.");
+    }
+}
+
+FileSpaceStrategy::FileSpaceStrategy(H5F_fspace_strategy_t strategy,
+                                     hbool_t persist,
+                                     hsize_t threshold)
+    : _strategy(strategy)
+    , _persist(persist)
+    , _threshold(threshold) {}
+
+
+FileSpacePageSize::FileSpacePageSize(hsize_t page_size)
+    : _page_size(page_size) {}
+
+void FileSpacePageSize::apply(const hid_t list) const {
+    if (H5Pset_file_space_page_size(list, _page_size) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>("Error setting file space page size.");
+    }
+}
+#endif
 
 inline void EstimatedLinkInfo::apply(const hid_t hid) const {
     if (H5Pset_est_link_info(hid, _entries, _length) < 0) {

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -89,12 +89,6 @@ inline void RawPropertyList<T>::add(const F& funct, const Args&... args) {
 
 // Specific options to be added to Property Lists
 #if H5_VERSION_GE(1, 10, 1)
-void FileSpaceStrategy::apply(const hid_t list) const {
-    if (H5Pset_file_space_strategy(list, _strategy, _persist, _threshold) < 0) {
-        HDF5ErrMapper::ToException<PropertyException>("Error setting file space strategy.");
-    }
-}
-
 FileSpaceStrategy::FileSpaceStrategy(H5F_fspace_strategy_t strategy,
                                      hbool_t persist,
                                      hsize_t threshold)
@@ -102,11 +96,16 @@ FileSpaceStrategy::FileSpaceStrategy(H5F_fspace_strategy_t strategy,
     , _persist(persist)
     , _threshold(threshold) {}
 
+inline void FileSpaceStrategy::apply(const hid_t list) const {
+    if (H5Pset_file_space_strategy(list, _strategy, _persist, _threshold) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>("Error setting file space strategy.");
+    }
+}
 
 FileSpacePageSize::FileSpacePageSize(hsize_t page_size)
     : _page_size(page_size) {}
 
-void FileSpacePageSize::apply(const hid_t list) const {
+inline void FileSpacePageSize::apply(const hid_t list) const {
     if (H5Pset_file_space_page_size(list, _page_size) < 0) {
         HDF5ErrMapper::ToException<PropertyException>("Error setting file space page size.");
     }

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -89,9 +89,9 @@ inline void RawPropertyList<T>::add(const F& funct, const Args&... args) {
 
 // Specific options to be added to Property Lists
 #if H5_VERSION_GE(1, 10, 1)
-FileSpaceStrategy::FileSpaceStrategy(H5F_fspace_strategy_t strategy,
-                                     hbool_t persist,
-                                     hsize_t threshold)
+inline FileSpaceStrategy::FileSpaceStrategy(H5F_fspace_strategy_t strategy,
+                                            hbool_t persist,
+                                            hsize_t threshold)
     : _strategy(strategy)
     , _persist(persist)
     , _threshold(threshold) {}
@@ -102,7 +102,7 @@ inline void FileSpaceStrategy::apply(const hid_t list) const {
     }
 }
 
-FileSpacePageSize::FileSpacePageSize(hsize_t page_size)
+inline FileSpacePageSize::FileSpacePageSize(hsize_t page_size)
     : _page_size(page_size) {}
 
 inline void FileSpacePageSize::apply(const hid_t list) const {

--- a/src/examples/create_page_allocated_files.cpp
+++ b/src/examples/create_page_allocated_files.cpp
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c), 2022, Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <highfive/H5File.hpp>
+#include <highfive/H5DataSet.hpp>
+#include <highfive/H5DataSpace.hpp>
+
+const std::string FILE_NAME("create_page_allocated_files.h5");
+const std::string DATASET_NAME("array");
+
+// This example show how to create an HDF5 file that internally aggregates
+// metadata and raw data into separate pages. The advantage of this approach
+// is that reading a single page, pulls in the metadata for a large chunk of
+// the file.
+//
+// This can be very useful when dealing with many small datasets. Note, this
+// is an optimization. Therefore, you must perform measurements in order to
+// know if this should be used.
+//
+// Internally, it uses two free space managers, one for metadata and one for
+// raw data. When space for data is allocated, the corresponding free space
+// manager is asked to allocate space. It will look if there is enough space
+// on a partially filled paged, if yes it keeps filling the page, if not it
+// requests page aligned space from the file driver as needed. Upstream
+// documentation explains the details well in:
+//
+//    RFC: HDF5 File Space Management: Paged Aggregation
+
+int main() {
+    using namespace HighFive;
+    try {
+        // Create a new file requesting paged allocation.
+        auto create_props = FileCreateProps{};
+
+        // Let request pagesizes of 16 kB. This setting should be tuned
+        // in real applications. We'll allow HDF5 to not keep track of
+        // left-over free space of size less than 128 bytes. Finally,
+        // we don't need the free space manager to be stored in the
+        // HDF5 file.
+        size_t pagesize = 16 * 1024;  // Must be tuned.
+        size_t threshold = 128;
+        size_t persist = false;
+
+        create_props.add(FileSpaceStrategy(H5F_FSPACE_STRATEGY_PAGE, persist, threshold));
+        create_props.add(FileSpacePageSize(pagesize));
+
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate, create_props);
+
+        // The `file` (and also the low-level `file.getId()`) behave as normal, i.e.
+        // one can proceed to add content to the file as usual.
+
+        auto data = std::vector<double>{0.0, 1.0, 2.0};
+        file.createDataSet(DATASET_NAME, data);
+
+    } catch (Exception& err) {
+        // catch and print any HDF5 error
+        std::cerr << err.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/src/examples/create_page_allocated_files.cpp
+++ b/src/examples/create_page_allocated_files.cpp
@@ -6,13 +6,16 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  *
  */
+
+
 #include <iostream>
 #include <string>
 #include <vector>
 
 #include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+
+// This example requires HDF5 version 1.10.1 or newer.
+#if H5_VERSION_GE(1, 10, 1)
 
 const std::string FILE_NAME("create_page_allocated_files.h5");
 const std::string DATASET_NAME("array");
@@ -68,3 +71,4 @@ int main() {
 
     return 0;
 }
+#endif

--- a/src/examples/create_page_allocated_files.cpp
+++ b/src/examples/create_page_allocated_files.cpp
@@ -71,4 +71,10 @@ int main() {
 
     return 0;
 }
+#else
+#include <iostream>
+int main() {
+    std::cout << "This example can't be run prior to HDF5 1.10.1.\n";
+    return 0;
+}
 #endif

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -153,6 +153,47 @@ TEST_CASE("Test file version bounds") {
     }
 }
 
+#if H5_VERSION_GE(1, 10, 1)
+TEST_CASE("Test file space strategy") {
+    const std::string FILE_NAME("h5_file_space_strategy.h5");
+    auto strategies = std::vector<H5F_fspace_strategy_t>{H5F_FSPACE_STRATEGY_FSM_AGGR,
+                                                         H5F_FSPACE_STRATEGY_AGGR,
+                                                         H5F_FSPACE_STRATEGY_PAGE,
+                                                         H5F_FSPACE_STRATEGY_NONE};
+
+    for (const auto& strategy: strategies) {
+        {
+            FileCreateProps create_props;
+            create_props.add(FileSpaceStrategy(strategy, true, 0));
+
+            File file(FILE_NAME, File::Truncate, create_props);
+        }
+
+        {
+            File file(FILE_NAME, File::ReadOnly);
+            CHECK(file.getFileSpaceStrategy() == strategy);
+        }
+    }
+}
+
+TEST_CASE("Test file space page size") {
+    const std::string FILE_NAME("h5_file_space_page_size.h5");
+    hsize_t page_size = 1024;
+    {
+        FileCreateProps create_props;
+        create_props.add(FileSpaceStrategy(H5F_FSPACE_STRATEGY_PAGE, true, 0));
+        create_props.add(FileSpacePageSize(page_size));
+
+        File file(FILE_NAME, File::Truncate, create_props);
+    }
+
+    {
+        File file(FILE_NAME, File::ReadOnly);
+        CHECK(file.getFileSpacePageSize() == page_size);
+    }
+}
+#endif
+
 TEST_CASE("Test metadata block size assignment") {
     const std::string FILE_NAME("h5_meta_block_size.h5");
 


### PR DESCRIPTION
Implements support for the different file space strategies:
https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_SPACE_STRATEGY
https://portal.hdfgroup.org/display/HDF5/H5P_SET_FILE_SPACE_PAGE_SIZE

including paged allocation with configurable page size. Since both are "file creation properties". This MR also includes a new ctor for `File` which enables creating files specifying both creation and access properties.