### PR TITLE
Prefer reference over pointer.

### DIFF
--- a/include/highfive/bits/H5Path_traits_misc.hpp
+++ b/include/highfive/bits/H5Path_traits_misc.hpp
@@ -34,7 +34,7 @@ inline PathTraits<Derivate>::PathTraits() {
 template <typename Derivate>
 inline std::string PathTraits<Derivate>::getPath() const {
     return details::get_name([this](char* buffer, size_t length) {
-        return H5Iget_name(static_cast<const Derivate*>(this)->getId(), buffer, length);
+        return H5Iget_name(static_cast<const Derivate&>(*this).getId(), buffer, length);
     });
 }
 


### PR DESCRIPTION
GCC 12 warns that `static_cast<Derived*>(*this)->getId()` dereferences a null pointer. We can use references instead.