### PR TITLE
Fix missing include.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
           -DHIGHFIVE_USE_EIGEN:BOOL=ON
           -DHIGHFIVE_USE_XTENSOR:BOOL=ON
           -DHIGHFIVE_BUILD_DOCS:BOOL=FALSE
+          -DHIGHFIVE_TEST_SINGLE_INCLUDES=ON
           -DCMAKE_CXX_FLAGS="-coverage -O0"
         )
         source $GITHUB_WORKSPACE/.github/build.sh
@@ -199,6 +200,7 @@ jobs:
           -DHIGHFIVE_USE_BOOST:BOOL=ON
           -DHIGHFIVE_USE_EIGEN:BOOL=ON
           -DHIGHFIVE_USE_XTENSOR:BOOL=ON
+          -DHIGHFIVE_TEST_SINGLE_INCLUDES=ON
         )
         source $GITHUB_WORKSPACE/.github/build.sh
 
@@ -232,6 +234,7 @@ jobs:
           -DHIGHFIVE_USE_EIGEN:BOOL=ON
           -DHIGHFIVE_USE_OPENCV:BOOL=ON
           #-DHIGHFIVE_USE_XTENSOR:BOOL=ON
+          -DHIGHFIVE_TEST_SINGLE_INCLUDES=ON
           -DHIGHFIVE_BUILD_DOCS:BOOL=FALSE
           -DCMAKE_CXX_FLAGS="-coverage -O0"
         )

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -20,6 +20,8 @@
 #include <half.hpp>
 #endif
 
+#include "H5Converter_misc.hpp"
+
 namespace HighFive {
 
 namespace {  // unnamed


### PR DESCRIPTION
When compiling `@develop` through Spack it would error with:
```
     407    In file included from /gpfs/bbp.cscs.ch/home/groshein/HighFive/include/highfive/H5DataType.hpp:395,
     408                     from /gpfs/bbp.cscs.ch/home/groshein/HighFive/spack-build-v3pxph2/tests/unit/tests_H5DataType.cpp:3:
     409    /gpfs/bbp.cscs.ch/home/groshein/HighFive/include/highfive/bits/H5DataType_misc.hpp: In constructor 'HighFive::AtomicType<T>::AtomicType()':
  >> 410    /gpfs/bbp.cscs.ch/home/groshein/HighFive/include/highfive/bits/H5DataType_misc.hpp:205:28: error: 'inspector' is not a member of 'HighFive::details'
```
which points to a missing include in `bits/H5DataType_misc.hpp`.

This MR adds the missing include and activates the CI that checks for these types of issues in CI.