### PR TITLE
Version 2.5.0

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -21,6 +21,7 @@ Kerim Khemraev
 Luc Grosheintz
 Marian Heil
 Mario Emmenlauer
+Mark Bicknell
 Mathieu Bernard
 Matthias Wolf
 Maximilian Nöthe
@@ -36,6 +37,8 @@ Philipp Gloor
 Pramod Kumbhar
 Richard Shaw
 Rick Nitsche
+Rob Latham
+Sergio Botelh
 Sergio Rivas-Gomez
 @spacescientist
 Taiguara Tupinambás

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 ## Version 2.5.0 - 2022-11-03
 ### New Features
-    - Enable collective MPI IO thought Data Transfer Property (#623). Thanks to Rob Latham.
+    - Enable collective MPI IO using the Data Transfer Property (#623). Thanks to Rob Latham.
     - Add a support for half-precision (16-bit) floating-point based on the Half library (http://half.sourceforge.net) (#587). Thanks to Sergio Botelh.
-    - Add an AllocationTime property for DataSet Create Props (#627).
-    - Add possibility to get and set file space strategy (#618).
-    - Add API for getting Access and Create property lists from different kinds of objects (#629).
-    - Let user configure metadata reads and writes at file level (#624).
+    - Enable choosing the allocation time of datasets (#627).
+    - Add possibility to get and set file space strategy. For page allocated files wrap the API to set/retrieve the page size (#618).
+    - Add API for getting Access and Create property lists of HighFive objects (#629).
+    - Let users configure metadata reads and writes at file level (#624). Thanks to Rob Latham.
 
 ### Improvements
     - MPIOFileDriver is now deprecated. Use FileAccessProps (#622).
     - Support of block argument in API (#584).
     - Serialization of types is now automagic and so recursive (#586).
-    - Add an argument to specific File Access Properties in File class construtor (#626).
+    - Add an argument to specific File Create Properties in File class construtor (#626).
 
 ### Bug Fixes
     - Padding of Compound Types (#581).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Version 2.4.2 - 2022-11-03
+### New Features
+    - Enable collective MPI IO thought Data Transfer Property (#623). Thanks to Rob Latham.
+    - Add a support for half-precision (16-bit) floating-point based on the Half library (http://half.sourceforge.net) (#587). Thanks to Sergio Botelh.
+    - Add an AllocationTime property for DataSet Create Props (#627).
+    - Add possibility to get and set file space strategy (#618).
+    - Add API for getting Access and Create property lists from differents kind of objects (#629).
+    - Let user configure metadata reads and writes at file level (#624).
+
+### Improvments
+    - MPIOFileDriver is now deprecated. Use FileAccessprops (#622).
+    - Support of block argument in API (#584).
+    - Serialization of types is now automagic and so recursive (#586).
+    - Add an argument to specific File Access Properties in File class construtor (#626).
+
+### Bug Fixes
+    - Padding of Compound Types (#581).
+    - Compilation with Visual Studio with C++17 or later (#578). Thanks to Mark Bicknell.
+    - Avoid leaking when printing stack for error (#583).
+
 ## Version 2.4.1 - 2022-05-11
 ### New Features
     - Support `std::complex`. Thanks to Philipp.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-## Version 2.4.2 - 2022-11-03
+## Version 2.5.0 - 2022-11-03
 ### New Features
     - Enable collective MPI IO thought Data Transfer Property (#623). Thanks to Rob Latham.
     - Add a support for half-precision (16-bit) floating-point based on the Half library (http://half.sourceforge.net) (#587). Thanks to Sergio Botelh.
     - Add an AllocationTime property for DataSet Create Props (#627).
     - Add possibility to get and set file space strategy (#618).
-    - Add API for getting Access and Create property lists from differents kind of objects (#629).
+    - Add API for getting Access and Create property lists from different kinds of objects (#629).
     - Let user configure metadata reads and writes at file level (#624).
 
-### Improvments
-    - MPIOFileDriver is now deprecated. Use FileAccessprops (#622).
+### Improvements
+    - MPIOFileDriver is now deprecated. Use FileAccessProps (#622).
     - Support of block argument in API (#584).
     - Serialization of types is now automagic and so recursive (#586).
     - Add an argument to specific File Access Properties in File class construtor (#626).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
   cmake_policy(VERSION 3.13)
 endif()
 
-project(HighFive VERSION 2.4.2)
+project(HighFive VERSION 2.5.0)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/highfive/H5Version.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
   cmake_policy(VERSION 3.13)
 endif()
 
-project(HighFive VERSION 2.4.1)
+project(HighFive VERSION 2.4.2)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/highfive/H5Version.hpp)


### PR DESCRIPTION
## Version 2.5.0 - 2022-11-03
### New Features
    - Enable collective MPI IO using the Data Transfer Property (#623). Thanks to Rob Latham.
    - Add a support for half-precision (16-bit) floating-point based on the Half library (http://half.sourceforge.net) (#587). Thanks to Sergio Botelh.
    - Enable choosing the allocation time of datasets (#627).
    - Add possibility to get and set file space strategy. For page allocated files wrap the API to set/retrieve the page size (#618).
    - Add API for getting Access and Create property lists of HighFive objects (#629).
    - Let users configure metadata reads and writes at file level (#624). Thanks to Rob Latham.

### Improvements
    - MPIOFileDriver is now deprecated. Use FileAccessProps (#622).
    - Support of block argument in API (#584).
    - Serialization of types is now automagic and so recursive (#586).
    - Add an argument to specific File Create Properties in File class construtor (#626).

### Bug Fixes
    - Padding of Compound Types (#581).
    - Compilation with Visual Studio with C++17 or later (#578). Thanks to Mark Bicknell.
    - Avoid leaking when printing stack for error (#583).
