### PR TITLE
Check also datatype sizes for floats to avoid losing bits

### DIFF
--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -24,18 +24,18 @@ namespace HighFive {
 /// \brief Enum of Fundamental data classes
 ///
 enum class DataTypeClass {
-    Time,
-    Integer,
-    Float,
-    String,
-    BitField,
-    Opaque,
-    Compound,
-    Reference,
-    Enum,
-    VarLen,
-    Array,
-    Invalid
+    Time = 1 << 1,
+    Integer = 1 << 2,
+    Float = 1 << 3,
+    String = 1 << 4,
+    BitField = 1 << 5,
+    Opaque = 1 << 6,
+    Compound = 1 << 7,
+    Reference = 1 << 8,
+    Enum = 1 << 9,
+    VarLen = 1 << 10,
+    Array = 1 << 11,
+    Invalid = 0
 };
 
 inline DataTypeClass operator|(DataTypeClass lhs, DataTypeClass rhs) {

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -9,6 +9,7 @@
 #ifndef H5DATATYPE_HPP
 #define H5DATATYPE_HPP
 
+#include <type_traits>
 #include <vector>
 
 #include "H5Object.hpp"
@@ -36,6 +37,16 @@ enum class DataTypeClass {
     Array,
     Invalid
 };
+
+inline DataTypeClass operator|(DataTypeClass lhs, DataTypeClass rhs) {
+    using T = std::underlying_type<DataTypeClass>::type;
+    return static_cast<DataTypeClass>(static_cast<T>(lhs) | static_cast<T>(rhs));
+}
+
+inline DataTypeClass operator&(DataTypeClass lhs, DataTypeClass rhs) {
+    using T = std::underlying_type<DataTypeClass>::type;
+    return static_cast<DataTypeClass>(static_cast<T>(lhs) & static_cast<T>(rhs));
+}
 
 
 ///

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -61,8 +61,10 @@ inline T Attribute::read() const {
 template <typename T>
 inline void Attribute::read(T& array) const {
     const DataSpace& mem_space = getMemSpace();
-    const details::BufferInfo<T> buffer_info(getDataType(),
-                                             [this]() -> std::string { return this->getName(); });
+    const details::BufferInfo<T> buffer_info(
+        getDataType(),
+        [this]() -> std::string { return this->getName(); },
+        details::BufferInfo<T>::read);
 
     if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
         std::ostringstream ss;
@@ -99,8 +101,10 @@ inline void Attribute::read(T* array, const DataType& dtype) const {
 template <typename T>
 inline void Attribute::write(const T& buffer) {
     const DataSpace& mem_space = getMemSpace();
-    const details::BufferInfo<T> buffer_info(getDataType(),
-                                             [this]() -> std::string { return this->getName(); });
+    const details::BufferInfo<T> buffer_info(
+        getDataType(),
+        [this]() -> std::string { return this->getName(); },
+        details::BufferInfo<T>::write);
 
     if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
         std::ostringstream ss;

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -120,6 +120,11 @@ BufferInfo<T>::BufferInfo(const DataType& dtype, F getName)
         std::cerr << "HighFive WARNING \"" << getName()
                   << "\": data and hdf5 dataset have different types: " << data_type.string()
                   << " -> " << dtype.string() << std::endl;
+    } else if (((dtype.getClass() & data_type.getClass()) == DataTypeClass::Float) &&
+               (dtype.getSize() != data_type.getSize())) {
+        std::cerr << "HighFive WARNING \"" << getName()
+                  << "\": data and hdf5 dataset have differing floating point precision: "
+                  << data_type.string() << " -> " << dtype.string() << std::endl;
     }
 }
 

--- a/include/highfive/bits/H5ReadWrite_misc.hpp
+++ b/include/highfive/bits/H5ReadWrite_misc.hpp
@@ -126,11 +126,11 @@ BufferInfo<T>::BufferInfo(const DataType& dtype, F getName, Operation _op)
                   << " -> " << dtype.string() << std::endl;
     } else if ((dtype.getClass() & data_type.getClass()) == DataTypeClass::Float) {
         if ((op == read) && (dtype.getSize() > data_type.getSize())) {
-            std::cerr << "HighFive WARNING \"" << getName()
+            std::clog << "HighFive WARNING \"" << getName()
                       << "\": hdf5 dataset has higher floating point precision than data on read: "
                       << dtype.string() << " -> " << data_type.string() << std::endl;
         } else if ((op == write) && (dtype.getSize() < data_type.getSize())) {
-            std::cerr << "HighFive WARNING \"" << getName()
+            std::clog << "HighFive WARNING \"" << getName()
                       << "\": data has higher floating point precision than hdf5 dataset on write: "
                       << data_type.string() << " -> " << dtype.string() << std::endl;
         }

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -172,9 +172,10 @@ template <typename T>
 inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_props) const {
     const auto& slice = static_cast<const Derivate&>(*this);
     const DataSpace& mem_space = slice.getMemSpace();
-    const details::BufferInfo<T> buffer_info(slice.getDataType(), [slice]() -> std::string {
-        return details::get_dataset(slice).getPath();
-    });
+    const details::BufferInfo<T> buffer_info(
+        slice.getDataType(),
+        [slice]() -> std::string { return details::get_dataset(slice).getPath(); },
+        details::BufferInfo<T>::Operation::read);
 
     if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
         std::ostringstream ss;
@@ -225,9 +226,10 @@ template <typename T>
 inline void SliceTraits<Derivate>::write(const T& buffer, const DataTransferProps& xfer_props) {
     const auto& slice = static_cast<const Derivate&>(*this);
     const DataSpace& mem_space = slice.getMemSpace();
-    const details::BufferInfo<T> buffer_info(slice.getDataType(), [slice]() -> std::string {
-        return details::get_dataset(slice).getPath();
-    });
+    const details::BufferInfo<T> buffer_info(
+        slice.getDataType(),
+        [slice]() -> std::string { return details::get_dataset(slice).getPath(); },
+        details::BufferInfo<T>::Operation::write);
 
     if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
         std::ostringstream ss;

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -2446,6 +2446,24 @@ TEST_CASE("HighFiveReadWriteConsts") {
     }
 }
 
+TEST_CASE("HighFiveDataTypeClass") {
+    auto Float = DataTypeClass::Float;
+    auto String = DataTypeClass::String;
+    auto Invalid = DataTypeClass::Invalid;
+
+    CHECK(Float != Invalid);
+
+    CHECK((Float & Float) == Float);
+    CHECK((Float | Float) == Float);
+
+    CHECK((Float & String) == Invalid);
+    CHECK((Float | String) != Invalid);
+
+    CHECK(((Float & String) & Float) == Invalid);
+    CHECK(((Float | String) & Float) == Float);
+    CHECK(((Float | String) & String) == String);
+}
+
 #ifdef H5_USE_EIGEN
 
 template <typename T>


### PR DESCRIPTION
**Description**

HDF5 treats floats and doubles as Float, one datatype class. so reading a double dataset into a float vector won't even cause a warning message. This PR extends DataTypeClass a little bit to allow comparing DataTypeClasses with bit operators and then treats the case specially where datatypes are floating types and also checks the type size, printing a warning if there is a mismatch.

**How to test this?**

Here's a minimal patch to one of the examples that tests this:

```
--- a/src/examples/create_dataset_double.cpp
+++ b/src/examples/create_dataset_double.cpp
@@ -6,6 +6,7 @@
  *          http://www.boost.org/LICENSE_1_0.txt)
  *
  */
+#include <array>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -37,6 +38,15 @@ int main(void) {
         // write it
         dataset.write(data);

+        std::vector<std::array<float, 6>> lore(2);
+        DataSet readback = file.getDataSet(DATASET_NAME);
+        readback.read(lore);
+        for (const auto& arr: lore) {
+            for (const auto e: arr) {
+                std::cout << " " << e;
+            }
+            std::cout << std::endl;
+        }
     } catch (Exception& err) {
         // catch and print any HDF5 error
         std::cerr << err.what() << std::endl;
```

```bash
cmake .. -DHIGHFIVE_EXAMPLES=ON
make -j8
src/examples/create_dataset_double_bin
```

