### PR TITLE
Fix leak when reading variable length strings

### DIFF
--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -79,8 +79,14 @@ inline void Attribute::read(T& array) const {
     r.unserialize();
     auto t = create_datatype<typename details::inspector<T>::base_type>();
     auto c = t.getClass();
-    if (c == DataTypeClass::VarLen) {
+    if (c == DataTypeClass::VarLen || t.isVariableStr()) {
+#if H5_VERSION_GE(1, 12, 0)
+        // This one have been created in 1.12.0
+        (void) H5Treclaim(t.getId(), mem_space.getId(), H5P_DEFAULT, r.get_pointer());
+#else
+        // This one is deprecated since 1.12.0
         (void) H5Dvlen_reclaim(t.getId(), mem_space.getId(), H5P_DEFAULT, r.get_pointer());
+#endif
     }
 }
 

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -10,6 +10,7 @@
 
 #include <type_traits>
 #include <cstring>
+#include <numeric>
 
 #include "../H5Reference.hpp"
 #ifdef H5_USE_BOOST

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -189,8 +189,14 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
     r.unserialize();
     auto t = create_datatype<typename details::inspector<T>::base_type>();
     auto c = t.getClass();
-    if (c == DataTypeClass::VarLen) {
+    if (c == DataTypeClass::VarLen || t.isVariableStr()) {
+#if H5_VERSION_GE(1, 12, 0)
+        // This one have been created in 1.12.0
+        (void) H5Treclaim(t.getId(), mem_space.getId(), xfer_props.getId(), r.get_pointer());
+#else
+        // This one is deprecated since 1.12.0
         (void) H5Dvlen_reclaim(t.getId(), mem_space.getId(), xfer_props.getId(), r.get_pointer());
+#endif
     }
 }
 


### PR DESCRIPTION
Variable length strings are not of type VariableLength, so need to add a check for them.

Fix #658 