### PR TITLE
Fix compilation failures for custom installation locations

### DIFF
--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -11,7 +11,7 @@
 #include <iostream>
 
 #include "../H5Exception.hpp"
-#include "highfive/H5Utility.hpp"
+#include "../H5Utility.hpp"
 
 namespace HighFive {
 namespace detail {


### PR DESCRIPTION
**Description**

This PR fixes an import statement that causes compilations to fail when trying to use HighFive as a header-only library with custom install locations. Symptoms are: (i) `fatal error: 'highfive/H5Utiity.hpp' not found` if the conda environment does not contain a system `highfive` or (ii) a long error stack starting with `error: redefinition of 'SilencedHDF5' [...]` if trying to compile with a custom location while having a `highfive` package installed. Using the relative import (which is used everywhere else) fixes the issue. 

- [x] fixed relative import

**How to test this?**

```bash
cmake ..
make -j8
make test
```

**Test System**
 - OS: macOS (inside `conda` environment with/without `highfive` package installed)
 - Compiler: AppleClang 14.0.3 
 - Dependency versions: hdf5 1.12
