### PR TITLE
Update MacOS image to `macOS-12`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
   # Job testing in OSX
   # ==================
   OSX:
-    runs-on: macOS-10.15
+    runs-on: macOS-12
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
GHA will drop support for `macOS-10.15`. Hence, we update to `macOS-12`. See #704 for more discussion.