### PR TITLE
Coverage CI: use codecov token

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,3 +64,4 @@ jobs:
         files: ./build/coverage-combined.info
         fail_ci_if_error: true
         verbose: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
* `CODECOV_TOKEN` defined in secrets on GH