### PR TITLE
Allow finding HDF5 in config mode.

### DIFF
--- a/CMake/HighFiveTargetDeps.cmake
+++ b/CMake/HighFiveTargetDeps.cmake
@@ -8,7 +8,6 @@ if(NOT TARGET libdeps)
 
   # HDF5
   if(NOT DEFINED HDF5_C_LIBRARIES)
-    set(HDF5_NO_FIND_PACKAGE_CONFIG_FILE TRUE)  # Consistency
     set(HDF5_PREFER_PARALLEL ${HIGHFIVE_PARALLEL_HDF5})
     find_package(HDF5 REQUIRED)
   endif()


### PR DESCRIPTION
This PR allows finding HDF5 when only `*-config.cmake` files are present, i.e. when the find module can't find HDF5, but in config mode the dependency could be found.