### PR TITLE
Bump hdf5 from 1.13.x to 1.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hdf5_version : [ hdf5-1_8_22, hdf5-1_10_9, hdf5-1_12_2, hdf5-1_13_3 ]
+        hdf5_version : [ hdf5-1_8_22, hdf5-1_10_9, hdf5-1_12_2, hdf5-1_14_0 ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
HDF5 1.13.x was a alpha version, let's move to the final version