### PR TITLE
Refactor raw read and write code.

### DIFF
--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -87,9 +87,17 @@ class Attribute: public Object, public PathTraits<Attribute> {
     template <typename T>
     void read(T& array) const;
 
-    /// \brief Read the attribute into a buffer
+    /// \brief Read the attribute into a buffer.
+    ///
+    /// Note, this is the shallowest wrapper around `H5Aread`.
     template <typename T>
-    void read(T* array, const DataType& dtype = {}) const;
+    void read(T* array, const DataType& mem_datatype) const;
+
+    /// \brief Read the attribute into a buffer
+    ///
+    /// This overload deduces the memory datatype from `T`.
+    template <typename T>
+    void read(T* array) const;
 
     ///
     /// Write the integrality N-dimension buffer to this attribute
@@ -101,9 +109,19 @@ class Attribute: public Object, public PathTraits<Attribute> {
     template <typename T>
     void write(const T& buffer);
 
-    /// \brief Write a buffer to this attribute
+    /// \brief Write to this attribute from `buffer`.
+    ///
+    /// Note that this is the shallowest wrapper around `H5Awrite`. It's useful
+    /// if you need full control. If possible prefer `Attribute::write`.
     template <typename T>
-    void write_raw(const T* buffer, const DataType& dtype = {});
+    void write_raw(const T* buffer, const DataType& mem_dtype);
+
+    /// \brief Write to this attribute from `buffer`.
+    ///
+    /// This version attempts to automatically deduce the datatype
+    /// of the buffer. Note, that the file datatype is already set.
+    template <typename T>
+    void write_raw(const T* buffer);
 
     /// \brief Get the list of properties for creation of this attribute
     AttributeCreateProps getCreatePropertyList() const {

--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -100,17 +100,21 @@ inline void Attribute::read(T& array) const {
 }
 
 template <typename T>
-inline void Attribute::read(T* array, const DataType& dtype) const {
+inline void Attribute::read(T* array, const DataType& mem_datatype) const {
     static_assert(!std::is_const<T>::value,
                   "read() requires a non-const structure to read data into");
-    using element_type = typename details::inspector<T>::base_type;
-    // Auto-detect mem datatype if not provided
-    const DataType& mem_datatype = dtype.empty() ? create_and_check_datatype<element_type>()
-                                                 : dtype;
 
     if (H5Aread(getId(), mem_datatype.getId(), static_cast<void*>(array)) < 0) {
         HDF5ErrMapper::ToException<AttributeException>("Error during HDF5 Read: ");
     }
+}
+
+template <typename T>
+inline void Attribute::read(T* array) const {
+    using element_type = typename details::inspector<T>::base_type;
+    const DataType& mem_datatype = create_and_check_datatype<element_type>();
+
+    read(array, mem_datatype);
 }
 
 template <typename T>
@@ -137,13 +141,18 @@ inline void Attribute::write(const T& buffer) {
 }
 
 template <typename T>
-inline void Attribute::write_raw(const T* buffer, const DataType& dtype) {
-    using element_type = typename details::inspector<T>::base_type;
-    const auto& mem_datatype = dtype.empty() ? create_and_check_datatype<element_type>() : dtype;
-
+inline void Attribute::write_raw(const T* buffer, const DataType& mem_datatype) {
     if (H5Awrite(getId(), mem_datatype.getId(), buffer) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Write: ");
     }
+}
+
+template <typename T>
+inline void Attribute::write_raw(const T* buffer) {
+    using element_type = typename details::inspector<T>::base_type;
+    const auto& mem_datatype = create_and_check_datatype<element_type>();
+
+    write_raw(buffer, mem_datatype);
 }
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -308,8 +308,20 @@ class SliceTraits {
     /// \param xfer_props: Data Transfer properties
     template <typename T>
     void read(T* array,
-              const DataType& dtype = DataType(),
+              const DataType& dtype,
               const DataTransferProps& xfer_props = DataTransferProps()) const;
+
+    ///
+    /// Read the entire dataset into a raw buffer
+    ///
+    /// Same as `read(T*, const DataType&, const DataTransferProps&)`. However,
+    /// this overload deduces the HDF5 datatype of the element of `array` from
+    /// `T`. Note, that the file datatype is already fixed.
+    ///
+    /// \param array: A buffer containing enough space for the data
+    /// \param xfer_props: Data Transfer properties
+    template <typename T>
+    void read(T* array, const DataTransferProps& xfer_props = DataTransferProps()) const;
 
     ///
     /// Write the integrality N-dimension buffer to this dataset
@@ -322,19 +334,34 @@ class SliceTraits {
     void write(const T& buffer, const DataTransferProps& xfer_props = DataTransferProps());
 
     ///
-    /// Write from a raw buffer into this dataset
+    /// Write from a raw pointer into this dataset.
     ///
     /// No dimensionality checks will be performed, it is the user's
     /// responsibility to ensure that the buffer holds the right amount of
     /// elements. For n-dimensional matrices the buffer layout follows H5
     /// default conventions.
+    ///
+    /// Note, this is the shallowest wrapper around `H5Dwrite` and should
+    /// be used if full control is needed. Generally prefer `write`.
+    ///
     /// \param buffer: A buffer containing the data to be written
-    /// \param dtype: The type of the data, in case it cannot be automatically guessed
+    /// \param dtype: The datatype of `buffer`, i.e. the memory data type.
     /// \param xfer_props: The HDF5 data transfer properties, e.g. collective MPI-IO.
     template <typename T>
     void write_raw(const T* buffer,
-                   const DataType& dtype = DataType(),
+                   const DataType& mem_datatype,
                    const DataTransferProps& xfer_props = DataTransferProps());
+
+    ///
+    /// Write from a raw pointer into this dataset.
+    ///
+    /// Same as `write_raw(const T*, const DataTransferProps&)`. However, this
+    /// overload attempts to guess the data type of `buffer`, i.e. the memory
+    /// datatype. Note that the file datatype is already fixed.
+    ///
+    template <typename T>
+    void write_raw(const T* buffer, const DataTransferProps& xfer_props = DataTransferProps());
+
 
   protected:
     inline Selection select_impl(const HyperSlab& hyperslab, const DataSpace& memspace) const;

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -214,16 +214,12 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
 template <typename Derivate>
 template <typename T>
 inline void SliceTraits<Derivate>::read(T* array,
-                                        const DataType& dtype,
+                                        const DataType& mem_datatype,
                                         const DataTransferProps& xfer_props) const {
     static_assert(!std::is_const<T>::value,
                   "read() requires a non-const structure to read data into");
-    const auto& slice = static_cast<const Derivate&>(*this);
-    using element_type = typename details::inspector<T>::base_type;
 
-    // Auto-detect mem datatype if not provided
-    const DataType& mem_datatype = dtype.empty() ? create_and_check_datatype<element_type>()
-                                                 : dtype;
+    const auto& slice = static_cast<const Derivate&>(*this);
 
     if (H5Dread(details::get_dataset(slice).getId(),
                 mem_datatype.getId(),
@@ -233,6 +229,15 @@ inline void SliceTraits<Derivate>::read(T* array,
                 static_cast<void*>(array)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Read.");
     }
+}
+
+template <typename Derivate>
+template <typename T>
+inline void SliceTraits<Derivate>::read(T* array, const DataTransferProps& xfer_props) const {
+    using element_type = typename details::inspector<T>::base_type;
+    const DataType& mem_datatype = create_and_check_datatype<element_type>();
+
+    read(array, mem_datatype, xfer_props);
 }
 
 
@@ -266,11 +271,9 @@ inline void SliceTraits<Derivate>::write(const T& buffer, const DataTransferProp
 template <typename Derivate>
 template <typename T>
 inline void SliceTraits<Derivate>::write_raw(const T* buffer,
-                                             const DataType& dtype,
+                                             const DataType& mem_datatype,
                                              const DataTransferProps& xfer_props) {
-    using element_type = typename details::inspector<T>::base_type;
     const auto& slice = static_cast<const Derivate&>(*this);
-    const auto& mem_datatype = dtype.empty() ? create_and_check_datatype<element_type>() : dtype;
 
     if (H5Dwrite(details::get_dataset(slice).getId(),
                  mem_datatype.getId(),
@@ -280,6 +283,15 @@ inline void SliceTraits<Derivate>::write_raw(const T* buffer,
                  static_cast<const void*>(buffer)) < 0) {
         HDF5ErrMapper::ToException<DataSetException>("Error during HDF5 Write: ");
     }
+}
+
+template <typename Derivate>
+template <typename T>
+inline void SliceTraits<Derivate>::write_raw(const T* buffer, const DataTransferProps& xfer_props) {
+    using element_type = typename details::inspector<T>::base_type;
+    const auto& mem_datatype = create_and_check_datatype<element_type>();
+
+    write_raw(buffer, mem_datatype, xfer_props);
 }
 
 


### PR DESCRIPTION
A raw read should be a very thin wrapper around HDF5. This allows users to use HighFive (as opposed to pure HDF5) to simply write from or read into a pointer.

To enable this, the function are restructure to not use the inspector if the user specified all required information.