### PR TITLE
Avoid templated friend classes.

### DIFF
--- a/include/highfive/H5Selection.hpp
+++ b/include/highfive/H5Selection.hpp
@@ -14,6 +14,10 @@
 
 namespace HighFive {
 
+namespace detail {
+Selection make_selection(const DataSpace&, const DataSpace&, const DataSet&);
+}
+
 ///
 /// \brief Selection: represent a view on a slice/part of a dataset
 ///
@@ -52,9 +56,7 @@ class Selection: public SliceTraits<Selection> {
     DataSpace _mem_space, _file_space;
     DataSet _set;
 
-    template <typename Derivate>
-    friend class ::HighFive::SliceTraits;
-    // absolute namespace naming due to GCC bug 52625
+    friend Selection detail::make_selection(const DataSpace&, const DataSpace&, const DataSet&);
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Annotate_traits_misc.hpp
+++ b/include/highfive/bits/H5Annotate_traits_misc.hpp
@@ -25,15 +25,15 @@ inline Attribute AnnotateTraits<Derivate>::createAttribute(const std::string& at
                                                            const DataType& dtype) {
     auto attr_id = H5Acreate2(static_cast<Derivate*>(this)->getId(),
                               attribute_name.c_str(),
-                              dtype._hid,
-                              space._hid,
+                              dtype.getId(),
+                              space.getId(),
                               H5P_DEFAULT,
                               H5P_DEFAULT);
     if (attr_id < 0) {
         HDF5ErrMapper::ToException<AttributeException>(
             std::string("Unable to create the attribute \"") + attribute_name + "\":");
     }
-    return Attribute(attr_id);
+    return detail::make_attribute(attr_id);
 }
 
 template <typename Derivate>
@@ -71,7 +71,7 @@ inline Attribute AnnotateTraits<Derivate>::getAttribute(const std::string& attri
         HDF5ErrMapper::ToException<AttributeException>(
             std::string("Unable to open the attribute \"") + attribute_name + "\":");
     }
-    return Attribute(attr_id);
+    return detail::make_attribute(attr_id);
 }
 
 template <typename Derivate>

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -41,8 +41,8 @@ inline DataSet NodeTraits<Derivate>::createDataSet(const std::string& dataset_na
     lcpl.add(CreateIntermediateGroup(parents));
     const auto hid = H5Dcreate2(static_cast<Derivate*>(this)->getId(),
                                 dataset_name.c_str(),
-                                dtype._hid,
-                                space._hid,
+                                dtype.getId(),
+                                space.getId(),
                                 lcpl.getId(),
                                 createProps.getId(),
                                 accessProps.getId());
@@ -142,7 +142,7 @@ inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name, bo
         HDF5ErrMapper::ToException<GroupException>(std::string("Unable to create the group \"") +
                                                    group_name + "\":");
     }
-    return Group(hid);
+    return detail::make_group(hid);
 }
 
 template <typename Derivate>
@@ -160,7 +160,7 @@ inline Group NodeTraits<Derivate>::createGroup(const std::string& group_name,
         HDF5ErrMapper::ToException<GroupException>(std::string("Unable to create the group \"") +
                                                    group_name + "\":");
     }
-    return Group(hid);
+    return detail::make_group(hid);
 }
 
 template <typename Derivate>
@@ -171,7 +171,7 @@ inline Group NodeTraits<Derivate>::getGroup(const std::string& group_name) const
         HDF5ErrMapper::ToException<GroupException>(std::string("Unable to open the group \"") +
                                                    group_name + "\":");
     }
-    return Group(hid);
+    return detail::make_group(hid);
 }
 
 template <typename Derivate>
@@ -369,7 +369,7 @@ inline Object NodeTraits<Derivate>::_open(const std::string& node_name,
         HDF5ErrMapper::ToException<GroupException>(std::string("Unable to open \"") + node_name +
                                                    "\":");
     }
-    return Object(id);
+    return detail::make_object(id);
 }
 
 

--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -13,6 +13,12 @@
 #include "../H5Exception.hpp"
 
 namespace HighFive {
+namespace detail {
+inline Object make_object(hid_t hid) {
+    return Object(hid);
+}
+}  // namespace detail
+
 
 inline Object::Object()
     : _hid(H5I_INVALID_HID) {}

--- a/include/highfive/bits/H5Selection_misc.hpp
+++ b/include/highfive/bits/H5Selection_misc.hpp
@@ -38,4 +38,12 @@ inline const DataType Selection::getDataType() const {
     return _set.getDataType();
 }
 
+namespace detail {
+inline Selection make_selection(const DataSpace& mem_space,
+                                const DataSpace& file_space,
+                                const DataSet& set) {
+    return Selection(mem_space, file_space, set);
+}
+}  // namespace detail
+
 }  // namespace HighFive

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -75,7 +75,7 @@ inline Selection SliceTraits<Derivate>::select_impl(const HyperSlab& hyperslab,
     const auto& slice = static_cast<const Derivate&>(*this);
     auto filespace = hyperslab.apply(slice.getSpace());
 
-    return Selection(memspace, filespace, details::get_dataset(slice));
+    return detail::make_selection(memspace, filespace, details::get_dataset(slice));
 }
 
 template <typename Derivate>
@@ -87,7 +87,7 @@ inline Selection SliceTraits<Derivate>::select(const HyperSlab& hyper_slab) cons
     auto n_elements = H5Sget_select_npoints(filespace.getId());
     auto memspace = DataSpace(std::array<size_t, 1>{size_t(n_elements)});
 
-    return Selection(memspace, filespace, details::get_dataset(slice));
+    return detail::make_selection(memspace, filespace, details::get_dataset(slice));
 }
 
 
@@ -153,7 +153,7 @@ inline Selection SliceTraits<Derivate>::select(const ElementSet& elements) const
         HDF5ErrMapper::ToException<DataSpaceException>("Unable to select elements");
     }
 
-    return Selection(DataSpace(num_elements), space, details::get_dataset(slice));
+    return detail::make_selection(DataSpace(num_elements), space, details::get_dataset(slice));
 }
 
 


### PR DESCRIPTION
There seems to be a compiler bug in numerous version of GCC which
prevent code such as:
```c++
class Foo {
  template<class Derived>
  friend class SomeCRTP<Derived>;
};
```
This commit removed all such constructs from HighFive, by allowing a
function `detail::make_*` to create `Object`, `Selection` and `Group`
from an `hid_t`.