### PR TITLE
Fix friends on windows.

### DIFF
--- a/CMake/HighFiveTargetDeps.cmake
+++ b/CMake/HighFiveTargetDeps.cmake
@@ -14,6 +14,10 @@ if(NOT TARGET libdeps)
     target_compile_definitions(libdeps INTERFACE -D_GLIBCXX_ASSERTIONS)
   endif()
 
+  if(HIGHFIVE_HAS_FRIENDS)
+    target_compile_definitions(libdeps INTERFACE -DHIGHFIVE_HAS_FRIENDS=1)
+  endif()
+
   if(HIGHFIVE_SANITIZER)
     target_compile_options(libdeps INTERFACE -fsanitize=${HIGHFIVE_SANITIZER})
     target_link_options(libdeps INTERFACE -fsanitize=${HIGHFIVE_SANITIZER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ option(HIGHFIVE_BUILD_DOCS "Enable documentation building" ON)
 option(HIGHFIVE_VERBOSE "Set logging level to verbose." OFF)
 option(HIGHFIVE_GLIBCXX_ASSERTIONS "Enable bounds check for STL." OFF)
 option(HIGHFIVE_HAS_FRIENDS "Enable additional friend declarations. Certain compiler require this On, others Off." OFF)
+mark_as_advanced(HIGHFIVE_HAS_FRIENDS)
 
 set(HIGHFIVE_SANITIZER OFF CACHE STRING "Enable a group of sanitizers, requires compiler support. Supported: 'address' and 'undefined'.")
 mark_as_advanced(HIGHFIVE_SANITIZER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(HIGHFIVE_PARALLEL_HDF5 "Enable Parallel HDF5 support" OFF)
 option(HIGHFIVE_BUILD_DOCS "Enable documentation building" ON)
 option(HIGHFIVE_VERBOSE "Set logging level to verbose." OFF)
 option(HIGHFIVE_GLIBCXX_ASSERTIONS "Enable bounds check for STL." OFF)
+option(HIGHFIVE_HAS_FRIENDS "Enable additional friend declarations. Certain compiler require this On, others Off." OFF)
 
 set(HIGHFIVE_SANITIZER OFF CACHE STRING "Enable a group of sanitizers, requires compiler support. Supported: 'address' and 'undefined'.")
 mark_as_advanced(HIGHFIVE_SANITIZER)

--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -14,6 +14,7 @@
 
 #include "H5DataType.hpp"
 #include "H5Object.hpp"
+#include "bits/H5Friends.hpp"
 #include "bits/H5Path_traits.hpp"
 
 namespace HighFive {
@@ -114,6 +115,11 @@ class Attribute: public Object, public PathTraits<Attribute> {
 
   private:
     using Object::Object;
+
+#if HIGHFIVE_HAS_FRIENDS
+    template <typename Derivate>
+    friend class ::HighFive::AnnotateTraits;
+#endif
 
     friend Attribute detail::make_attribute(hid_t);
 };

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -71,7 +71,6 @@ class Group: public Object,
     template <typename Derivate>
     friend class ::HighFive::NodeTraits;
 #endif
-
 };
 
 inline std::pair<unsigned int, unsigned int> Group::getEstimatedLinkInfo() const {

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -11,6 +11,7 @@
 #include <H5Gpublic.h>
 
 #include "H5Object.hpp"
+#include "bits/H5Friends.hpp"
 #include "bits/H5_definitions.hpp"
 #include "bits/H5Annotate_traits.hpp"
 #include "bits/H5Node_traits.hpp"
@@ -66,6 +67,11 @@ class Group: public Object,
     friend Group detail::make_group(hid_t);
     friend class File;
     friend class Reference;
+#if HIGHFIVE_HAS_FRIENDS
+    template <typename Derivate>
+    friend class ::HighFive::NodeTraits;
+#endif
+
 };
 
 inline std::pair<unsigned int, unsigned int> Group::getEstimatedLinkInfo() const {

--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -14,6 +14,7 @@
 #include <H5Opublic.h>
 
 #include "bits/H5_definitions.hpp"
+#include "bits/H5Friends.hpp"
 
 namespace HighFive {
 
@@ -107,6 +108,15 @@ class Object {
     friend Object detail::make_object(hid_t);
     friend class Reference;
     friend class CompoundType;
+
+#if HIGHFIVE_HAS_FRIENDS
+    template <typename Derivate>
+    friend class NodeTraits;
+    template <typename Derivate>
+    friend class AnnotateTraits;
+    template <typename Derivate>
+    friend class PathTraits;
+#endif
 };
 
 

--- a/include/highfive/H5Selection.hpp
+++ b/include/highfive/H5Selection.hpp
@@ -11,6 +11,7 @@
 #include "H5DataSet.hpp"
 #include "H5DataSpace.hpp"
 #include "bits/H5Slice_traits.hpp"
+#include "bits/H5Friends.hpp"
 
 namespace HighFive {
 
@@ -56,6 +57,10 @@ class Selection: public SliceTraits<Selection> {
     DataSpace _mem_space, _file_space;
     DataSet _set;
 
+#if HIGHFIVE_HAS_FRIENDS
+    template <typename Derivate>
+    friend class ::HighFive::SliceTraits;
+#endif
     friend Selection detail::make_selection(const DataSpace&, const DataSpace&, const DataSet&);
 };
 

--- a/include/highfive/H5Utility.hpp
+++ b/include/highfive/H5Utility.hpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <iostream>
 
+#include "bits/H5Friends.hpp"
+
 namespace HighFive {
 
 ///

--- a/include/highfive/bits/H5Friends.hpp
+++ b/include/highfive/bits/H5Friends.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifndef HIGHFIVE_HAS_FRIENDS
+#ifdef _MSC_VER
+#define HIGHFIVE_HAS_FRIENDS 1
+#endif
+#endif

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -21,6 +21,7 @@
 #include <H5public.h>
 
 #include "../H5Exception.hpp"
+#include "H5Friends.hpp"
 
 namespace HighFive {
 


### PR DESCRIPTION
Reintroduces friend declarations, which are the most likely cause of the regression seen in #724. Since these declaration cause issues on older versions of GCC, they're behind the include guard `HIGHFIVE_HAS_FRIENDS=1`. For HighFive code the friend declarations are not needed.
