### PR TITLE
Use 'H5free_memory(void*)' instead of native 'free(void*)' in error handler.

### DIFF
--- a/include/highfive/bits/H5Exception_misc.hpp
+++ b/include/highfive/bits/H5Exception_misc.hpp
@@ -28,8 +28,8 @@ struct HDF5ErrMapper {
         std::ostringstream oss;
         oss << '(' << major_err << ") " << minor_err;
 
-        free((void*) major_err);
-        free((void*) minor_err);
+        H5free_memory((void*) major_err);
+        H5free_memory((void*) minor_err);
 
         auto* e = new ExceptionType(oss.str());
         e->_err_major = err_desc->maj_num;


### PR DESCRIPTION
**Description**

Please include a summary of the change and which issue is fixed or which feature is added.

Windows Visual Studio did not like the native call to `free(..)`. Using the Hdf5 function resolves the issue.

https://portal.hdfgroup.org/display/HDF5/H5_FREE_MEMORY
