### PR TITLE
Turn on collective HDF5 metadata

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -138,6 +138,21 @@ class MPIOFileAccess {
     MPI_Comm _comm;
     MPI_Info _info;
 };
+
+class MPIOCollectiveMD {
+  public:
+    /* no resources or arguments to manage */
+    void apply(const hid_t list) const {
+        if (H5Pset_all_coll_metadata_ops(list, 1) < 0) {
+            HDF5ErrMapper::ToException<FileException>(
+                "Unable to request collective metadata reads");
+        }
+        if (H5Pset_coll_metadata_write(list, 1) < 0) {
+            HDF5ErrMapper::ToException<FileException>(
+                "Unable to request collective metadata writes");
+        }
+    }
+};
 #endif
 
 ///

--- a/include/highfive/bits/H5FileDriver_misc.hpp
+++ b/include/highfive/bits/H5FileDriver_misc.hpp
@@ -15,6 +15,7 @@ namespace HighFive {
 #ifdef H5_HAVE_PARALLEL
 inline MPIOFileDriver::MPIOFileDriver(MPI_Comm comm, MPI_Info info) {
     add(MPIOFileAccess(comm, info));
+    add(MPIOCollectiveMD());
 }
 #endif
 


### PR DESCRIPTION
**Description**
Since HDF5 1.10.0 (march 2016), HDF5 has the ability to request "collective metadata".  When requested, HDF5 (internally) will use collective operations to update the data structures stored in the HDF5 file.    If not requested, every single process will make these data structure updates, resulting in lots of small reads and writes -- particularly at scale. 

This does not fix #112 but users who are interested in collective I/O optimizations and are OK with the restrictions collective I/O imposes (every process has to create datasets, every process has to call H5Dwrite etc) are likely to be interested in this optimization as well.

A "darshan" log of a four process `parallel_hdf5_write_dataset` example from HighFive tells me there were 0 MPI-IO collective writes, 11 MPI-IO independent writes, and 11 POSIX writes before this change, and 
Please include a summary of the change and which issue is fixed or which feature is added.

**How to test this?**

The Darshan (https://www.mcs.anl.gov/research/projects/darshan/)  I/O characterization tool collects counters (not logs) of I/O applications.  I used it to observe the effects of this change on the `parallel_hdf5_write_dataset` example.  I'm also using the 'spack' package management tool, but that's not relevant to this pull request. 

```bash
    $ mpicxx -I${HOME}/work/soft/highfive/include -I$(spack location -i hdf5)/include ../src/examples/parallel_hdf5_write_dataset.cpp -o parallel_hdf5_write_dataset -L$(spack location -i hdf5)/lib -lhdf5
    $ LD_PRELOAD=$(spack location -i darshan-runtime)/lib/libdarshan.so mpiexec -np 4 ./parallel_hdf5_write_dataset
```

**Test System**
 - OS: Ubuntu 22.04
 - Compiler: g++-11.2
 - Dependency versions: hdf5-1.10 or newer
