### PR TITLE
Add chunking property if necessary and not set by user

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -97,6 +97,10 @@ class DataSpace: public Object {
     /// associated dataset maximum dimension
     std::vector<size_t> getMaxDimensions() const;
 
+    /// \brief isExtendable
+    /// \return return true if this dataspace is extendable, false otherwise
+    bool isExtendable() const;
+
     /// Create a dataspace matching a type accepted by details::inspector
     template <typename T>
     static DataSpace From(const T& value);

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -476,6 +476,7 @@ class EstimatedLinkInfo {
 ///                                                   dataspace.getMaxDimensions()
 ///                                                   AtomicType<float>{}.getSize());
 /// }
+/// \endcode
 class Chunking {
   public:
     explicit Chunking(const std::vector<hsize_t>& dims);

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -453,6 +453,29 @@ class EstimatedLinkInfo {
     unsigned _length;
 };
 
+/// \brief Set chunking to DataSet.
+///
+/// To set a chunking size:
+/// \code{.cpp}
+/// DataSetCreateProps dcpl{};
+/// dcpl.add(Chuking(std::vector<hsize_t>{2, 2}));
+/// auto dset = file.createDataSet<float>{"chunked", dataspace, dcpl);
+/// \endcode
+///
+/// To get chunking size:
+/// \code{.cpp}
+/// auto dcpl = dset.getCreatePropertyList();
+/// auto chunk = Chunking(dcpl);
+/// auto dims = chunk.getDimensions();
+/// \endcode
+///
+/// To set guessed chunking size:
+/// \code{.cpp}
+/// if ((dpcl.needs_chunking() || dataspace.isExtendable) && !dpcl.has_chunking()) {
+///     dpcl.add(Chunking(Chunking::guessChunkingSize(dataspace.getDimensions(),
+///                                                   dataspace.getMaxDimensions()
+///                                                   AtomicType<float>{}.getSize());
+/// }
 class Chunking {
   public:
     explicit Chunking(const std::vector<hsize_t>& dims);
@@ -463,8 +486,14 @@ class Chunking {
 
     explicit Chunking(DataSetCreateProps& plist, size_t max_dims = 32);
 
+    /// \brief Return size of the chunking for this dataset.
     const std::vector<hsize_t>& getDimensions() const noexcept;
 
+    /// \brief Function to get a default chunk vector
+    /// If you don't want to choose a chunking size yourself, this function will do for you.
+    /// See also: DataSpace::isExpendable() and PropertyList<DATASET_CREATE>::needs_chunking() and
+    /// PropertyList<DATASET_CREATE>::has_chunking() to know if your Dataset needs chunking.
+    /// \return a vector of dimensions for chunking
     static std::vector<std::size_t> guessChunkingSize(const std::vector<std::size_t>& dims,
                                                       const std::vector<std::size_t>& max_dims,
                                                       std::size_t typesize);

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -448,7 +448,9 @@ class Chunking {
         return _dims;
     }
 
-    static std::vector<std::size_t> guessChunkingSize(const std::vector<std::size_t>& dims, const std::vector<std::size_t>& max_dims, std::size_t typesize);
+    static std::vector<std::size_t> guessChunkingSize(const std::vector<std::size_t>& dims,
+                                                      const std::vector<std::size_t>& max_dims,
+                                                      std::size_t typesize);
 
   private:
     friend DataSetCreateProps;

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -82,7 +82,7 @@ class PropertyList: public PropertyListBase {
   public:
     ///
     /// \brief return the type of this PropertyList
-    constexpr PropertyType getType() const noexcept {
+    constexpr static PropertyType getType() noexcept {
         return T;
     }
 
@@ -109,7 +109,7 @@ class PropertyList<PropertyType::DATASET_CREATE>: public PropertyListBase {
   public:
     ///
     /// \brief return the type of this PropertyList
-    constexpr PropertyType getType() const noexcept {
+    constexpr static PropertyType getType() noexcept {
         return PropertyType::DATASET_CREATE;
     }
 

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -19,6 +19,8 @@
 
 #include "H5Exception.hpp"
 #include "H5Object.hpp"
+#include "bits/H5Utils.hpp"
+
 
 namespace HighFive {
 
@@ -427,9 +429,11 @@ class EstimatedLinkInfo {
     const unsigned _length;
 };
 
-
 class Chunking {
   public:
+    explicit Chunking(const std::vector<size_t>& dims)
+        : _dims(details::to_vector_hsize_t(dims)) {}
+
     explicit Chunking(const std::vector<hsize_t>& dims)
         : _dims(dims) {}
 
@@ -444,9 +448,11 @@ class Chunking {
         return _dims;
     }
 
+    static std::vector<std::size_t> guessChunkingSize(const std::vector<std::size_t>& dims, const std::vector<std::size_t>& max_dims, std::size_t typesize);
+
   private:
     friend DataSetCreateProps;
-    void apply(hid_t hid) const;
+    void apply(const hid_t hid) const;
     const std::vector<hsize_t> _dims;
 };
 

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -24,8 +24,8 @@
 #endif
 
 namespace HighFive {
-inline size_t compute_total_size(const std::vector<size_t>& dims) {
-    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<size_t>());
+inline size_t compute_total_size(const std::vector<std::size_t>& dims) {
+    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<std::size_t>());
 }
 
 template <typename T>

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -10,7 +10,6 @@
 
 #include <type_traits>
 #include <cstring>
-#include <numeric>
 
 #include "../H5Reference.hpp"
 #ifdef H5_USE_BOOST
@@ -24,10 +23,6 @@
 #endif
 
 namespace HighFive {
-inline size_t compute_total_size(const std::vector<std::size_t>& dims) {
-    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<std::size_t>());
-}
-
 template <typename T>
 using unqualified_t = typename std::remove_const<typename std::remove_reference<T>::type>::type;
 

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -127,6 +127,12 @@ inline std::vector<size_t> DataSpace::getMaxDimensions() const {
     return details::to_vector_size_t(maxdims);
 }
 
+inline bool DataSpace::isExtendable() const {
+    const auto maxdims = getMaxDimensions();
+    const auto dims = getDimensions();
+    return !std::equal(dims.begin(), dims.end(), maxdims.begin());
+}
+
 template <typename T>
 inline DataSpace DataSpace::From(const T& value) {
     auto dims = details::inspector<T>::getDimensions(value);

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -9,9 +9,10 @@
 #pragma once
 
 #include <array>
+#include <algorithm>
 #include <initializer_list>
-#include <vector>
 #include <numeric>
+#include <vector>
 
 #include <H5Spublic.h>
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -211,10 +211,6 @@ class NodeTraits {
     // Opens an arbitrary object to obtain info
     Object _open(const std::string& node_name,
                  const DataSetAccessProps& accessProps = DataSetAccessProps::Default()) const;
-
-    DataSetCreateProps _chunkIfNecessary(const DataSpace& space,
-                                         const DataType& dtype,
-                                         const DataSetCreateProps& createProps);
 };
 
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -212,8 +212,7 @@ class NodeTraits {
     Object _open(const std::string& node_name,
                  const DataSetAccessProps& accessProps = DataSetAccessProps::Default()) const;
 
-    DataSetCreateProps _chunkIfNecessary(const std::string& dataset_name,
-                                         const DataSpace& space,
+    DataSetCreateProps _chunkIfNecessary(const DataSpace& space,
                                          const DataType& dtype,
                                          const DataSetCreateProps& createProps);
 };

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -211,6 +211,11 @@ class NodeTraits {
     // Opens an arbitrary object to obtain info
     Object _open(const std::string& node_name,
                  const DataSetAccessProps& accessProps = DataSetAccessProps::Default()) const;
+
+    DataSetCreateProps _chunkIfNecessary(const std::string& dataset_name,
+                                         const DataSpace& space,
+                                         const DataType& dtype,
+                                         const DataSetCreateProps& createProps);
 };
 
 

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -55,7 +55,8 @@ static inline std::vector<hsize_t> _guessChunkDims(const std::vector<std::size_t
     }
 
     std::size_t dset_size = compute_total_size(chunkdims) * typesize;
-    double target_size = CHUNK_BASE * std::exp2(std::log10(static_cast<double>(dset_size) / (1024. * 1024.)));
+    double target_size = CHUNK_BASE *
+                         std::exp2(std::log10(static_cast<double>(dset_size) / (1024. * 1024.)));
 
     if (target_size > CHUNK_MAX) {
         target_size = CHUNK_MAX;
@@ -72,7 +73,8 @@ static inline std::vector<hsize_t> _guessChunkDims(const std::vector<std::size_t
 
         std::size_t chunk_size = compute_total_size(chunkdims) * typesize;
 
-        if ((static_cast<double>(chunk_size) < target_size || std::abs(static_cast<double>(chunk_size) - target_size) / target_size < 0.5) &&
+        if ((static_cast<double>(chunk_size) < target_size ||
+             std::abs(static_cast<double>(chunk_size) - target_size) / target_size < 0.5) &&
             chunk_size < CHUNK_MAX) {
             break;
         }
@@ -81,7 +83,8 @@ static inline std::vector<hsize_t> _guessChunkDims(const std::vector<std::size_t
             break;  // Element size larger than CHUNK_MAX
         }
 
-        chunkdims[idx % ndims] = static_cast<std::size_t>(std::ceil(static_cast<double>(chunkdims[idx % ndims]) / 2.));
+        chunkdims[idx % ndims] = static_cast<std::size_t>(
+            std::ceil(static_cast<double>(chunkdims[idx % ndims]) / 2.));
         idx++;
     }
 

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -48,14 +48,14 @@ static inline std::vector<hsize_t> _guessChunkDims(const std::vector<std::size_t
     std::vector<std::size_t> chunkdims = dims;
 
     // If the dimension is unlimited, set chunksize to 1024 along that
-    for (int i = 0; i < ndims; i++) {
+    for (std::size_t i = 0; i < ndims; i++) {
         if (max_dims[i] == DataSpace::UNLIMITED) {
             chunkdims[i] = 1024;
         }
     }
 
     std::size_t dset_size = compute_total_size(chunkdims) * typesize;
-    double target_size = CHUNK_BASE * std::pow(2.0, std::log10(dset_size / (1024. * 1024)));
+    double target_size = CHUNK_BASE * std::exp2(std::log10(static_cast<double>(dset_size) / (1024. * 1024.)));
 
     if (target_size > CHUNK_MAX) {
         target_size = CHUNK_MAX;
@@ -63,7 +63,7 @@ static inline std::vector<hsize_t> _guessChunkDims(const std::vector<std::size_t
         target_size = CHUNK_MIN;
     }
 
-    int idx = 0;
+    std::size_t idx = 0;
     while (1) {
         // Repeatedly loop over the axes, dividing them by 2.  Stop when:
         // 1a. We're smaller than the target chunk size, OR
@@ -72,7 +72,7 @@ static inline std::vector<hsize_t> _guessChunkDims(const std::vector<std::size_t
 
         std::size_t chunk_size = compute_total_size(chunkdims) * typesize;
 
-        if ((chunk_size < target_size || std::abs(chunk_size - target_size) / target_size < 0.5) &&
+        if ((static_cast<double>(chunk_size) < target_size || std::abs(static_cast<double>(chunk_size) - target_size) / target_size < 0.5) &&
             chunk_size < CHUNK_MAX) {
             break;
         }
@@ -81,7 +81,7 @@ static inline std::vector<hsize_t> _guessChunkDims(const std::vector<std::size_t
             break;  // Element size larger than CHUNK_MAX
         }
 
-        chunkdims[idx % ndims] = static_cast<std::size_t>(std::ceil(chunkdims[idx % ndims] / 2.0));
+        chunkdims[idx % ndims] = static_cast<std::size_t>(std::ceil(static_cast<double>(chunkdims[idx % ndims]) / 2.));
         idx++;
     }
 

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -41,9 +41,11 @@ inline DataSet NodeTraits<Derivate>::createDataSet(const std::string& dataset_na
     LinkCreateProps lcpl;
     lcpl.add(CreateIntermediateGroup(parents));
 
-    bool extendable = !std::equal(space.getDimensions().begin(),
-                                  space.getDimensions().end(),
-                                  space.getMaxDimensions().begin());
+    auto dims = space.getDimensions();
+    auto max_dims = space.getMaxDimensions();
+    bool extendable = !std::equal(dims.begin(),
+                                  dims.end(),
+                                  max_dims.begin());
 
     if ((extendable || createProps.needs_chunking()) && !createProps.has_chunking()) {
         HDF5ErrMapper::ToException<DataSetException>(std::string("Chunking is needed but not set for dataset \"") + dataset_name + "\":");

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -41,11 +41,7 @@ inline DataSet NodeTraits<Derivate>::createDataSet(const std::string& dataset_na
     LinkCreateProps lcpl;
     lcpl.add(CreateIntermediateGroup(parents));
 
-    auto dims = space.getDimensions();
-    auto max_dims = space.getMaxDimensions();
-    bool extendable = !std::equal(dims.begin(), dims.end(), max_dims.begin());
-
-    if ((extendable || createProps.needs_chunking()) && !createProps.has_chunking()) {
+    if ((space.isExtendable() || createProps.needs_chunking()) && !createProps.has_chunking()) {
         HDF5ErrMapper::ToException<DataSetException>(
             std::string("Chunking is needed but not set for dataset \"") + dataset_name + "\":");
     }

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -105,8 +105,7 @@ inline DataSetCreateProps NodeTraits<Derivate>::_chunkIfNecessary(
     if ((extendable || createProps.needs_chunking()) && !createProps.has_chunking()) {
         DataSetCreateProps createPropsNew;
         createPropsNew._hid = H5Pcopy(createProps.getId());
-        std::vector<hsize_t> chunkDims;
-        chunkDims =
+        std::vector<hsize_t> chunkDims =
             _guessChunkDims(space.getDimensions(), space.getMaxDimensions(), dtype.getSize());
         createPropsNew.add(Chunking(chunkDims));
         return createPropsNew;

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -43,12 +43,11 @@ inline DataSet NodeTraits<Derivate>::createDataSet(const std::string& dataset_na
 
     auto dims = space.getDimensions();
     auto max_dims = space.getMaxDimensions();
-    bool extendable = !std::equal(dims.begin(),
-                                  dims.end(),
-                                  max_dims.begin());
+    bool extendable = !std::equal(dims.begin(), dims.end(), max_dims.begin());
 
     if ((extendable || createProps.needs_chunking()) && !createProps.has_chunking()) {
-        HDF5ErrMapper::ToException<DataSetException>(std::string("Chunking is needed but not set for dataset \"") + dataset_name + "\":");
+        HDF5ErrMapper::ToException<DataSetException>(
+            std::string("Chunking is needed but not set for dataset \"") + dataset_name + "\":");
     }
 
     const auto hid = H5Dcreate2(static_cast<Derivate*>(this)->getId(),

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -9,9 +9,7 @@
 #pragma once
 
 #include <string>
-#include <algorithm>
 #include <vector>
-#include <functional>
 
 #include <H5Apublic.h>
 #include <H5Dpublic.h>

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -363,9 +363,10 @@ template <typename... Args>
 inline Chunking::Chunking(hsize_t item, Args... args)
     : Chunking(std::vector<hsize_t>{item, static_cast<hsize_t>(args)...}) {}
 
-std::vector<std::size_t> Chunking::guessChunkingSize(const std::vector<std::size_t>& dims,
-                                                     const std::vector<std::size_t>& max_dims,
-                                                     std::size_t typesize) {
+inline std::vector<std::size_t> Chunking::guessChunkingSize(
+    const std::vector<std::size_t>& dims,
+    const std::vector<std::size_t>& max_dims,
+    std::size_t typesize) {
     const std::size_t CHUNK_BASE = 16 * 1024;   // Multiplier by which chunks are adjusted
     const std::size_t CHUNK_MIN = 8 * 1024;     // Soft lower limit (8k)
     const std::size_t CHUNK_MAX = 1024 * 1024;  // Hard upper limit (1M)

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -180,7 +180,9 @@ inline void Chunking::apply(const hid_t hid) const {
     }
 }
 
-std::vector<std::size_t> Chunking::guessChunkingSize(const std::vector<std::size_t>& dims, const std::vector<std::size_t>& max_dims, std::size_t typesize) {
+std::vector<std::size_t> Chunking::guessChunkingSize(const std::vector<std::size_t>& dims,
+                                                     const std::vector<std::size_t>& max_dims,
+                                                     std::size_t typesize) {
     const std::size_t CHUNK_BASE = 16 * 1024;   // Multiplier by which chunks are adjusted
     const std::size_t CHUNK_MIN = 8 * 1024;     // Soft lower limit (8k)
     const std::size_t CHUNK_MAX = 1024 * 1024;  // Hard upper limit (1M)
@@ -195,7 +197,7 @@ std::vector<std::size_t> Chunking::guessChunkingSize(const std::vector<std::size
 
     std::size_t dset_size = details::compute_total_size(chunkingDims) * typesize;
     double target_size = CHUNK_BASE *
-        std::exp2(std::log10(static_cast<double>(dset_size) / (1024. * 1024.)));
+                         std::exp2(std::log10(static_cast<double>(dset_size) / (1024. * 1024.)));
 
     if (target_size > CHUNK_MAX) {
         target_size = CHUNK_MAX;
@@ -213,8 +215,8 @@ std::vector<std::size_t> Chunking::guessChunkingSize(const std::vector<std::size
         std::size_t chunk_size = details::compute_total_size(chunkingDims) * typesize;
 
         if ((static_cast<double>(chunk_size) < target_size ||
-                    std::abs(static_cast<double>(chunk_size) - target_size) / target_size < 0.5) &&
-                chunk_size < CHUNK_MAX) {
+             std::abs(static_cast<double>(chunk_size) - target_size) / target_size < 0.5) &&
+            chunk_size < CHUNK_MAX) {
             break;
         }
 
@@ -223,7 +225,7 @@ std::vector<std::size_t> Chunking::guessChunkingSize(const std::vector<std::size
         }
 
         chunkingDims[idx % chunkingDims.size()] = static_cast<std::size_t>(
-                std::ceil(static_cast<double>(chunkingDims[idx % chunkingDims.size()]) / 2.));
+            std::ceil(static_cast<double>(chunkingDims[idx % chunkingDims.size()]) / 2.));
         idx++;
     }
 

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -76,6 +76,21 @@ inline void PropertyList<T>::add(const P& property) {
     property.apply(_hid);
 }
 
+inline void PropertyList<PropertyType::DATASET_CREATE>::_initializeIfNeeded() {
+    if (_hid != H5P_DEFAULT) {
+        return;
+    }
+    if ((_hid = H5Pcreate(convert_plist_type(PropertyType::DATASET_CREATE))) < 0) {
+        HDF5ErrMapper::ToException<PropertyException>("Unable to create property list");
+    }
+}
+
+template <typename P>
+inline void PropertyList<PropertyType::DATASET_CREATE>::add(const P& property) {
+    _initializeIfNeeded();
+    property.apply(_hid);
+}
+
 template <PropertyType T>
 template <typename F, typename... Args>
 inline void RawPropertyList<T>::add(const F& funct, const Args&... args) {

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -62,7 +62,7 @@ inline std::vector<hsize_t> to_vector_hsize_t(const std::vector<hsize_t>& vec) {
     return vec;
 }
 
-template<typename T>
+template <typename T>
 inline T compute_total_size(const std::vector<T>& dims) {
     return std::accumulate(dims.begin(), dims.end(), T{1u}, std::multiplies<T>());
 }

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cstddef>  // __GLIBCXX__
 #include <exception>
+#include <numeric>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -59,6 +60,14 @@ inline std::vector<hsize_t> to_vector_hsize_t(const std::vector<Size>& vec) {
 // converter function for size_t -> hsize_t when hsize_t == size_t
 inline std::vector<hsize_t> to_vector_hsize_t(const std::vector<hsize_t>& vec) {
     return vec;
+}
+
+inline hsize_t compute_total_size(const std::vector<hsize_t>& dims) {
+    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<std::size_t>());
+}
+
+inline size_t compute_total_size(const std::vector<std::size_t>& dims) {
+    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<std::size_t>());
 }
 
 // read name from a H5 object using the specified function

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -45,6 +45,23 @@ inline std::vector<std::size_t> to_vector_size_t(const std::vector<std::size_t>&
     return vec;
 }
 
+// converter function for size_t -> hsize_t when size_t != hsize_t
+template <typename Size>
+inline std::vector<hsize_t> to_vector_hsize_t(const std::vector<Size>& vec) {
+    static_assert(std::is_same<Size, hsize_t>::value == false,
+                  " size_t != hsize_t mandatory here");
+    std::vector<hsize_t> res(vec.size());
+    std::transform(vec.cbegin(), vec.cend(), res.begin(), [](Size e) {
+        return static_cast<hsize_t>(e);
+    });
+    return res;
+}
+
+// converter function for size_t -> hsize_t when hsize_t == size_t
+inline std::vector<hsize_t> to_vector_hsize_t(const std::vector<hsize_t>& vec) {
+    return vec;
+}
+
 // read name from a H5 object using the specified function
 template <typename T>
 inline std::string get_name(T fct) {

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -62,12 +62,9 @@ inline std::vector<hsize_t> to_vector_hsize_t(const std::vector<hsize_t>& vec) {
     return vec;
 }
 
-inline hsize_t compute_total_size(const std::vector<hsize_t>& dims) {
-    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<std::size_t>());
-}
-
-inline size_t compute_total_size(const std::vector<std::size_t>& dims) {
-    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<std::size_t>());
+template<typename T>
+inline T compute_total_size(const std::vector<T>& dims) {
+    return std::accumulate(dims.begin(), dims.end(), T{1u}, std::multiplies<T>());
 }
 
 // read name from a H5 object using the specified function

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -48,8 +48,7 @@ inline std::vector<std::size_t> to_vector_size_t(const std::vector<std::size_t>&
 // converter function for size_t -> hsize_t when size_t != hsize_t
 template <typename Size>
 inline std::vector<hsize_t> to_vector_hsize_t(const std::vector<Size>& vec) {
-    static_assert(std::is_same<Size, hsize_t>::value == false,
-                  " size_t != hsize_t mandatory here");
+    static_assert(std::is_same<Size, hsize_t>::value == false, " size_t != hsize_t mandatory here");
     std::vector<hsize_t> res(vec.size());
     std::transform(vec.cbegin(), vec.cend(), res.begin(), [](Size e) {
         return static_cast<hsize_t>(e);

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -437,7 +437,9 @@ TEST_CASE("Test extensible datasets") {
 
         // Use chunking
         DataSetCreateProps props;
+        CHECK(props.has_chunking() == false);
         props.add(Chunking(std::vector<hsize_t>{2, 2}));
+        CHECK(props.has_chunking() == true);
 
         // Create the dataset
         DataSet dataset =
@@ -1547,10 +1549,16 @@ void readWriteShuffleDeflateTest() {
         props.add(Chunking(std::vector<hsize_t>{x_chunk, y_chunk}));
 
         // Enable shuffle
+        CHECK(props.needs_chunking() == false);
+        CHECK(props.has_filter(H5Z_FILTER_SHUFFLE) == false);
         props.add(Shuffle());
+        CHECK(props.needs_chunking() == true);
+        CHECK(props.has_filter(H5Z_FILTER_SHUFFLE) == true);
 
         // Enable deflate
+        CHECK(props.has_filter(H5Z_FILTER_DEFLATE) == false);
         props.add(Deflate(deflate_level));
+        CHECK(props.has_filter(H5Z_FILTER_DEFLATE) == true);
 
         // Create a dataset with arbitrary type
         DataSet dataset = file.createDataSet<T>(DATASET_NAME, dataspace, props);
@@ -1613,7 +1621,11 @@ void readWriteSzipTest() {
         props.add(Chunking(std::vector<hsize_t>{x_chunk, y_chunk}));
 
         // Enable szip
+        CHECK(props.needs_chunking() == false);
+        CHECK(props.has_filter(H5Z_FILTER_DEFLATE) == false);
         props.add(Szip(options_mask, pixels_per_block));
+        CHECK(props.needs_chunking() == true);
+        CHECK(props.has_filter(H5Z_FILTER_SZIP) == true);
 
         // Create a dataset with arbitrary type
         DataSet dataset = file.createDataSet<T>(DATASET_NAME, dataspace, props);


### PR DESCRIPTION
**Description**

Adds Chunking property if the data set is extendable, compressed or the shuffle filter is set and Chunking was not set by the user.
Chunk size guessing is based on the current h5py implementation (https://github.com/h5py/h5py/blob/0e6dbac0a01d85e8ce2d11f3a567b0526c325d09/h5py/_hl/filters.py#L338).

Related issue: #216 

**How to test this?**

Should I write test cases? Let me know. I'm new to that to be honest.
Anyways I tried a few combinations and they worked.

**Test System**
 - OS: Ubuntu 22.04
 - Compiler: g++ 11.3.0
 - Dependency versions: hdf5 1.10.7
