### PR TITLE
Add a track order property

### DIFF
--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -498,6 +498,10 @@ class UseCollectiveIO {
 };
 #endif
 
+struct TrackOrderProperty {
+    void apply(hid_t hid) const;
+};
+
 }  // namespace HighFive
 
 #include "bits/H5PropertyList_misc.hpp"

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -216,4 +216,11 @@ inline void UseCollectiveIO::apply(const hid_t hid) const {
 }
 #endif
 
+void de::hdf::TrackOrder::apply(hid_t hid) const {
+    if (H5Pset_link_creation_order(hid, H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED)) {
+        HighFive::HDF5ErrMapper::ToException<HighFive::PropertyException>(
+            "Error setting track order property");
+    }
+}
+
 }  // namespace HighFive


### PR DESCRIPTION
**Description**`

This PR adds a PropertyList to enable `H5P_CRT_ORDER_TRACKED | H5P_CRT_ORDER_INDEXED`, which allows to track the order in which the groups are created and to later iterate on them following that order. 

Closes #670 


