### PR TITLE
Include `Windows.h` to uncover more defects on Windows.

### DIFF
--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -13,6 +13,14 @@
 #include <vector>
 #include <tuple>
 
+// We don't need windows specific functionality. However, to better detect defects caused by macros,
+// we include this header.
+// The list of identifiers is taken from `Boost::Predef`.
+#if defined(_WIN32) || defined(_WIN64) || defined(__WIN32__) || defined(__TOS_WIN__) || \
+    defined(__WINDOWS__)
+#include <Windows.h>
+#endif
+
 using ldcomplex = std::complex<long double>;
 using dcomplex = std::complex<double>;
 using fcomplex = std::complex<float>;


### PR DESCRIPTION
The purpose is to make our CI more sensitive to name clashes of macros with tokens we've used in HighFive. The idea is that by including `Windows.h` we should be pulling in many standard macros. Hence we should be able to detect the defect.