### PR TITLE
Remove outdated badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # HighFive - HDF5 header-only C++ Library
 
 [![Build Status](https://travis-ci.org/BlueBrain/HighFive.svg?branch=master)](https://travis-ci.org/BlueBrain/HighFive)
-[![Coverity Statys](https://scan.coverity.com/projects/13635/badge.svg)](https://scan.coverity.com/projects/highfive)
 [![Doxygen -> gh-pages](https://github.com/BlueBrain/HighFive/workflows/gh-pages/badge.svg)](https://BlueBrain.github.io/HighFive)
 [![codecov](https://codecov.io/gh/BlueBrain/HighFive/branch/master/graph/badge.svg?token=UBKxHEn7RS)](https://codecov.io/gh/BlueBrain/HighFive)
 [![HighFive_Integration_tests](https://github.com/BlueBrain/HighFive-testing/actions/workflows/integration.yml/badge.svg)](https://github.com/BlueBrain/HighFive-testing/actions/workflows/integration.yml)


### PR DESCRIPTION
This PR proposes to remove the codecov CI because it's been highly unreliable recently. I'd like to avoid getting used to failing CI. Therefore, I think it's best if we simply remove it for the time being.

Next this also removes a badge for static analysis which ran last in 2017.