### PR TITLE
Improve Cmake detection quietness, and adhere to standard procedure

### DIFF
--- a/CMake/HighFiveConfig.cmake.in
+++ b/CMake/HighFiveConfig.cmake.in
@@ -15,6 +15,8 @@ if(TARGET HighFive)
     return()
 endif()
 
+@PACKAGE_INIT@
+
 # Get HighFive targets
 include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargets.cmake")
 
@@ -61,8 +63,12 @@ if(HIGHFIVE_USE_XTENSOR AND NOT CMAKE_VERSION VERSION_LESS 3.8)
   set_property(TARGET HighFive APPEND PROPERTY INTERFACE_COMPILE_FEATURES cxx_std_14)
 endif()
 
-message(STATUS "HIGHFIVE @PROJECT_VERSION@: (Re)Detecting Highfive dependencies (HIGHFIVE_USE_INSTALL_DEPS=NO)")
+if(NOT HighFive_FIND_QUIETLY)
+  message(STATUS "HIGHFIVE @PROJECT_VERSION@: (Re)Detecting Highfive dependencies (HIGHFIVE_USE_INSTALL_DEPS=NO)")
+endif()
 include("${CMAKE_CURRENT_LIST_DIR}/HighFiveTargetDeps.cmake")
 foreach(dependency HighFive_libheaders libdeps)
     copy_interface_properties(HighFive ${dependency})
 endforeach()
+
+check_required_components(HighFive)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
 
 # Disable test if Boost was expressly disabled, or if HighFive is a sub-project
 if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  if(HIGHFIVE_UNIT_TESTS)
+  if(HIGHFIVE_UNIT_TESTS AND NOT HighFive_FIND_QUIETLY)
     message(WARNING "Unit tests have been DISABLED.")
   endif()
   set(HIGHFIVE_UNIT_TESTS FALSE)

--- a/tests/test_dependent_library/CMakeLists.txt
+++ b/tests/test_dependent_library/CMakeLists.txt
@@ -15,7 +15,7 @@ option(USE_BUNDLED_HIGHFIVE "Use highfive from deps folder. Otherwise must be in
 if(USE_BUNDLED_HIGHFIVE)
     add_subdirectory("deps/HighFive" EXCLUDE_FROM_ALL)
 else()
-    find_package(HighFive REQUIRED)
+    find_package(HighFive REQUIRED QUIET)
 endif()
 
 add_library(simpleton SHARED "src/simpleton.cpp" "src/otherton.cpp")

--- a/tests/test_project_integration.sh
+++ b/tests/test_project_integration.sh
@@ -11,7 +11,7 @@ test_install() {
     local builddir="${BUILDDIR}/${project}/${2}"
     shift
     shift
-    ln -s ../../.. "${TESTDIR}/${project}/deps/HighFive"
+    ln -sf ../../.. "${TESTDIR}/${project}/deps/HighFive"
     rm -rf "${builddir}"
     mkdir -p "${builddir}"
     pushd "${builddir}"


### PR DESCRIPTION
**Description**

The `packageConfig.cmake` was not respecting QUIET request. Further, it seems that we were not calling `check_required_components` which is pretty standard to validate component request.

Fixes #593

**How to test this?**

Tested locally, launching `test_project_integration.sh`

```bash
cd HighFive/tests
bash test_project_integration.sh
```