### PR TITLE
Avoid MSVC compiler bug.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,8 +260,13 @@ jobs:
 
   # Job testing in Windows
   # ======================
-  Windows:
-    runs-on: Windows-latest
+  Windows-2022:
+    runs-on:  ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ "windows-2022"]
+        vs-toolset: [ "v141", "v143" ]
+        cxxstd: ["14", "17"]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -276,6 +281,8 @@ jobs:
       shell: bash -l {0}
       run: |
         CMAKE_OPTIONS=(
+          -T ${{matrix.vs-toolset}}
+          -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
           -DHIGHFIVE_UNIT_TESTS=ON
           -DHIGHFIVE_USE_BOOST:BOOL=ON
           -DHIGHFIVE_USE_EIGEN:BOOL=ON
@@ -288,4 +295,40 @@ jobs:
       working-directory: ${{github.workspace}}/build
       shell: bash -l {0}
       run: ctest --output-on-failure -C $BUILD_TYPE
+
+  Windows-2019:
+    runs-on:  ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ "windows-2019"]
+        vs-toolset: [ "v142" ]
+        cxxstd: ["14", "17"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: doc/environment.yaml
+          environment-name: win-test
+
+      - name: Build
+        shell: bash -l {0}
+        run: |
+          CMAKE_OPTIONS=(
+            -T ${{matrix.vs-toolset}}
+            -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
+            -DHIGHFIVE_UNIT_TESTS=ON
+            -DHIGHFIVE_USE_BOOST:BOOL=ON
+            -DHIGHFIVE_USE_EIGEN:BOOL=ON
+            -DHIGHFIVE_USE_XTENSOR:BOOL=ON
+            -DHIGHFIVE_TEST_SINGLE_INCLUDES=ON
+          )
+          source $GITHUB_WORKSPACE/.github/build.sh
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        shell: bash -l {0}
+        run: ctest --output-on-failure -C $BUILD_TYPE
 

--- a/CMake/HighFiveTargetDeps.cmake
+++ b/CMake/HighFiveTargetDeps.cmake
@@ -14,6 +14,10 @@ if(NOT TARGET libdeps)
     target_compile_definitions(libdeps INTERFACE -D_GLIBCXX_ASSERTIONS)
   endif()
 
+  if(HIGHFIVE_HAS_FRIEND_DECLARATIONS)
+    target_compile_definitions(libdeps INTERFACE -DHIGHFIVE_HAS_FRIEND_DECLARATIONS=1)
+  endif()
+
   if(HIGHFIVE_SANITIZER)
     target_compile_options(libdeps INTERFACE -fsanitize=${HIGHFIVE_SANITIZER})
     target_link_options(libdeps INTERFACE -fsanitize=${HIGHFIVE_SANITIZER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,33 @@ option(HIGHFIVE_BUILD_DOCS "Enable documentation building" ON)
 option(HIGHFIVE_VERBOSE "Set logging level to verbose." OFF)
 option(HIGHFIVE_GLIBCXX_ASSERTIONS "Enable bounds check for STL." OFF)
 
+# Controls if HighFive classes are friends of each other.
+#
+# There are two compiler bugs that require incompatible choices. The
+# GCC compiler bug [1] prevents us from writing:
+#
+#     template<class D>
+#     friend class NodeTraits<D>;
+#
+# While a MSVC compiler bug [2] complains that it can't access a
+# protected constructor, e.g., `HighFive::Object::Object`.
+#
+# Starting with `2.7.0` these friend declarations don't matter
+# anymore. It's mearly a means of appeasing a compiler.
+#
+# The values of `HIGHFIVE_HAS_FRIEND_DECLARATIONS` are:
+#   - that the macro is undefined.
+#   - `0` which implies not adding the friend declarations.
+#   - any non-zero integer, i.e. `1`, to add the friend declarations.
+#
+# Not defining the macro implies that it'll be set to `1` if MSVC is
+# detected (or other compilers requiring the friend declarations).
+#
+# [1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52625
+# [2]: https://developercommunity.visualstudio.com/t/MSVC-compiler-improperly-implements-N489/1516410
+option(HIGHFIVE_HAS_FRIEND_DECLARATIONS "Enable additional friend declarations. Certain compiler require this On, others Off." OFF)
+mark_as_advanced(HIGHFIVE_HAS_FRIEND_DECLARATIONS)
+
 set(HIGHFIVE_SANITIZER OFF CACHE STRING "Enable a group of sanitizers, requires compiler support. Supported: 'address' and 'undefined'.")
 mark_as_advanced(HIGHFIVE_SANITIZER)
 

--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -14,6 +14,7 @@
 
 #include "H5DataType.hpp"
 #include "H5Object.hpp"
+#include "bits/H5Friends.hpp"
 #include "bits/H5Path_traits.hpp"
 
 namespace HighFive {
@@ -112,8 +113,14 @@ class Attribute: public Object, public PathTraits<Attribute> {
     // No empty attributes
     Attribute() = delete;
 
-  private:
+  protected:
     using Object::Object;
+
+  private:
+#if HIGHFIVE_HAS_FRIEND_DECLARATIONS
+    template <typename Derivate>
+    friend class ::HighFive::AnnotateTraits;
+#endif
 
     friend Attribute detail::make_attribute(hid_t);
 };

--- a/include/highfive/H5File.hpp
+++ b/include/highfive/H5File.hpp
@@ -112,10 +112,9 @@ class File: public Object, public NodeTraits<File>, public AnnotateTraits<File> 
 
   protected:
     File() = default;
-
-  private:
     using Object::Object;
 
+  private:
     mutable std::string _filename{};
 
     template <typename>

--- a/include/highfive/H5Group.hpp
+++ b/include/highfive/H5Group.hpp
@@ -11,6 +11,7 @@
 #include <H5Gpublic.h>
 
 #include "H5Object.hpp"
+#include "bits/H5Friends.hpp"
 #include "bits/H5_definitions.hpp"
 #include "bits/H5Annotate_traits.hpp"
 #include "bits/H5Node_traits.hpp"
@@ -66,6 +67,10 @@ class Group: public Object,
     friend Group detail::make_group(hid_t);
     friend class File;
     friend class Reference;
+#if HIGHFIVE_HAS_FRIEND_DECLARATIONS
+    template <typename Derivate>
+    friend class ::HighFive::NodeTraits;
+#endif
 };
 
 inline std::pair<unsigned int, unsigned int> Group::getEstimatedLinkInfo() const {

--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -14,6 +14,7 @@
 #include <H5Opublic.h>
 
 #include "bits/H5_definitions.hpp"
+#include "bits/H5Friends.hpp"
 
 namespace HighFive {
 
@@ -107,6 +108,15 @@ class Object {
     friend Object detail::make_object(hid_t);
     friend class Reference;
     friend class CompoundType;
+
+#if HIGHFIVE_HAS_FRIEND_DECLARATIONS
+    template <typename Derivate>
+    friend class NodeTraits;
+    template <typename Derivate>
+    friend class AnnotateTraits;
+    template <typename Derivate>
+    friend class PathTraits;
+#endif
 };
 
 

--- a/include/highfive/H5Selection.hpp
+++ b/include/highfive/H5Selection.hpp
@@ -11,6 +11,7 @@
 #include "H5DataSet.hpp"
 #include "H5DataSpace.hpp"
 #include "bits/H5Slice_traits.hpp"
+#include "bits/H5Friends.hpp"
 
 namespace HighFive {
 
@@ -50,12 +51,17 @@ class Selection: public SliceTraits<Selection> {
     /// \return return the datatype of the selection
     const DataType getDataType() const;
 
-  private:
+  protected:
     Selection(const DataSpace& memspace, const DataSpace& file_space, const DataSet& set);
 
+  private:
     DataSpace _mem_space, _file_space;
     DataSet _set;
 
+#if HIGHFIVE_HAS_FRIEND_DECLARATIONS
+    template <typename Derivate>
+    friend class ::HighFive::SliceTraits;
+#endif
     friend Selection detail::make_selection(const DataSpace&, const DataSpace&, const DataSet&);
 };
 

--- a/include/highfive/H5Utility.hpp
+++ b/include/highfive/H5Utility.hpp
@@ -14,6 +14,8 @@
 #include <string>
 #include <iostream>
 
+#include "bits/H5Friends.hpp"
+
 namespace HighFive {
 
 ///

--- a/include/highfive/bits/H5Friends.hpp
+++ b/include/highfive/bits/H5Friends.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef HIGHFIVE_HAS_FRIEND_DECLARATIONS
+#ifdef _MSC_VER
+// This prevents a compiler bug on certain versions of MSVC.
+// Known to fail: Toolset 141.
+// See `CMakeLists.txt` for more information.
+#define HIGHFIVE_HAS_FRIEND_DECLARATIONS 1
+#endif
+#endif

--- a/include/highfive/bits/H5Utils.hpp
+++ b/include/highfive/bits/H5Utils.hpp
@@ -21,6 +21,7 @@
 #include <H5public.h>
 
 #include "../H5Exception.hpp"
+#include "H5Friends.hpp"
 
 namespace HighFive {
 


### PR DESCRIPTION
The purpose of this MR is to get older versions of MSVC to compile HighFive. The hope is it'll reproduce the issue in #724. This fixes required are also included in this PR.