### PR TITLE
Enable collective MPI IO.

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -300,6 +300,17 @@ class CreateIntermediateGroup {
     const bool _create;
 };
 
+class UseCollectiveIO {
+  public:
+    explicit UseCollectiveIO(bool enable = true)
+        : _enable(enable) {}
+
+  private:
+    friend DataTransferProps;
+    void apply(hid_t hid) const;
+    bool _enable;
+};
+
 }  // namespace HighFive
 
 #include "bits/H5PropertyList_misc.hpp"

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -300,6 +300,7 @@ class CreateIntermediateGroup {
     const bool _create;
 };
 
+#ifdef H5_HAVE_PARALLEL
 class UseCollectiveIO {
   public:
     explicit UseCollectiveIO(bool enable = true)
@@ -310,6 +311,7 @@ class UseCollectiveIO {
     void apply(hid_t hid) const;
     bool _enable;
 };
+#endif
 
 }  // namespace HighFive
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -143,8 +143,7 @@ inline void CreateIntermediateGroup::apply(const hid_t hid) const {
 #ifdef H5_HAVE_PARALLEL
 inline void UseCollectiveIO::apply(const hid_t hid) const {
     if (H5Pset_dxpl_mpio(hid, _enable ? H5FD_MPIO_COLLECTIVE : H5FD_MPIO_INDEPENDENT) < 0) {
-        HDF5ErrMapper::ToException<PropertyException>(
-            "Error setting H5Pset_dxpl_mpio.");
+        HDF5ErrMapper::ToException<PropertyException>("Error setting H5Pset_dxpl_mpio.");
     }
 }
 #endif

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -140,11 +140,14 @@ inline void CreateIntermediateGroup::apply(const hid_t hid) const {
     }
 }
 
+#ifdef H5_HAVE_PARALLEL
 inline void UseCollectiveIO::apply(const hid_t hid) const {
     if (H5Pset_dxpl_mpio(hid, _enable ? H5FD_MPIO_COLLECTIVE : H5FD_MPIO_INDEPENDENT) < 0) {
-        HDF5ErrMapper::ToException<PropertyException>("Error setting H5Pset_dxpl_mpio.");
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting H5Pset_dxpl_mpio.");
     }
 }
+#endif
 
 }  // namespace HighFive
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -142,8 +142,7 @@ inline void CreateIntermediateGroup::apply(const hid_t hid) const {
 
 inline void UseCollectiveIO::apply(const hid_t hid) const {
     if (H5Pset_dxpl_mpio(hid, _enable ? H5FD_MPIO_COLLECTIVE : H5FD_MPIO_INDEPENDENT) < 0) {
-        HDF5ErrMapper::ToException<PropertyException>(
-            "Error setting H5Pset_dxpl_mpio.");
+        HDF5ErrMapper::ToException<PropertyException>("Error setting H5Pset_dxpl_mpio.");
     }
 }
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -143,7 +143,7 @@ inline void CreateIntermediateGroup::apply(const hid_t hid) const {
 inline void UseCollectiveIO::apply(const hid_t hid) const {
     if (H5Pset_dxpl_mpio(hid, _enable ? H5FD_MPIO_COLLECTIVE : H5FD_MPIO_INDEPENDENT) < 0) {
         HDF5ErrMapper::ToException<PropertyException>(
-            "Error setting property for create intermediate groups");
+            "Error setting H5Pset_dxpl_mpio.");
     }
 }
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -140,6 +140,13 @@ inline void CreateIntermediateGroup::apply(const hid_t hid) const {
     }
 }
 
+inline void UseCollectiveIO::apply(const hid_t hid) const {
+    if (H5Pset_dxpl_mpio(hid, _enable ? H5FD_MPIO_COLLECTIVE : H5FD_MPIO_INDEPENDENT) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>(
+            "Error setting property for create intermediate groups");
+    }
+}
+
 }  // namespace HighFive
 
 #endif  // H5PROPERTY_LIST_HPP

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -284,7 +284,7 @@ class SliceTraits {
     Selection select(const ElementSet& elements) const;
 
     template <typename T>
-    T read() const;
+    T read(const DataTransferProps& xfer_props = DataTransferProps()) const;
 
     ///
     /// Read the entire dataset into a buffer
@@ -296,7 +296,7 @@ class SliceTraits {
     /// responsibility to ensure that the right amount of space has been
     /// allocated.
     template <typename T>
-    void read(T& array) const;
+    void read(T& array, const DataTransferProps& xfer_props = DataTransferProps()) const;
 
     ///
     /// Read the entire dataset into a raw buffer
@@ -307,7 +307,9 @@ class SliceTraits {
     /// \param array: A buffer containing enough space for the data
     /// \param dtype: The type of the data, in case it cannot be automatically guessed
     template <typename T>
-    void read(T* array, const DataType& dtype = DataType()) const;
+    void read(T* array,
+              const DataType& dtype = DataType(),
+              const DataTransferProps& xfer_props = DataTransferProps()) const;
 
     ///
     /// Write the integrality N-dimension buffer to this dataset
@@ -317,7 +319,7 @@ class SliceTraits {
     /// The array type can be a N-pointer or a N-vector ( e.g int** integer two
     /// dimensional array )
     template <typename T>
-    void write(const T& buffer);
+    void write(const T& buffer, const DataTransferProps& xfer_props = DataTransferProps());
 
     ///
     /// Write from a raw buffer into this dataset
@@ -328,20 +330,14 @@ class SliceTraits {
     /// default conventions.
     /// \param buffer: A buffer containing the data to be written
     /// \param dtype: The type of the data, in case it cannot be automatically guessed
+    /// \param xfer_props: The HDF5 data transfer properties, e.g. collective MPI-IO.
     template <typename T>
-    void write_raw(const T* buffer, const DataType& dtype = DataType());
-
-    ///
-    /// Request collective I/O when writing to or reading from this dataset
-    void enable_collective() {
-        m_plist.add(UseCollectiveIO(true));
-    }
+    void write_raw(const T* buffer,
+                   const DataType& dtype = DataType(),
+                   const DataTransferProps& xfer_props = DataTransferProps());
 
   protected:
     inline Selection select_impl(const HyperSlab& hyperslab, const DataSpace& memspace) const;
-
-  private:
-    DataTransferProps m_plist;
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -15,6 +15,8 @@
 #include "H5_definitions.hpp"
 #include "H5Utils.hpp"
 
+#include "../H5PropertyList.hpp"
+
 namespace HighFive {
 
 class ElementSet {
@@ -329,8 +331,17 @@ class SliceTraits {
     template <typename T>
     void write_raw(const T* buffer, const DataType& dtype = DataType());
 
+    ///
+    /// Request collective I/O when writing to or reading from this dataset
+    void enable_collective() {
+        m_plist.add(UseCollectiveIO(true));
+    }
+
   protected:
     inline Selection select_impl(const HyperSlab& hyperslab, const DataSpace& memspace) const;
+
+  private:
+    DataTransferProps m_plist;
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -211,7 +211,7 @@ inline void SliceTraits<Derivate>::read(T* array, const DataType& dtype) const {
                 mem_datatype.getId(),
                 details::get_memspace_id(slice),
                 slice.getSpace().getId(),
-                H5P_DEFAULT,
+                m_plist.getId(),
                 static_cast<void*>(array)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Read: ");
     }
@@ -249,10 +249,14 @@ inline void SliceTraits<Derivate>::write_raw(const T* buffer, const DataType& dt
                  mem_datatype.getId(),
                  details::get_memspace_id(slice),
                  slice.getSpace().getId(),
-                 H5P_DEFAULT,
+                 m_plist.getId(),
                  static_cast<const void*>(buffer)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Write: ");
     }
+    uint32_t local_cause=0, global_cause=0;
+    H5Pget_mpio_no_collective_cause(m_plist.getId(), &local_cause, &global_cause);
+    if (local_cause || global_cause)
+        std::cout << "h5dwrite wasn't collective " << local_cause << " " << global_cause << " " << std::endl;
 }
 
 

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -49,10 +49,11 @@ int main(int argc, char** argv) {
 
         // Create the dataset
         DataSet dataset = file.createDataSet<double>(DATASET_NAME, DataSpace(dims));
+        dataset.enable_collective();
 
         // Each node want to write its own rank two time in
         // its associated row
-        int data[1][2] = {{mpi_rank, mpi_rank}};
+        double data[1][2] = {{mpi_rank*1.0, mpi_rank*1.0}};
 
         // write it to the associated mpi_rank
         dataset.select({std::size_t(mpi_rank), 0}, {1, 2}).write(data);

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -69,11 +69,9 @@ int main(int argc, char** argv) {
             throw std::runtime_error("Failed to check mpio_no_collective_cause.");
         }
         if (local_cause || global_cause) {
-            std::cout << "The operation wasn't collective: " << local_cause << " " << global_cause
-                      << std::endl;
-            throw std::runtime_error("IO wasn't collective.");
-        } else {
-            std::cout << "Success! The operation was collective.\n";
+            std::cout
+                << "The operation was successful, but couldn't use collective MPI-IO. local cause: "
+                << local_cause << " global cause:" << global_cause << std::endl;
         }
 
 

--- a/src/examples/parallel_hdf5_write_dataset.cpp
+++ b/src/examples/parallel_hdf5_write_dataset.cpp
@@ -65,18 +65,16 @@ int main(int argc, char** argv) {
         // collective MPI-IO operations were used, one may:
         uint32_t local_cause = 0, global_cause = 0;
         auto err = H5Pget_mpio_no_collective_cause(xfer_props.getId(), &local_cause, &global_cause);
-        if(err < 0) {
+        if (err < 0) {
             throw std::runtime_error("Failed to check mpio_no_collective_cause.");
         }
         if (local_cause || global_cause) {
             std::cout << "The operation wasn't collective: " << local_cause << " " << global_cause
                       << std::endl;
             throw std::runtime_error("IO wasn't collective.");
-        }
-        else {
+        } else {
             std::cout << "Success! The operation was collective.\n";
         }
-
 
 
     } catch (Exception& err) {

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -39,6 +39,15 @@ struct MpiFixture {
     int size;
 };
 
+void check_was_collective(const DataTransferProps& xfer_props) {
+    uint32_t local_cause = 0, global_cause = 0;
+    if (H5Pget_mpio_no_collective_cause(xfer_props.getId(), &local_cause, &global_cause) < 0) {
+        throw std::runtime_error("Failed to check mpio_no_collective_cause.");
+    }
+    CHECK(local_cause == 0);
+    CHECK(global_cause == 0);
+}
+
 template <typename T>
 void selectionArraySimpleTestParallel() {
     int mpi_rank, mpi_size;
@@ -54,7 +63,8 @@ void selectionArraySimpleTestParallel() {
     const auto offset_x = static_cast<size_t>(mpi_rank);
     const auto count_x = static_cast<size_t>(mpi_size - mpi_rank);
 
-    const std::string DATASET_NAME("dset");
+    const std::string d1_name("dset1");
+    const std::string d2_name("dset2");
 
     Vector values(size_x);
 
@@ -66,31 +76,55 @@ void selectionArraySimpleTestParallel() {
     adam.add(MPIOFileAccess(MPI_COMM_WORLD, MPI_INFO_NULL));
     File file(filename.str(), File::ReadWrite | File::Create | File::Truncate, adam);
 
-    DataSet dataset = file.createDataSet<T>(DATASET_NAME, DataSpace::From(values));
+    DataSet d1 = file.createDataSet<T>(d1_name, DataSpace::From(values));
+    if (mpi_rank == 0) {
+        d1.write(values);
+    }
 
-    dataset.write(values);
+    DataSet d2 = file.createDataSet<T>(d2_name, DataSpace::From(values));
+    auto xfer_props = DataTransferProps{};
+    xfer_props.add(UseCollectiveIO{});
+
+    {
+        auto offset = std::vector<size_t>{static_cast<size_t>(mpi_rank)};
+        auto count = std::vector<size_t>{1ul};
+        auto slice = d2.select(offset, count);
+
+        auto local_values = Vector(count[0]);
+        local_values[0] = values[offset[0]];
+
+        // Write collectively, each MPI rank writes one slab.
+        slice.write(local_values, xfer_props);
+        check_was_collective(xfer_props);
+    }
 
     file.flush();
 
-    // read it back
-    Vector result;
-    std::vector<size_t> offset;
-    offset.push_back(offset_x);
-    std::vector<size_t> size;
-    size.push_back(count_x);
+    // -- read it back
 
-    Selection slice = dataset.select(offset, size);
+    auto check_result = [&values, offset_x, count_x](const Vector& result) {
+        CHECK(result.size() == count_x);
 
-    CHECK(slice.getSpace().getDimensions()[0] == size_x);
-    CHECK(slice.getMemSpace().getDimensions()[0] == count_x);
+        for (size_t i = offset_x; i < count_x; ++i) {
+            CHECK(values[i + offset_x] == result[i]);
+        }
+    };
 
-    slice.read(result);
+    auto make_slice = [size_x, offset_x, count_x](DataSet& dataset) {
+        auto slice = dataset.select(std::vector<size_t>{offset_x}, std::vector<size_t>{count_x});
 
-    CHECK(result.size() == count_x);
+        CHECK(slice.getSpace().getDimensions()[0] == size_x);
+        CHECK(slice.getMemSpace().getDimensions()[0] == count_x);
 
-    for (size_t i = offset_x; i < count_x; ++i) {
-        CHECK(values[i + offset_x] == result[i]);
-    }
+        return slice;
+    };
+
+    auto s1 = make_slice(d1);
+    check_result(s1.template read<Vector>());
+
+    auto s2 = make_slice(d2);
+    check_result(s2.template read<Vector>(xfer_props));
+    check_was_collective(xfer_props);
 }
 
 TEMPLATE_LIST_TEST_CASE("mpiSelectionArraySimple", "[template]", numerical_test_types) {


### PR DESCRIPTION
This PR adds the ability to pass a data transfer property list to `read` and `write` operations. This is needed to enable collective MPI-IO.

In essence this is #621