### PR TITLE
Add wrapper for commonly used 'H5T*' functions.

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -26,6 +26,64 @@
 
 namespace HighFive {
 
+namespace detail {
+
+inline hid_t h5t_copy(hid_t original) {
+    auto copy = H5Tcopy(original);
+    if (copy == H5I_INVALID_HID) {
+        HDF5ErrMapper::ToException<DataTypeException>("Error copying datatype.");
+    }
+
+    return copy;
+}
+
+inline hsize_t h5t_get_size(hid_t hid) {
+    hsize_t size = H5Tget_size(hid);
+    if (size == 0) {
+        HDF5ErrMapper::ToException<DataTypeException>("Error getting size of datatype.");
+    }
+
+    return size;
+}
+
+inline H5T_cset_t h5t_get_cset(hid_t hid) {
+    auto cset = H5Tget_cset(hid);
+    if (cset == H5T_CSET_ERROR) {
+        HDF5ErrMapper::ToException<DataTypeException>("Error getting cset of datatype.");
+    }
+
+    return cset;
+}
+
+inline H5T_str_t h5t_get_strpad(hid_t hid) {
+    auto strpad = H5Tget_strpad(hid);
+    if (strpad == H5T_STR_ERROR) {
+        HDF5ErrMapper::ToException<DataTypeException>("Error getting strpad of datatype.");
+    }
+
+    return strpad;
+}
+
+inline void h5t_set_size(hid_t hid, hsize_t size) {
+    if (H5Tset_size(hid, size) < 0) {
+        HDF5ErrMapper::ToException<DataTypeException>("Error setting size of datatype.");
+    }
+}
+
+inline void h5t_set_cset(hid_t hid, H5T_cset_t cset) {
+    if (H5Tset_cset(hid, cset) < 0) {
+        HDF5ErrMapper::ToException<DataTypeException>("Error setting cset of datatype.");
+    }
+}
+
+inline void h5t_set_strpad(hid_t hid, H5T_str_t strpad) {
+    if (H5Tset_strpad(hid, strpad) < 0) {
+        HDF5ErrMapper::ToException<DataTypeException>("Error setting strpad of datatype.");
+    }
+}
+}  // namespace detail
+
+
 namespace {  // unnamed
 inline DataTypeClass convert_type_class(const H5T_class_t& tclass);
 inline std::string type_class_string(DataTypeClass);
@@ -41,7 +99,7 @@ inline DataTypeClass DataType::getClass() const {
 }
 
 inline size_t DataType::getSize() const {
-    return H5Tget_size(_hid);
+    return detail::h5t_get_size(_hid);
 }
 
 inline bool DataType::operator==(const DataType& other) const {
@@ -75,61 +133,61 @@ inline std::string DataType::string() const {
 // char mapping
 template <>
 inline AtomicType<char>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_CHAR);
+    _hid = detail::h5t_copy(H5T_NATIVE_CHAR);
 }
 
 template <>
 inline AtomicType<signed char>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_SCHAR);
+    _hid = detail::h5t_copy(H5T_NATIVE_SCHAR);
 }
 
 template <>
 inline AtomicType<unsigned char>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_UCHAR);
+    _hid = detail::h5t_copy(H5T_NATIVE_UCHAR);
 }
 
 // short mapping
 template <>
 inline AtomicType<short>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_SHORT);
+    _hid = detail::h5t_copy(H5T_NATIVE_SHORT);
 }
 
 template <>
 inline AtomicType<unsigned short>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_USHORT);
+    _hid = detail::h5t_copy(H5T_NATIVE_USHORT);
 }
 
 // integer mapping
 template <>
 inline AtomicType<int>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_INT);
+    _hid = detail::h5t_copy(H5T_NATIVE_INT);
 }
 
 template <>
 inline AtomicType<unsigned>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_UINT);
+    _hid = detail::h5t_copy(H5T_NATIVE_UINT);
 }
 
 // long mapping
 template <>
 inline AtomicType<long>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_LONG);
+    _hid = detail::h5t_copy(H5T_NATIVE_LONG);
 }
 
 template <>
 inline AtomicType<unsigned long>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_ULONG);
+    _hid = detail::h5t_copy(H5T_NATIVE_ULONG);
 }
 
 // long long mapping
 template <>
 inline AtomicType<long long>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_LLONG);
+    _hid = detail::h5t_copy(H5T_NATIVE_LLONG);
 }
 
 template <>
 inline AtomicType<unsigned long long>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_ULLONG);
+    _hid = detail::h5t_copy(H5T_NATIVE_ULLONG);
 }
 
 // half-float, float, double and long double mapping
@@ -138,11 +196,11 @@ using float16_t = half_float::half;
 
 template <>
 inline AtomicType<float16_t>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_FLOAT);
+    _hid = detail::h5t_copy(H5T_NATIVE_FLOAT);
     // Sign position, exponent position, exponent size, mantissa position, mantissa size
     H5Tset_fields(_hid, 15, 10, 5, 0, 10);
     // Total datatype size (in bytes)
-    H5Tset_size(_hid, 2);
+    detail::h5t_set_size(_hid, 2);
     // Floating point exponent bias
     H5Tset_ebias(_hid, 15);
 }
@@ -150,17 +208,17 @@ inline AtomicType<float16_t>::AtomicType() {
 
 template <>
 inline AtomicType<float>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_FLOAT);
+    _hid = detail::h5t_copy(H5T_NATIVE_FLOAT);
 }
 
 template <>
 inline AtomicType<double>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_DOUBLE);
+    _hid = detail::h5t_copy(H5T_NATIVE_DOUBLE);
 }
 
 template <>
 inline AtomicType<long double>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_LDOUBLE);
+    _hid = detail::h5t_copy(H5T_NATIVE_LDOUBLE);
 }
 
 // std string
@@ -173,7 +231,7 @@ inline AtomicType<std::string>::AtomicType() {
 // std byte
 template <>
 inline AtomicType<std::byte>::AtomicType() {
-    _hid = H5Tcopy(H5T_NATIVE_B8);
+    _hid = detail::h5t_copy(H5T_NATIVE_B8);
 }
 #endif
 
@@ -271,7 +329,7 @@ inline std::string FixedLenStringArray<N>::getString(std::size_t i) const {
 // Reference mapping
 template <>
 inline AtomicType<Reference>::AtomicType() {
-    _hid = H5Tcopy(H5T_STD_REF_OBJ);
+    _hid = detail::h5t_copy(H5T_STD_REF_OBJ);
 }
 
 inline size_t find_first_atomic_member_size(hid_t hid) {
@@ -294,7 +352,7 @@ inline size_t find_first_atomic_member_size(hid_t hid) {
     } else if (H5Tget_class(hid) == H5T_STRING) {
         return 1;
     }
-    return H5Tget_size(hid);
+    return detail::h5t_get_size(hid);
 }
 
 // Calculate the padding required to align an element of a struct
@@ -325,7 +383,7 @@ inline void CompoundType::create(size_t size) {
 
         // Do a first pass to find the total size of the compound datatype
         for (auto& member: members) {
-            size_t member_size = H5Tget_size(member.base_type.getId());
+            size_t member_size = detail::h5t_get_size(member.base_type.getId());
 
             if (member_size == 0) {
                 throw DataTypeException("Cannot get size of DataType with hid: " +
@@ -393,12 +451,9 @@ inline void EnumType<T>::commit(const Object& object, const std::string& name) c
 namespace {
 
 inline hid_t create_string(size_t length) {
-    hid_t _hid = H5Tcopy(H5T_C_S1);
-    if (H5Tset_size(_hid, length) < 0) {
-        HDF5ErrMapper::ToException<DataTypeException>("Unable to define datatype size to variable");
-    }
-    // define encoding to UTF-8 by default
-    H5Tset_cset(_hid, H5T_CSET_UTF8);
+    hid_t _hid = detail::h5t_copy(H5T_C_S1);
+    detail::h5t_set_size(_hid, length);
+    detail::h5t_set_cset(_hid, H5T_CSET_UTF8);
     return _hid;
 }
 


### PR DESCRIPTION
This add wrappers that perform the required error checking for commonly used `H5T*` functions. The wrappers are intentionally kept internal.