### PR TITLE
Allow user-specified `mem_space` for hyperslabs.

### DIFF
--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -259,6 +259,15 @@ class SliceTraits {
     Selection select(const HyperSlab& hyperslab) const;
 
     ///
+    /// \brief Select an \p hyperslab in the current Slice/Dataset.
+    ///
+    /// If the selection can be read into a simple, multi-dimensional dataspace,
+    /// then this overload enable specifying the shape of the memory dataspace
+    /// with `memspace`. Note, that simple implies no offsets, strides or
+    /// number of blocks, just the size of the block in each dimension.
+    Selection select(const HyperSlab& hyperslab, const DataSpace& memspace) const;
+
+    ///
     /// \brief Select a region in the current Slice/Dataset of \p count points at
     /// \p offset separated by \p stride. If strides are not provided they will
     /// default to 1 in all dimensions.
@@ -361,10 +370,6 @@ class SliceTraits {
     ///
     template <typename T>
     void write_raw(const T* buffer, const DataTransferProps& xfer_props = DataTransferProps());
-
-
-  protected:
-    inline Selection select_impl(const HyperSlab& hyperslab, const DataSpace& memspace) const;
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -64,8 +64,8 @@ inline ElementSet::ElementSet(const std::vector<std::vector<std::size_t>>& eleme
 }
 
 template <typename Derivate>
-inline Selection SliceTraits<Derivate>::select_impl(const HyperSlab& hyperslab,
-                                                    const DataSpace& memspace) const {
+inline Selection SliceTraits<Derivate>::select(const HyperSlab& hyperslab,
+                                               const DataSpace& memspace) const {
     // Note: The current limitation are that memspace must describe a
     //       packed memspace.
     //
@@ -98,7 +98,7 @@ inline Selection SliceTraits<Derivate>::select(const std::vector<size_t>& offset
                                                const std::vector<size_t>& block) const {
     auto slab = HyperSlab(RegularHyperSlab(offset, count, stride, block));
     auto memspace = DataSpace(count);
-    return select_impl(slab, memspace);
+    return select(slab, memspace);
 }
 
 template <typename Derivate>
@@ -121,7 +121,7 @@ inline Selection SliceTraits<Derivate>::select(const std::vector<size_t>& column
     std::vector<size_t> memdims = dims;
     memdims.back() = columns.size();
 
-    return select_impl(slab, DataSpace(memdims));
+    return select(slab, DataSpace(memdims));
 }
 
 template <typename Derivate>


### PR DESCRIPTION
This commit allows users to specify the memory dataspace. Previously, we forced the memspace to be 1D, because in general a hyperslab selection isn't a multi-dimensional block anymore.

We now allow users to specify the memory dataspace, which must be simple; but can be multi-dimensional.