### PR TITLE
Example of reading an in memory HDF5 file.

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -111,6 +111,9 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
         return details::get_plist<FileAccessProps>(*this, H5Fget_access_plist);
     }
 
+  protected:
+    File() = default;
+
   private:
     using Object::Object;
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -32,6 +32,11 @@ function(compile_example exemple_source)
     add_executable(${example_name} ${exemple_source})
     target_link_libraries(${example_name} HighFive)
 
+    if(${example_name} MATCHES ".*hl_hdf5.*")
+        find_package(HDF5 REQUIRED C HL)
+        target_link_libraries(${example_name} ${HDF5_HL_LIBRARIES})
+    endif()
+
 endfunction()
 
 file(GLOB list_example "*.cpp")

--- a/src/examples/hl_hdf5_inmemory_files.cpp
+++ b/src/examples/hl_hdf5_inmemory_files.cpp
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c), 2022, Blue Brain Project
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#include <iostream>
+#include <vector>
+
+
+#include <highfive/H5File.hpp>
+#include <hdf5_hl.h>
+
+using namespace HighFive;
+
+class InMemoryFile: public HighFive::File {
+  public:
+    explicit InMemoryFile(std::vector<std::uint8_t> buffer)
+        : _buffer(std::move(buffer)) {
+        _hid = H5LTopen_file_image(_buffer.data(),
+                                   sizeof(_buffer[0]) * _buffer.size(),
+                                   H5LT_FILE_IMAGE_DONT_RELEASE | H5LT_FILE_IMAGE_DONT_COPY);
+    }
+
+  private:
+    std::vector<std::uint8_t> _buffer;
+};
+
+
+// Create a 2D dataset 10x3 of double with eigen matrix
+// and write it to a file
+int main(void) {
+    const std::string FILE_NAME("inmemory_file.h5");
+    const std::string DATASET_NAME("dset");
+
+    try {
+        auto data = std::vector<double>{1.0, 2.0, 3.0};
+
+        {
+            // we create a new hdf5 file
+            File file(FILE_NAME, File::Truncate);
+            file.createDataSet(DATASET_NAME, data);
+        }
+
+        auto buffer = std::vector<std::uint8_t>(1ul << 20);
+        auto file = std::fopen(FILE_NAME.c_str(), "r");
+        std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file);
+
+        auto h5 = InMemoryFile(std::move(buffer));
+
+        auto read_back = h5.getDataSet(DATASET_NAME).read<std::vector<double>>();
+
+        for (size_t i = 0; i < read_back.size(); ++i) {
+            if (read_back[i] != data[i]) {
+                std::runtime_error("Values don't match.");
+            } else {
+                std::cout << "read_back[" << i << "] = " << read_back[i] << "\n";
+            }
+        }
+    } catch (Exception& err) {
+        // catch and print any HDF5 error
+        std::cerr << err.what() << std::endl;
+    }
+
+    return 0;  // successfully terminated
+}

--- a/src/examples/hl_hdf5_inmemory_files.cpp
+++ b/src/examples/hl_hdf5_inmemory_files.cpp
@@ -48,7 +48,8 @@ int main(void) {
         // byte-by-byte into RAM.
         auto buffer = std::vector<std::uint8_t>(1ul << 20);
         auto file = std::fopen(FILE_NAME.c_str(), "r");
-        static_cast<void>(std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file));
+        auto nread = std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file);
+        std::cout << "Bytes read: " << nread << "\n";
 
         // Create a file from a buffer.
         auto h5 = InMemoryFile(std::move(buffer));

--- a/src/examples/hl_hdf5_inmemory_files.cpp
+++ b/src/examples/hl_hdf5_inmemory_files.cpp
@@ -48,7 +48,7 @@ int main(void) {
         // byte-by-byte into RAM.
         auto buffer = std::vector<std::uint8_t>(1ul << 20);
         auto file = std::fopen(FILE_NAME.c_str(), "r");
-        (void) std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file);
+        static_cast<void>(std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file));
 
         // Create a file from a buffer.
         auto h5 = InMemoryFile(std::move(buffer));

--- a/src/examples/hl_hdf5_inmemory_files.cpp
+++ b/src/examples/hl_hdf5_inmemory_files.cpp
@@ -39,22 +39,27 @@ int main(void) {
         auto data = std::vector<double>{1.0, 2.0, 3.0};
 
         {
-            // we create a new hdf5 file
+            // We create an HDF5 file.
             File file(FILE_NAME, File::Truncate);
             file.createDataSet(DATASET_NAME, data);
         }
 
+        // Simulate having an inmemory file by reading a file
+        // byte-by-byte into RAM.
         auto buffer = std::vector<std::uint8_t>(1ul << 20);
         auto file = std::fopen(FILE_NAME.c_str(), "r");
-        std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file);
+        (void) std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file);
 
+        // Create a file from a buffer.
         auto h5 = InMemoryFile(std::move(buffer));
 
+        // Read a dataset as usual.
         auto read_back = h5.getDataSet(DATASET_NAME).read<std::vector<double>>();
 
+        // Check if the values match.
         for (size_t i = 0; i < read_back.size(); ++i) {
             if (read_back[i] != data[i]) {
-                std::runtime_error("Values don't match.");
+                throw std::runtime_error("Values don't match.");
             } else {
                 std::cout << "read_back[" << i << "] = " << read_back[i] << "\n";
             }


### PR DESCRIPTION
As discussed internally, one way of adding functionality related to inmemory file would be to subclass `HighFive::File`. In the PR this option is sketched out as an example.

This could be an alternative to implementing #648