### PR TITLE
Bump Catch2 to v3.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,26 +28,28 @@ jobs:
   # Job testing compiling on several Ubuntu systems + MPI
   # =========================================================
   #
-  # For 18.04:  bare HighFive
-  # For 20.04:  activate Boost, OpenCV
+  # For 20.04:  bare and activate Boost, OpenCV
   # For latest: activate Boost, Eigen, OpenCV, with Ninja
   #
   # XTensor tests are run for conda/mamba and MacOS
   Linux_MPI:
-    runs-on: ${{matrix.os}}
+    runs-on: ${{matrix.config.os}}
+    name: ${{toJson(matrix.config)}}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
         include:
-          - os: ubuntu-18.04
-            pkgs: ''
-            flags: '-DHIGHFIVE_USE_BOOST:Bool=OFF'
-          - os: ubuntu-20.04
-            pkgs: 'libboost-all-dev libopencv-dev'
-            flags: '-DHIGHFIVE_USE_OPENCV:Bool=ON -GNinja'
-          - os: ubuntu-latest
-            pkgs: 'libboost-all-dev libeigen3-dev libopencv-dev'
-            flags: '-DHIGHFIVE_USE_EIGEN:Bool=ON -DHIGHFIVE_USE_OPENCV:Bool=ON -GNinja'
+          - config:
+              os: ubuntu-20.04
+              pkgs: ''
+              flags: '-DHIGHFIVE_USE_BOOST:Bool=OFF'
+          - config:
+              os: ubuntu-20.04
+              pkgs: 'libboost-all-dev libopencv-dev'
+              flags: '-DHIGHFIVE_USE_OPENCV:Bool=ON -GNinja'
+          - config:
+              os: ubuntu-latest
+              pkgs: 'libboost-all-dev libeigen3-dev libopencv-dev'
+              flags: '-DHIGHFIVE_USE_EIGEN:Bool=ON -DHIGHFIVE_USE_OPENCV:Bool=ON -GNinja'
 
     steps:
     - uses: actions/checkout@v3
@@ -62,11 +64,11 @@ jobs:
     - name: "Install libraries"
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install libhdf5-openmpi-dev libsz2 ninja-build ${{ matrix.pkgs }}
+        sudo apt-get -qq install libhdf5-openmpi-dev libsz2 ninja-build ${{ matrix.config.pkgs }}
 
     - name: Build
       run: |
-        CMAKE_OPTIONS=(-DHIGHFIVE_PARALLEL_HDF5:BOOL=ON ${{ matrix.flags }})
+        CMAKE_OPTIONS=(-DHIGHFIVE_PARALLEL_HDF5:BOOL=ON ${{ matrix.config.flags }})
         source $GITHUB_WORKSPACE/.github/build.sh
 
     - name: Test

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 ## Base tests
 foreach(test_name tests_high_five_base tests_high_five_multi_dims tests_high_five_easy)
   add_executable(${test_name} "${test_name}.cpp")
-  target_link_libraries(${test_name} HighFive Catch2::Catch2)
+  target_link_libraries(${test_name} HighFive Catch2::Catch2WithMain)
   catch_discover_tests(${test_name})
 endforeach()
 

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -35,8 +35,8 @@ using base_test_types = std::tuple<int,
 #include <half.hpp>
 
 using float16_t = half_float::half;
-using numerical_test_types = decltype(
-    std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
+using numerical_test_types =
+    decltype(std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));
 #else
 using numerical_test_types = base_test_types;
 #endif

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <random>
 #include <string>
@@ -24,8 +25,9 @@
 #include <highfive/H5Reference.hpp>
 #include <highfive/H5Utility.hpp>
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
 
 #include "tests_high_five.hpp"
 

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -27,8 +27,7 @@
 #include <xtensor/xview.hpp>
 #endif
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("H5Easy_Compression") {
     {

--- a/tests/unit/tests_high_five_multi_dims.cpp
+++ b/tests/unit/tests_high_five_multi_dims.cpp
@@ -18,8 +18,8 @@
 #include <boost/multi_array.hpp>
 #endif
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 
 #include "tests_high_five.hpp"
 

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -18,8 +18,9 @@
 #include <highfive/H5DataSpace.hpp>
 #include <highfive/H5Group.hpp>
 
-#define CATCH_CONFIG_RUNNER
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_session.hpp>
 
 #include "tests_high_five.hpp"
 


### PR DESCRIPTION
From 2 to v3, catch2 breaks a lot of things: fix it.

Will fix #668 