### PR TITLE
Avoid name collision with macros `TRUE` and `FALSE`.

### DIFF
--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -212,10 +212,11 @@ struct type_helper {
 template <typename T>
 struct inspector: type_helper<T> {};
 
-enum Boolean : int8_t {
-    FALSE = 0,
-    TRUE = 1,
+enum class Boolean : int8_t {
+    HighFiveFalse = 0,
+    HighFiveTrue = 1,
 };
+
 template <>
 struct inspector<bool>: type_helper<bool> {
     using base_type = Boolean;

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -207,7 +207,7 @@ class AtomicType<std::complex<T>>: public DataType {
 
 // For boolean we act as h5py
 inline EnumType<details::Boolean> create_enum_boolean() {
-    return {{"FALSE", details::Boolean::FALSE}, {"TRUE", details::Boolean::TRUE}};
+    return {{"FALSE", details::Boolean::HighFiveFalse}, {"TRUE", details::Boolean::HighFiveTrue}};
 }
 
 // Other cases not supported. Fail early with a user message


### PR DESCRIPTION
See #721.