### PR TITLE
Avoid name collision with macros in LogSeverity.

### DIFF
--- a/include/highfive/H5Utility.hpp
+++ b/include/highfive/H5Utility.hpp
@@ -47,21 +47,21 @@ class SilenceHDF5 {
 #endif
 
 enum class LogSeverity {
-    DEBUG = HIGHFIVE_LOG_LEVEL_DEBUG,
-    INFO = HIGHFIVE_LOG_LEVEL_INFO,
-    WARN = HIGHFIVE_LOG_LEVEL_WARN,
-    ERROR = HIGHFIVE_LOG_LEVEL_ERROR
+    Debug = HIGHFIVE_LOG_LEVEL_DEBUG,
+    Info = HIGHFIVE_LOG_LEVEL_INFO,
+    Warn = HIGHFIVE_LOG_LEVEL_WARN,
+    Error = HIGHFIVE_LOG_LEVEL_ERROR
 };
 
 inline std::string to_string(LogSeverity severity) {
     switch (severity) {
-    case LogSeverity::DEBUG:
+    case LogSeverity::Debug:
         return "DEBUG";
-    case LogSeverity::INFO:
+    case LogSeverity::Info:
         return "INFO";
-    case LogSeverity::WARN:
+    case LogSeverity::Warn:
         return "WARN";
-    case LogSeverity::ERROR:
+    case LogSeverity::Error:
         return "ERROR";
     default:
         return "??";
@@ -151,7 +151,7 @@ inline void log(LogSeverity severity,
 
 #if HIGHFIVE_LOG_LEVEL <= HIGHFIVE_LOG_LEVEL_DEBUG
 #define HIGHFIVE_LOG_DEBUG(message) \
-    ::HighFive::detail::log(::HighFive::LogSeverity::DEBUG, (message), __FILE__, __LINE__);
+    ::HighFive::detail::log(::HighFive::LogSeverity::Debug, (message), __FILE__, __LINE__);
 
 // Useful, for the common pattern: if ...; then log something.
 #define HIGHFIVE_LOG_DEBUG_IF(cond, message) \
@@ -166,7 +166,7 @@ inline void log(LogSeverity severity,
 
 #if HIGHFIVE_LOG_LEVEL <= HIGHFIVE_LOG_LEVEL_INFO
 #define HIGHFIVE_LOG_INFO(message) \
-    ::HighFive::detail::log(::HighFive::LogSeverity::INFO, (message), __FILE__, __LINE__);
+    ::HighFive::detail::log(::HighFive::LogSeverity::Info, (message), __FILE__, __LINE__);
 
 // Useful, for the common pattern: if ...; then log something.
 #define HIGHFIVE_LOG_INFO_IF(cond, message) \
@@ -182,7 +182,7 @@ inline void log(LogSeverity severity,
 
 #if HIGHFIVE_LOG_LEVEL <= HIGHFIVE_LOG_LEVEL_WARN
 #define HIGHFIVE_LOG_WARN(message) \
-    ::HighFive::detail::log(::HighFive::LogSeverity::WARN, (message), __FILE__, __LINE__);
+    ::HighFive::detail::log(::HighFive::LogSeverity::Warn, (message), __FILE__, __LINE__);
 
 // Useful, for the common pattern: if ...; then log something.
 #define HIGHFIVE_LOG_WARN_IF(cond, message) \
@@ -197,7 +197,7 @@ inline void log(LogSeverity severity,
 
 #if HIGHFIVE_LOG_LEVEL <= HIGHFIVE_LOG_LEVEL_ERROR
 #define HIGHFIVE_LOG_ERROR(message) \
-    ::HighFive::detail::log(::HighFive::LogSeverity::ERROR, (message), __FILE__, __LINE__);
+    ::HighFive::detail::log(::HighFive::LogSeverity::Error, (message), __FILE__, __LINE__);
 
 // Useful, for the common pattern: if ...; then log something.
 #define HIGHFIVE_LOG_ERROR_IF(cond, message) \

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -3090,74 +3090,74 @@ TEST_CASE("Logging") {
     };
 
     SECTION("LOG_DEBUG") {
-        auto message = "DEBUG!";
+        auto message = "Debug!";
         HIGHFIVE_LOG_DEBUG(message);
-        check(true, message, LogSeverity::DEBUG);
+        check(true, message, LogSeverity::Debug);
     }
 
     SECTION("LOG_DEBUG_IF true") {
         auto message = "DEBUG_IF true!";
         HIGHFIVE_LOG_DEBUG_IF(true, message);
-        check(true, message, LogSeverity::DEBUG);
+        check(true, message, LogSeverity::Debug);
     }
 
     SECTION("LOG_DEBUG_IF false") {
         auto message = "DEBUG_IF false!";
         HIGHFIVE_LOG_DEBUG_IF(false, message);
-        check(false, message, LogSeverity::DEBUG);
+        check(false, message, LogSeverity::Debug);
     }
 
     SECTION("LOG_INFO") {
-        auto message = "INFO!";
+        auto message = "Info!";
         HIGHFIVE_LOG_INFO(message);
-        check(true, message, LogSeverity::INFO);
+        check(true, message, LogSeverity::Info);
     }
 
     SECTION("LOG_INFO_IF true") {
         auto message = "INFO_IF true!";
         HIGHFIVE_LOG_INFO_IF(true, message);
-        check(true, message, LogSeverity::INFO);
+        check(true, message, LogSeverity::Info);
     }
 
     SECTION("LOG_INFO_IF false") {
         auto message = "INFO_IF false!";
         HIGHFIVE_LOG_INFO_IF(false, message);
-        check(false, message, LogSeverity::INFO);
+        check(false, message, LogSeverity::Info);
     }
 
     SECTION("LOG_WARN") {
-        auto message = "WARN!";
+        auto message = "Warn!";
         HIGHFIVE_LOG_WARN(message);
-        check(true, message, LogSeverity::WARN);
+        check(true, message, LogSeverity::Warn);
     }
 
     SECTION("LOG_WARN_IF true") {
         auto message = "WARN_IF true!";
         HIGHFIVE_LOG_WARN_IF(true, message);
-        check(true, message, LogSeverity::WARN);
+        check(true, message, LogSeverity::Warn);
     }
 
     SECTION("LOG_WARN_IF false") {
         auto message = "WARN_IF false!";
         HIGHFIVE_LOG_WARN_IF(false, message);
-        check(false, message, LogSeverity::WARN);
+        check(false, message, LogSeverity::Warn);
     }
 
     SECTION("LOG_ERROR") {
-        auto message = "ERROR!";
+        auto message = "Error!";
         HIGHFIVE_LOG_ERROR(message);
-        check(true, message, LogSeverity::ERROR);
+        check(true, message, LogSeverity::Error);
     }
 
     SECTION("LOG_ERROR_IF true") {
         auto message = "ERROR_IF true!";
         HIGHFIVE_LOG_ERROR_IF(true, message);
-        check(true, message, LogSeverity::ERROR);
+        check(true, message, LogSeverity::Error);
     }
 
     SECTION("LOG_ERROR_IF false") {
         auto message = "ERROR_IF false!";
         HIGHFIVE_LOG_ERROR_IF(false, message);
-        check(false, message, LogSeverity::ERROR);
+        check(false, message, LogSeverity::Error);
     }
 }


### PR DESCRIPTION
See  #716.