### PR TITLE
Add wrapper for allocation time.

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -267,6 +267,23 @@ class Shuffle {
     void apply(hid_t hid) const;
 };
 
+/// \brief When are datasets allocated?
+///
+/// The precise time of when HDF5 requests space to store the dataset
+/// can be configured. Please, consider the upstream documentation for
+/// `H5Pset_alloc_time`.
+class AllocationTime {
+  public:
+    explicit AllocationTime(H5D_alloc_time_t alloc_time)
+        : _alloc_time(alloc_time) {}
+
+  private:
+    friend DataSetCreateProps;
+    void apply(hid_t dcpl) const;
+
+    H5D_alloc_time_t _alloc_time;
+};
+
 /// Dataset access property to control chunk cache configuration.
 /// Do not confuse with the similar file access property for H5Pset_cache
 class Caching {

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -127,7 +127,7 @@ inline void Shuffle::apply(const hid_t hid) const {
     }
 }
 
-void AllocationTime::apply(hid_t dcpl) const {
+inline void AllocationTime::apply(hid_t dcpl) const {
     if (H5Pset_alloc_time(dcpl, _alloc_time) < 0) {
         HDF5ErrMapper::ToException<PropertyException>("Error setting allocation time");
     }

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -127,6 +127,12 @@ inline void Shuffle::apply(const hid_t hid) const {
     }
 }
 
+void AllocationTime::apply(hid_t dcpl) const {
+    if (H5Pset_alloc_time(dcpl, _alloc_time) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>("Error setting allocation time");
+    }
+}
+
 inline void Caching::apply(const hid_t hid) const {
     if (H5Pset_chunk_cache(hid, _numSlots, _cacheSize, _w0) < 0) {
         HDF5ErrMapper::ToException<PropertyException>("Error setting dataset cache parameters");

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -191,6 +191,24 @@ TEST_CASE("Test group properties") {
     CHECK(sizes.second == 500);
 }
 
+TEST_CASE("Test allocation time") {
+    const std::string FILE_NAME("h5_dataset_alloc_time.h5");
+    File file(FILE_NAME, File::Truncate);
+
+    size_t n_elements = 10;
+    std::vector<double> data(n_elements);
+
+    auto dcpl = DataSetCreateProps{};
+    dcpl.add(AllocationTime(H5D_ALLOC_TIME_EARLY));
+
+    auto dataspace = DataSpace::From(data);
+    auto datatype = create_datatype<decltype(data)::value_type>();
+    auto dataset = file.createDataSet("dset", dataspace, datatype, dcpl);
+
+    auto alloc_size = H5Dget_storage_size(dataset.getId());
+    CHECK(alloc_size == data.size() * sizeof(decltype(data)::value_type));
+}
+
 TEST_CASE("Test default constructors") {
     const std::string FILE_NAME("h5_group_test.h5");
     const std::string DATASET_NAME("dset");


### PR DESCRIPTION
The precise timing of when space is allocated for the raw data of a dataset can be configured via the dataset creation property list. This commit wraps the required HDF5 function.