### PR TITLE
Prepare version 2.7.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 2.7.1 - 2023-04-04
+### Bug Fix
+    - Revert removing `#include "H5FileDriver.hpp"` from `H5File.hpp` (#711).
+    - Change relative import to "../H5Utility.hpp" (#726).
+    - Fix nameclash with macros on Windows (#717 #722 #723).
+    - Add workaround for MSVC bug (#728).
+    - Don't downgrade the requested C++ standard (#729).
+
 ## Version 2.7.0 - 2023-03-31
 ### New Features
     - Properties can now be read (#684).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
   cmake_policy(VERSION 3.13)
 endif()
 
-project(HighFive VERSION 2.7.0)
+project(HighFive VERSION 2.7.1)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
                ${CMAKE_CURRENT_BINARY_DIR}/include/highfive/H5Version.hpp)


### PR DESCRIPTION
This time we ran the deployment with the HighFive Spack recipe pointing `highfive@2.7.1` at commit `11e45f00303305dd409a5c8865a0e9dacce3cd5d`.