### PR TITLE
Add missing include of `H5FileDriver.hpp`

### DIFF
--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -10,6 +10,7 @@
 
 #include <string>
 
+#include "H5FileDriver.hpp"
 #include "H5Object.hpp"
 #include "H5PropertyList.hpp"
 #include "bits/H5Annotate_traits.hpp"


### PR DESCRIPTION
Reverts removal of `#include<H5FileDriver.hpp>` from `#include <H5File.hpp>`.