### PR TITLE
Work in progress: collective data

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -300,6 +300,17 @@ class CreateIntermediateGroup {
     const bool _create;
 };
 
+class UseCollectiveIO {
+  public:
+    explicit UseCollectiveIO(bool enable = true)
+        : _enable(enable) {}
+
+  private:
+    friend DataTransferProps;
+    void apply(hid_t hid) const;
+    bool _enable;
+};
+
 }  // namespace HighFive
 
 #include "bits/H5PropertyList_misc.hpp"

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -140,6 +140,13 @@ inline void CreateIntermediateGroup::apply(const hid_t hid) const {
     }
 }
 
+inline void UseCollectiveIO::apply(const hid_t hid) const {
+    if (H5Pset_dxpl_mpio(hid, _enable ? H5FD_MPIO_COLLECTIVE : H5FD_MPIO_INDEPENDENT) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting property for create intermediate groups");
+    }
+}
+
 }  // namespace HighFive
 
 #endif  // H5PROPERTY_LIST_HPP

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -15,6 +15,8 @@
 #include "H5_definitions.hpp"
 #include "H5Utils.hpp"
 
+#include "../H5PropertyList.hpp"
+
 namespace HighFive {
 
 class ElementSet {
@@ -329,8 +331,17 @@ class SliceTraits {
     template <typename T>
     void write_raw(const T* buffer, const DataType& dtype = DataType());
 
+    ///
+    /// Request collective I/O when writing to or reading from this dataset
+    void enable_collective() {
+        m_plist.add(UseCollectiveIO(true));
+    }
+
   protected:
     inline Selection select_impl(const HyperSlab& hyperslab, const DataSpace& memspace) const;
+
+  private:
+    DataTransferProps m_plist;
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -211,7 +211,7 @@ inline void SliceTraits<Derivate>::read(T* array, const DataType& dtype) const {
                 mem_datatype.getId(),
                 details::get_memspace_id(slice),
                 slice.getSpace().getId(),
-                H5P_DEFAULT,
+                m_plist.getId(),
                 static_cast<void*>(array)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Read: ");
     }
@@ -249,7 +249,7 @@ inline void SliceTraits<Derivate>::write_raw(const T* buffer, const DataType& dt
                  mem_datatype.getId(),
                  details::get_memspace_id(slice),
                  slice.getSpace().getId(),
-                 H5P_DEFAULT,
+                 m_plist.getId(),
                  static_cast<const void*>(buffer)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Write: ");
     }

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -253,6 +253,10 @@ inline void SliceTraits<Derivate>::write_raw(const T* buffer, const DataType& dt
                  static_cast<const void*>(buffer)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Write: ");
     }
+    uint32_t local_cause=0, global_cause=0;
+    H5Pget_mpio_no_collective_cause(m_plist.getId(), &local_cause, &global_cause);
+    if (local_cause || global_cause)
+        std::cout << "h5dwrite wasn't collective " << local_cause << " " << global_cause << " " << std::endl;
 }
 
 

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -49,6 +49,7 @@ int main(int argc, char** argv) {
 
         // Create the dataset
         DataSet dataset = file.createDataSet<double>(DATASET_NAME, DataSpace(dims));
+        dataset.enable_collective();
 
         // Each node want to write its own rank two time in
         // its associated row

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
 
         // Each node want to write its own rank two time in
         // its associated row
-        int data[1][2] = {{mpi_rank, mpi_rank}};
+        double data[1][2] = {{mpi_rank*1.0, mpi_rank*1.0}};
 
         // write it to the associated mpi_rank
         dataset.select({std::size_t(mpi_rank), 0}, {1, 2}).write(data);


### PR DESCRIPTION
**Description**
Make it possible to request collective I/O for H5Dwrite and H5Dread.   Like HDF5 itself, users have to opt-in with an 'enable' call. 

I'm brand new to HighFive, and have developed a lot more C code than C++ code, so I would appreciate a review to make sure I'm doing this the HighFive way

fixes #112 


**How to test this?**

Also in this pull request are some updates to the parallel write test
- make the memory type match the file type
- request collective I/O
- 
 - Dependency versions: collective I/O has been in HDF5 "forever".  The "why wasn't this collective"? routine was introduced in hdf5-1.8.0 
