### PR TITLE
v2.7.0

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -28,6 +28,7 @@ Maximilian Nöthe
 @Mightrider
 Mike DePalatis
 Mike Gevaert
+Moritz Koenemann
 Nico Jahn
 Nicolas Cornu (maintainer)
 Omar Awile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Bug Fix
     - To avoid build failure in certain circumstances, user can not set `Boost_NO_BOOST_CMAKE` (#687).
     - Fix leak when reading variable length strings (#660).
-    - Use `H5free_memory` instead of `free` in error handler (#665). Thanks to lefi7z
+    - Use `H5free_memory` instead of `free` in error handler (#665). Thanks to Moritz Koenemann
     - Fix a bug with old GCC due to templated friend classes (#688).
 
 ## Version 2.6.2 - 2022-11-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Version 2.6.3 - 2023-02-28
+### New Features
+    - Properties can now be read (#684).
+    - Adding a property for LinkCreationOrder (#683).
+    - Adding a logging infrastructure (#690).
+    - Support of bool in the way of h5py (#654).
+
+### Improvements
+    - Catch2 move to v3 (#655).
+
+### Bug Fix
+    - To avoid build failure in certain circumstances, user can not set `Boost_NO_BOOST_CMAKE` (#687).
+    - Fix leak when reading variable length strings (#660).
+    - Use `H5free_memory` instead of `free` in error handler (#665). Thanks to lefi7z
+    - Fix a bug with old GCC due to templated friend classes (#688).
+
 ## Version 2.6.2 - 2022-11-10
 ### Bug Fix
     - Allow CMake to use Config mode to find HDF5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
     - Adding a property for LinkCreationOrder (#683).
     - Adding a logging infrastructure (#690).
     - Support of bool in the way of h5py (#654).
+    - Support `std::bool` in C++17 mode (#698).
 
 ### Improvements
     - Catch2 move to v3 (#655).
@@ -13,6 +14,7 @@
     - Fix leak when reading variable length strings (#660).
     - Use `H5free_memory` instead of `free` in error handler (#665). Thanks to Moritz Koenemann
     - Fix a bug with old GCC due to templated friend classes (#688).
+    - Fix regression in broadcasting support (#697)
 
 ## Version 2.6.2 - 2022-11-10
 ### Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 2.6.3 - 2023-02-28
+## Version 2.7.0 - 2023-02-28
 ### New Features
     - Properties can now be read (#684).
     - Adding a property for LinkCreationOrder (#683).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 2.7.0 - 2023-02-28
+## Version 2.7.0 - 2023-03-31
 ### New Features
     - Properties can now be read (#684).
     - Adding a property for LinkCreationOrder (#683).
@@ -12,9 +12,10 @@
 ### Bug Fix
     - To avoid build failure in certain circumstances, user can not set `Boost_NO_BOOST_CMAKE` (#687).
     - Fix leak when reading variable length strings (#660).
-    - Use `H5free_memory` instead of `free` in error handler (#665). Thanks to Moritz Koenemann
+    - Use `H5free_memory` instead of `free` in error handler (#665). Thanks to Moritz Koenemann.
     - Fix a bug with old GCC due to templated friend classes (#688).
-    - Fix regression in broadcasting support (#697)
+    - Fix regression in broadcasting support (#697).
+    - Fix bug related to zero-length datasets (#702).
 
 ## Version 2.6.2 - 2022-11-10
 ### Bug Fix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
   cmake_policy(VERSION 3.13)
 endif()
 
-project(HighFive VERSION 2.6.2)
+project(HighFive VERSION 2.6.3)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/highfive/H5Version.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
   cmake_policy(VERSION 3.13)
 endif()
 
-project(HighFive VERSION 2.6.3)
+project(HighFive VERSION 2.7.0)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/highfive/H5Version.hpp)


### PR DESCRIPTION
## Version 2.7.0 - 2023-03-31
### New Features
    - Properties can now be read (#684).
    - Adding a property for LinkCreationOrder (#683).
    - Adding a logging infrastructure (#690).
    - Support of bool in the way of h5py (#654).
    - Support `std::bool` in C++17 mode (#698).

### Improvements
    - Catch2 move to v3 (#655).

### Bug Fix
    - To avoid build failure in certain circumstances, user can not set `Boost_NO_BOOST_CMAKE` (#687).
    - Fix leak when reading variable length strings (#660).
    - Use `H5free_memory` instead of `free` in error handler (#665). Thanks to Moritz Koenemann.
    - Fix a bug with old GCC due to templated friend classes (#688).
    - Fix regression in broadcasting support (#697).
    - Fix bug related to zero-length datasets (#702).