### PR TITLE
Deprecate FileDriver(s)

### DIFF
--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -17,7 +17,7 @@ namespace HighFive {
 ///
 /// \brief file driver base concept
 ///
-class H5_DEPRECATED("Use FileAccessProps directly") FileDriver: public FileAccessProps{};
+class H5_DEPRECATED("Use FileAccessProps directly") FileDriver: public FileAccessProps {};
 
 #ifdef H5_HAVE_PARALLEL
 ///

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -16,13 +16,14 @@ namespace HighFive {
 ///
 /// \brief file driver base concept
 ///
-class FileDriver: public FileAccessProps {};
+class [[deprecated("Use FileAccessProps directly")]] FileDriver: public FileAccessProps {
+};
 
 #ifdef H5_HAVE_PARALLEL
 ///
 /// \brief MPIIO Driver for Parallel HDF5
 ///
-class MPIOFileDriver: public FileAccessProps {
+class [[deprecated("Add MPIOFileAccess directly to FileAccessProps")]] MPIOFileDriver: public FileAccessProps {
   public:
     inline MPIOFileDriver(MPI_Comm mpi_comm, MPI_Info mpi_info);
 

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -16,14 +16,14 @@ namespace HighFive {
 ///
 /// \brief file driver base concept
 ///
-class [[deprecated("Use FileAccessProps directly")]] FileDriver: public FileAccessProps {
-};
+class [[deprecated("Use FileAccessProps directly")]] FileDriver: public FileAccessProps{};
 
 #ifdef H5_HAVE_PARALLEL
 ///
 /// \brief MPIIO Driver for Parallel HDF5
 ///
-class [[deprecated("Add MPIOFileAccess directly to FileAccessProps")]] MPIOFileDriver: public FileAccessProps {
+class [[deprecated("Add MPIOFileAccess directly to FileAccessProps")]] MPIOFileDriver
+    : public FileAccessProps {
   public:
     inline MPIOFileDriver(MPI_Comm mpi_comm, MPI_Info mpi_info);
 

--- a/include/highfive/H5FileDriver.hpp
+++ b/include/highfive/H5FileDriver.hpp
@@ -10,19 +10,21 @@
 #define H5FILEDRIVER_HPP
 
 #include "H5PropertyList.hpp"
+#include "bits/H5_definitions.hpp"
 
 namespace HighFive {
 
 ///
 /// \brief file driver base concept
 ///
-class [[deprecated("Use FileAccessProps directly")]] FileDriver: public FileAccessProps{};
+class H5_DEPRECATED("Use FileAccessProps directly") FileDriver: public FileAccessProps{};
 
 #ifdef H5_HAVE_PARALLEL
 ///
 /// \brief MPIIO Driver for Parallel HDF5
 ///
-class [[deprecated("Add MPIOFileAccess directly to FileAccessProps")]] MPIOFileDriver
+
+class H5_DEPRECATED("Add MPIOFileAccess directly to FileAccessProps") MPIOFileDriver
     : public FileAccessProps {
   public:
     inline MPIOFileDriver(MPI_Comm mpi_comm, MPI_Info mpi_info);

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -36,9 +36,11 @@ int main(int argc, char** argv) {
     using namespace HighFive;
     try {
         // open a new file with the MPI IO driver for parallel Read/Write
+        FileAccessProps faprops;
+        faprops.add(MPIOFileACCess{MPI_COMM_WORLD, MPI_INFO_NULL});
         File file(FILE_NAME,
                   File::ReadWrite | File::Create | File::Truncate,
-                  MPIOFileDriver(MPI_COMM_WORLD, MPI_INFO_NULL));
+                  faprops);
 
         // we define the size of our dataset to
         //  lines : total number of mpi_rank

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -15,6 +15,7 @@
 #include <highfive/H5DataSet.hpp>
 #include <highfive/H5DataSpace.hpp>
 #include <highfive/H5File.hpp>
+#include <highfive/H5PropertyList.hpp>
 
 const std::string FILE_NAME("parallel_dataset_example.h5");
 const std::string DATASET_NAME("dset");

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -37,9 +37,9 @@ int main(int argc, char** argv) {
     using namespace HighFive;
     try {
         // open a new file with the MPI IO driver for parallel Read/Write
-        FileAccessProps faprops;
-        faprops.add(MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate, faprops);
+        FileAccessProps fapl;
+        fapl.add(MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate, fapl);
 
         // we define the size of our dataset to
         //  lines : total number of mpi_rank

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -38,9 +38,7 @@ int main(int argc, char** argv) {
         // open a new file with the MPI IO driver for parallel Read/Write
         FileAccessProps faprops;
         faprops.add(MPIOFileACCess{MPI_COMM_WORLD, MPI_INFO_NULL});
-        File file(FILE_NAME,
-                  File::ReadWrite | File::Create | File::Truncate,
-                  faprops);
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate, faprops);
 
         // we define the size of our dataset to
         //  lines : total number of mpi_rank

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     try {
         // open a new file with the MPI IO driver for parallel Read/Write
         FileAccessProps faprops;
-        faprops.add(MPIOFileACCess{MPI_COMM_WORLD, MPI_INFO_NULL});
+        faprops.add(MPIOFileAccess{MPI_COMM_WORLD, MPI_INFO_NULL});
         File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate, faprops);
 
         // we define the size of our dataset to

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -144,9 +144,9 @@ TEST_CASE("Test file version bounds") {
     std::remove(FILE_NAME.c_str());
 
     {
-        FileDriver driver;
-        driver.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
-        File file(FILE_NAME, File::Truncate, driver);
+        FileAccessProps fapl;
+        fapl.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
+        File file(FILE_NAME, File::Truncate, fapl);
         auto bounds = file.getVersionBounds();
         CHECK(bounds.first == H5F_LIBVER_LATEST);
         CHECK(bounds.second == H5F_LIBVER_LATEST);
@@ -167,20 +167,20 @@ TEST_CASE("Test metadata block size assignment") {
     std::remove(FILE_NAME.c_str());
 
     {
-        FileDriver driver;
-        driver.add(MetadataBlockSize(10240));
-        File file(FILE_NAME, File::Truncate, driver);
+        FileAccessProps fapl;
+        fapl.add(MetadataBlockSize(10240));
+        File file(FILE_NAME, File::Truncate, fapl);
         CHECK(file.getMetadataBlockSize() == 10240);
     }
 }
 
 TEST_CASE("Test group properties") {
     const std::string FILE_NAME("h5_group_properties.h5");
-    FileDriver adam;
+    FileAccessProps fapl;
     // When using hdf5 1.10.2 and later, the lower bound may be set to
     // H5F_LIBVER_V18
-    adam.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
-    File file(FILE_NAME, File::Truncate, adam);
+    fapl.add(FileVersionBounds(H5F_LIBVER_LATEST, H5F_LIBVER_LATEST));
+    File file(FILE_NAME, File::Truncate, fapl);
 
     GroupCreateProps props;
     props.add(EstimatedLinkInfo(1000, 500));

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -62,9 +62,9 @@ void selectionArraySimpleTestParallel() {
     std::generate(values.begin(), values.end(), generator);
 
     // Create a new file using the default property lists.
-    FileDriver adam;
-    adam.add(MPIOFileAccess(MPI_COMM_WORLD, MPI_INFO_NULL));
-    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate, adam);
+    FileAccessProps fapl;
+    fapl.add(MPIOFileAccess(MPI_COMM_WORLD, MPI_INFO_NULL));
+    File file(filename.str(), File::ReadWrite | File::Create | File::Truncate, fapl);
 
     DataSet dataset = file.createDataSet<T>(DATASET_NAME, DataSpace::From(values));
 


### PR DESCRIPTION
The current FileDriver implementations just inherit from
FileAccessProps, and I think that with further additions to the file
access property lists, it is cleaner to just use FileAccessProps
directly.
