### PR TITLE
Fix : Add support for std::byte as Dataset type for c++17 and above

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - config:
               os: ubuntu-20.04
               pkgs: 'libboost-all-dev'
-              flags: 'CMAKE_CXX_STANDARD=17'
+              flags: '-DCMAKE_CXX_STANDARD=17'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
               os: ubuntu-latest
               pkgs: 'libboost-all-dev libeigen3-dev libopencv-dev'
               flags: '-DHIGHFIVE_USE_EIGEN:Bool=ON -DHIGHFIVE_USE_OPENCV:Bool=ON -GNinja'
+          - config:
+              os: ubuntu-20.04
+              pkgs: 'libboost-all-dev'
+              flags: 'CMAKE_CXX_STANDARD=17'
 
     steps:
     - uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ if(HIGHFIVE_USE_XTENSOR)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
+add_compile_definitions(HIGHFIVE_CXX_STD=${CMAKE_CXX_STANDARD})
 
 # Search dependencies (hdf5, boost, eigen, xtensor, mpi) and build target highfive_deps
 include(${PROJECT_SOURCE_DIR}/CMake/HighFiveTargetDeps.cmake)

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -262,6 +262,7 @@ struct inspector<std::vector<T>> {
     using value_type = unqualified_t<T>;
     using base_type = typename inspector<value_type>::base_type;
     using hdf5_type = typename inspector<value_type>::hdf5_type;
+
     static constexpr size_t ndim = 1;
     static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
     static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -262,7 +262,6 @@ struct inspector<std::vector<T>> {
     using value_type = unqualified_t<T>;
     using base_type = typename inspector<value_type>::base_type;
     using hdf5_type = typename inspector<value_type>::hdf5_type;
-
     static constexpr size_t ndim = 1;
     static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
     static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <complex>
 #include <cstring>
+#include <cstddef>
 
 #include <H5Ppublic.h>
 #include <H5Tpublic.h>
@@ -165,6 +166,14 @@ template <>
 inline AtomicType<std::string>::AtomicType() {
     _hid = create_string(H5T_VARIABLE);
 }
+
+#if HIGHFIVE_CXX_STD >= 17
+// std byte
+template <>
+inline AtomicType<std::byte>::AtomicType() {
+    _hid = H5Tcopy(H5T_NATIVE_B8);
+}
+#endif
 
 // Fixed-Length strings
 // require class specialization templated for the char length

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -11,7 +11,9 @@
 #include <string>
 #include <complex>
 #include <cstring>
+#if HIGHFIVE_CXX_STD >= 17
 #include <cstddef>
+#endif
 
 #include <H5Ppublic.h>
 #include <H5Tpublic.h>

--- a/tests/unit/test_all_types.cpp
+++ b/tests/unit/test_all_types.cpp
@@ -179,3 +179,36 @@ TEMPLATE_TEST_CASE("Scalar in std::vector<std::array>", "[Types]", bool, std::st
         CHECK(value.size() == 5);
     }
 }
+
+#if HIGHFIVE_CXX_STD >= 17
+TEMPLATE_TEST_CASE("Scalar in std::vector<std::byte>", "[Types]", std::byte) {
+    const std::string FILE_NAME("Test_vector_byte.h5");
+    const std::string DATASET_NAME("dset");
+    std::vector<TestType> t1(5, std::byte(0xCD));
+
+    {
+        // Create a new file using the default property lists.
+        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+
+        // Create the dataset
+        DataSet dataset = file.createDataSet(
+            DATASET_NAME,
+            {5},
+            create_datatype<typename details::inspector<std::vector<TestType>>::base_type>());
+
+        // Write into the initial part of the dataset
+        dataset.write(t1);
+    }
+
+    // read it back
+    {
+        File file(FILE_NAME, File::ReadOnly);
+
+        std::vector<TestType> value(5, std::byte(0xCD));
+        DataSet dataset = file.getDataSet("/" + DATASET_NAME);
+        dataset.read(value);
+        CHECK(t1 == value);
+        CHECK(value.size() == 5);
+    }
+}
+#endif

--- a/tests/unit/test_all_types.cpp
+++ b/tests/unit/test_all_types.cpp
@@ -181,10 +181,10 @@ TEMPLATE_TEST_CASE("Scalar in std::vector<std::array>", "[Types]", bool, std::st
 }
 
 #if HIGHFIVE_CXX_STD >= 17
-TEMPLATE_TEST_CASE("Scalar in std::vector<std::byte>", "[Types]", std::byte) {
+TEMPLATE_PRODUCT_TEST_CASE("Scalar in std::vector<std::byte>", "[Types]", std::vector, std::byte) {
     const std::string FILE_NAME("Test_vector_byte.h5");
     const std::string DATASET_NAME("dset");
-    std::vector<TestType> t1(5, std::byte(0xCD));
+    TestType t1(5, std::byte(0xCD));
 
     {
         // Create a new file using the default property lists.
@@ -192,9 +192,7 @@ TEMPLATE_TEST_CASE("Scalar in std::vector<std::byte>", "[Types]", std::byte) {
 
         // Create the dataset
         DataSet dataset = file.createDataSet(
-            DATASET_NAME,
-            {5},
-            create_datatype<typename details::inspector<std::vector<TestType>>::base_type>());
+            DATASET_NAME, {5}, create_datatype<typename details::inspector<TestType>::base_type>());
 
         // Write into the initial part of the dataset
         dataset.write(t1);
@@ -204,7 +202,7 @@ TEMPLATE_TEST_CASE("Scalar in std::vector<std::byte>", "[Types]", std::byte) {
     {
         File file(FILE_NAME, File::ReadOnly);
 
-        std::vector<TestType> value(5, std::byte(0xCD));
+        TestType value(5, std::byte(0xCD));
         DataSet dataset = file.getDataSet("/" + DATASET_NAME);
         dataset.read(value);
         CHECK(t1 == value);

--- a/tests/unit/test_all_types.cpp
+++ b/tests/unit/test_all_types.cpp
@@ -191,8 +191,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Scalar in std::vector<std::byte>", "[Types]", std::v
         File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
         // Create the dataset
-        DataSet dataset = file.createDataSet(
-            DATASET_NAME, {5}, create_datatype<typename details::inspector<TestType>::base_type>());
+        DataSet dataset = file.createDataSet(DATASET_NAME, {5}, create_datatype<std::byte>());
 
         // Write into the initial part of the dataset
         dataset.write(t1);


### PR DESCRIPTION
**Description**
Add  support for std::byte as Dataset type when using c++17 and above 
- [x] Issue 1 fixed
- [x] Feature 1 added

Fixes #480 

**How to test this?**

```bash
cmake -DCMAKE_CXX_STANDARD=17 ..
make -j8
make test
```

**Test System**
 - OS: [e.g. Ubuntu 20.04]
 - Compiler: [e.g. clang 12.0.0]
 - Dependency versions: [e.g. hdf5 1.12]
