### PR TITLE
Construct HDF5 file from existing hid_t

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -70,6 +70,12 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
          const FileAccessProps& fileAccessProps = FileAccessProps::Default());
 
     ///
+    /// \brief File creating a HighFive::File from and already opended HDF5 file.
+    ///
+    /// \param hid: existing hid, usually created by H5Gopen (follows H5LTopen_file_image)
+    explicit File(const hid_t hid);
+
+    ///
     /// \brief Return the name of the file
     ///
     const std::string& getName() const noexcept;

--- a/include/highfive/bits/H5File_misc.hpp
+++ b/include/highfive/bits/H5File_misc.hpp
@@ -43,7 +43,6 @@ inline File::File(const std::string& filename,
                   const FileAccessProps& fileAccessProps)
     : File(filename, openFlags, FileCreateProps::Default(), fileAccessProps) {}
 
-
 inline File::File(const std::string& filename,
                   unsigned openFlags,
                   const FileCreateProps& fileCreateProps,
@@ -82,6 +81,10 @@ inline File::File(const std::string& filename,
     if ((_hid = H5Fcreate(filename.c_str(), createMode, fcpl, fapl)) < 0) {
         HDF5ErrMapper::ToException<FileException>(std::string("Unable to create file " + filename));
     }
+}
+
+inline File::File(const hid_t hid) {
+    _hid = hid;
 }
 
 inline const std::string& File::getName() const noexcept {


### PR DESCRIPTION
**Description**

This pull request enables creating a `HighFive::File` from existing `hid_t`, to allow use patterns like reading HDF5 files from memory buffers:

```cpp
  hid_t file_id = H5LTopen_file_image(const_cast<void*>(data), size,
                                      H5LT_FILE_IMAGE_DONT_RELEASE);
  hid_t root_id = H5Gopen(file_id, "/", H5P_DEFAULT);
  HighFive::File file(root_id);
```