### PR TITLE
Remove the 'try-catch' constructs from examples.

### DIFF
--- a/src/examples/boost_multi_array_2D.cpp
+++ b/src/examples/boost_multi_array_2D.cpp
@@ -16,36 +16,25 @@
 
 using namespace HighFive;
 
-const std::string FILE_NAME("boost_multiarray_example.h5");
-const std::string DATASET_NAME("dset");
-const int size_x = 10;
-const int size_y = 3;
-
 // Create a 2D dataset 10x3 of double with boost multi array
-// and write it to a file
+// and write it to a file.
 int main(void) {
-    try {
-        boost::multi_array<double, 2> my_array(boost::extents[size_x][size_y]);
+    const int nx = 10;
+    const int ny = 3;
 
-        for (int i = 0; i < size_x; ++i) {
-            for (int j = 0; j < size_y; ++j) {
-                my_array[i][j] = double(j + i * size_y);
-            }
+    boost::multi_array<double, 2> array(boost::extents[nx][ny]);
+
+    for (int i = 0; i < nx; ++i) {
+        for (int j = 0; j < ny; ++j) {
+            array[i][j] = double(j + i * ny);
         }
-
-        // we create a new hdf5 file
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
-
-        // let's create our dataset of the size of the boost::multi_array
-        DataSet dataset = file.createDataSet<double>(DATASET_NAME, DataSpace::From(my_array));
-
-        // we fill it
-        dataset.write(my_array);
-
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
     }
 
-    return 0;  // successfully terminated
+    // We create a new HDF5 file
+    File file("boost_multiarray_example.h5", File::Truncate);
+
+    // let's create our dataset of the size of the boost::multi_array
+    file.createDataSet("dset", array);
+
+    return 0;
 }

--- a/src/examples/boost_multiarray_complex.cpp
+++ b/src/examples/boost_multiarray_complex.cpp
@@ -25,7 +25,7 @@ int main() {
     multi_array[1][1][0][0] = complex_t{1.1, 1.2};
 
     HighFive::File file("multi_array_complex.h5", HighFive::File::Truncate);
-
     HighFive::DataSet dataset = file.createDataSet("multi_array", multi_array);
+
     return 0;
 }

--- a/src/examples/compound_types.cpp
+++ b/src/examples/compound_types.cpp
@@ -27,17 +27,16 @@ HighFive::CompoundType create_compound_Size2D() {
 HIGHFIVE_REGISTER_TYPE(Size2D, create_compound_Size2D)
 
 int main() {
-    const std::string FILE_NAME("compounds_test.h5");
-    const std::string DATASET_NAME("dims");
+    const std::string dataset_name("dims");
 
-    HighFive::File file(FILE_NAME, HighFive::File::Truncate);
+    HighFive::File file("compounds_test.h5", HighFive::File::Truncate);
 
     auto t1 = create_compound_Size2D();
     t1.commit(file, "Size2D");
 
     std::vector<Size2D> dims = {{1., 2.5}, {3., 4.5}};
-    auto dataset = file.createDataSet(DATASET_NAME, dims);
+    auto dataset = file.createDataSet(dataset_name, dims);
 
     auto g1 = file.createGroup("group1");
-    g1.createAttribute(DATASET_NAME, dims);
+    g1.createAttribute(dataset_name, dims);
 }

--- a/src/examples/create_attribute_string_integer.cpp
+++ b/src/examples/create_attribute_string_integer.cpp
@@ -17,53 +17,34 @@
 
 using namespace HighFive;
 
-const std::string FILE_NAME("create_attribute.h5");
-const std::string DATASET_NAME("my_dataset");
-
-const std::string ATTRIBUTE_NAME_NOTE("note");
-const std::string ATTRIBUTE_NAME_VERSION("version_string");
-
 // create a dataset from a vector of string
 // read it back and print it
 int main(void) {
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+    // Create a new file using the default property lists.
+    File file("create_attribute.h5", File::Truncate);
 
-        // Create a dummy dataset of one single integer
-        DataSet dataset = file.createDataSet(DATASET_NAME, DataSpace(1), create_datatype<int>());
+    // Create a dummy dataset of one single integer
+    DataSet dataset = file.createDataSet("dset", DataSpace(1), create_datatype<int>());
 
-        // Now let's add a attribute on this dataset
-        // This attribute will be named "note"
-        // and have the following content
-        std::string string_list("very important Dataset !");
+    // Now let's add a attribute on this dataset
+    // This attribute will be named "note"
+    // and have the following content
+    std::string note = "Very important Dataset!";
 
-        Attribute a = dataset.createAttribute<std::string>(ATTRIBUTE_NAME_NOTE,
-                                                           DataSpace::From(string_list));
-        a.write(string_list);
+    // Write in one line of code:
+    dataset.createAttribute<std::string>("note", note);
 
-        // We also add a "version" attribute
-        // that will be an array 1x2 of integer
-        std::vector<int> version;
-        version.push_back(1);
-        version.push_back(0);  // version 1.0
+    // We also add a "version" attribute
+    // that will be an array 1x2 of integer
+    std::vector<int> version{1, 0};
 
-        Attribute v = dataset.createAttribute<int>(ATTRIBUTE_NAME_VERSION,
-                                                   DataSpace::From(version));
-        v.write(version);
+    Attribute v = dataset.createAttribute("version", version);
 
-        // Ok all attributes are now written
-
-        // let's list the keys of all attributes now
-        std::vector<std::string> all_attributes_keys = dataset.listAttributeNames();
-        for (const auto& attr: all_attributes_keys) {
-            std::cout << "attribute: " << attr << std::endl;
-        }
-
-    } catch (const Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+    // let's now list the keys of all attributes
+    std::vector<std::string> all_attributes_keys = dataset.listAttributeNames();
+    for (const auto& attr: all_attributes_keys) {
+        std::cout << "attribute: " << attr << std::endl;
     }
 
-    return 0;  // successfully terminated
+    return 0;
 }

--- a/src/examples/create_dataset_double.cpp
+++ b/src/examples/create_dataset_double.cpp
@@ -14,33 +14,27 @@
 #include <highfive/H5DataSpace.hpp>
 #include <highfive/H5File.hpp>
 
-const std::string FILE_NAME("create_dataset_example.h5");
-const std::string DATASET_NAME("dset");
-
 // Create a dataset name "dset" of double 4x6
-//
 int main(void) {
     using namespace HighFive;
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // Define the size of our dataset: 2x6
-        std::vector<size_t> dims{2, 6};
+    // Create a new file using the default property lists. Note that
+    // `File::Truncate` will, if present, truncate the file before opening
+    // it for reading and writing.
+    File file("create_dataset_example.h5", File::Truncate);
 
-        // Create the dataset
-        DataSet dataset = file.createDataSet<double>(DATASET_NAME, DataSpace(dims));
+    // Define the size of our dataset: 2x6
+    std::vector<size_t> dims{2, 6};
 
-        double data[2][6] = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6},
-                             {11.11, 12.12, 13.13, 14.14, 15.15, 16.16}};
+    // Create the dataset
+    DataSet dataset = file.createDataSet<double>("dset", DataSpace(dims));
 
-        // write it
-        dataset.write(data);
+    double data[2][6] = {{1.1, 2.2, 3.3, 4.4, 5.5, 6.6},
+                         {11.11, 12.12, 13.13, 14.14, 15.15, 16.16}};
 
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
-    }
+    // write it
+    dataset.write(data);
+
 
     return 0;  // successfully terminated
 }

--- a/src/examples/create_dataset_half_float.cpp
+++ b/src/examples/create_dataset_half_float.cpp
@@ -25,32 +25,27 @@ const std::string DATASET_NAME("dset");
 //
 int main(void) {
     using namespace HighFive;
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // Define the size of our dataset: 4x6
-        std::vector<size_t> dims{4, 6};
+    // Create a new file using the default property lists.
+    File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // Create the dataset
-        DataSet dataset = file.createDataSet<float16_t>(DATASET_NAME, DataSpace(dims));
+    // Define the size of our dataset: 4x6
+    std::vector<size_t> dims{4, 6};
 
-        std::vector<std::vector<float16_t>> data;
-        for (size_t i = 0; i < 4; ++i) {
-            data.emplace_back();
-            for (size_t j = 0; j < 6; ++j)
-                data[i].emplace_back((i + 1) * (j + 1));
-        }
+    // Create the dataset
+    DataSet dataset = file.createDataSet<float16_t>(DATASET_NAME, DataSpace(dims));
 
-        // write it
-        dataset.write(data);
-
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+    std::vector<std::vector<float16_t>> data;
+    for (size_t i = 0; i < 4; ++i) {
+        data.emplace_back();
+        for (size_t j = 0; j < 6; ++j)
+            data[i].emplace_back((i + 1) * (j + 1));
     }
 
-    return 0;  // successfully terminated
+    // write it
+    dataset.write(data);
+
+    return 0;
 }
 
 #endif

--- a/src/examples/create_datatype.cpp
+++ b/src/examples/create_datatype.cpp
@@ -34,77 +34,69 @@ CompoundType create_compound_csl() {
 HIGHFIVE_REGISTER_TYPE(csl, create_compound_csl)
 
 int main(void) {
-    try {
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+    File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // Create a simple compound type with automatic alignment of the
-        // members. For this the type alignment is trivial.
-        std::vector<CompoundType::member_def> t_members(
-            {{"real", create_datatype<int>()}, {"imag", create_datatype<int>()}});
-        CompoundType t(t_members);
-        t.commit(file, "new_type1");
+    // Create a simple compound type with automatic alignment of the
+    // members. For this the type alignment is trivial.
+    std::vector<CompoundType::member_def> t_members(
+        {{"real", create_datatype<int>()}, {"imag", create_datatype<int>()}});
+    CompoundType t(t_members);
+    t.commit(file, "new_type1");
 
-        // Create a complex nested datatype with manual alignment
-        CompoundType u({{"u1", t, 0}, {"u2", t, 9}, {"u3", create_datatype<int>(), 20}}, 26);
-        u.commit(file, "new_type3");
+    // Create a complex nested datatype with manual alignment
+    CompoundType u({{"u1", t, 0}, {"u2", t, 9}, {"u3", create_datatype<int>(), 20}}, 26);
+    u.commit(file, "new_type3");
 
-        // Create a more complex type with automatic alignment. For this the
-        // type alignment is more complex.
-        CompoundType v_aligned{{"u1", create_datatype<unsigned char>()},
-                               {"u2", create_datatype<short>()},
-                               {"u3", create_datatype<unsigned long long>()}};
-        // introspect the compound type
-        std::cout << "v_aligned size: " << v_aligned.getSize();
-        for (const auto& member: v_aligned.getMembers()) {
-            std::cout << "  field " << member.name << " offset: " << member.offset << std::endl;
-        }
-
-        v_aligned.commit(file, "new_type2_aligned");
-
-        // Create a more complex type with a fully packed alignment. The
-        // equivalent type is created with a standard struct alignment in the
-        // implementation of HighFive::create_datatype above
-        CompoundType v_packed({{"u1", create_datatype<unsigned char>(), 0},
-                               {"u2", create_datatype<short>(), 1},
-                               {"u3", create_datatype<unsigned long long>(), 3}},
-                              11);
-        v_packed.commit(file, "new_type2_packed");
-
-
-        // Initialise some data
-        std::vector<csl> data;
-        data.push_back({'f', 1, 4});
-        data.push_back({'g', -4, 18});
-
-        // Write the data into the file in a fully packed form
-        DataSet dataset = file.createDataSet(DATASET_NAME, DataSpace(2), v_packed);
-        dataset.write(data);
-
-        file.flush();
-
-        // Read a subset of the data back
-        std::vector<csl> result;
-        dataset.select({0}, {2}).read(result);
-
-        for (size_t i = 0; i < data.size(); ++i) {
-            if (result[i] != data[i]) {
-                std::cout << "result[" << i << "]:" << std::endl;
-                std::cout << "    " << result[i].a << std::endl;
-                std::cout << "    " << result[i].b << std::endl;
-                std::cout << "    " << result[i].c << std::endl;
-                std::cout << "data[" << i << "]:" << std::endl;
-                std::cout << "    " << data[i].a << std::endl;
-                std::cout << "    " << data[i].b << std::endl;
-                std::cout << "    " << data[i].c << std::endl;
-            }
-        }
-
-
-    } catch (const Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
-        return 1;
+    // Create a more complex type with automatic alignment. For this the
+    // type alignment is more complex.
+    CompoundType v_aligned{{"u1", create_datatype<unsigned char>()},
+                           {"u2", create_datatype<short>()},
+                           {"u3", create_datatype<unsigned long long>()}};
+    // introspect the compound type
+    std::cout << "v_aligned size: " << v_aligned.getSize();
+    for (const auto& member: v_aligned.getMembers()) {
+        std::cout << "  field " << member.name << " offset: " << member.offset << std::endl;
     }
 
-    return 0;  // successfully terminated
+    v_aligned.commit(file, "new_type2_aligned");
+
+    // Create a more complex type with a fully packed alignment. The
+    // equivalent type is created with a standard struct alignment in the
+    // implementation of HighFive::create_datatype above
+    CompoundType v_packed({{"u1", create_datatype<unsigned char>(), 0},
+                           {"u2", create_datatype<short>(), 1},
+                           {"u3", create_datatype<unsigned long long>(), 3}},
+                          11);
+    v_packed.commit(file, "new_type2_packed");
+
+
+    // Initialise some data
+    std::vector<csl> data;
+    data.push_back({'f', 1, 4});
+    data.push_back({'g', -4, 18});
+
+    // Write the data into the file in a fully packed form
+    DataSet dataset = file.createDataSet(DATASET_NAME, DataSpace(2), v_packed);
+    dataset.write(data);
+
+    file.flush();
+
+    // Read a subset of the data back
+    std::vector<csl> result;
+    dataset.select({0}, {2}).read(result);
+
+    for (size_t i = 0; i < data.size(); ++i) {
+        if (result[i] != data[i]) {
+            std::cout << "result[" << i << "]:" << std::endl;
+            std::cout << "    " << result[i].a << std::endl;
+            std::cout << "    " << result[i].b << std::endl;
+            std::cout << "    " << result[i].c << std::endl;
+            std::cout << "data[" << i << "]:" << std::endl;
+            std::cout << "    " << data[i].a << std::endl;
+            std::cout << "    " << data[i].b << std::endl;
+            std::cout << "    " << data[i].c << std::endl;
+        }
+    }
+
+    return 0;
 }

--- a/src/examples/create_extensible_dataset.cpp
+++ b/src/examples/create_extensible_dataset.cpp
@@ -21,51 +21,45 @@ const std::string DATASET_NAME("dset");
 //
 int main(void) {
     using namespace HighFive;
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // Create a dataspace with initial shape and max shape
-        DataSpace dataspace = DataSpace({4, 5}, {17, DataSpace::UNLIMITED});
+    // Create a new file using the default property lists.
+    File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // Use chunking
-        DataSetCreateProps props;
-        props.add(Chunking(std::vector<hsize_t>{2, 2}));
+    // Create a dataspace with initial shape and max shape
+    DataSpace dataspace = DataSpace({4, 5}, {17, DataSpace::UNLIMITED});
 
-        // Create the dataset
-        DataSet dataset =
-            file.createDataSet(DATASET_NAME, dataspace, create_datatype<double>(), props);
+    // Use chunking
+    DataSetCreateProps props;
+    props.add(Chunking(std::vector<hsize_t>{2, 2}));
 
-        // Write into the initial part of the dataset
-        double t1[3][1] = {{2.0}, {2.0}, {4.0}};
-        dataset.select({0, 0}, {3, 1}).write(t1);
+    // Create the dataset
+    DataSet dataset = file.createDataSet(DATASET_NAME, dataspace, create_datatype<double>(), props);
 
-        // Resize the dataset to a larger size
-        dataset.resize({4, 6});
+    // Write into the initial part of the dataset
+    double t1[3][1] = {{2.0}, {2.0}, {4.0}};
+    dataset.select({0, 0}, {3, 1}).write(t1);
 
-        // Write into the new part of the dataset
-        double t2[1][3] = {{4.0, 8.0, 6.0}};
-        dataset.select({3, 3}, {1, 3}).write(t2);
+    // Resize the dataset to a larger size
+    dataset.resize({4, 6});
 
-        // now we read it back
-        std::vector<std::vector<double>> result;
-        dataset.read(result);
+    // Write into the new part of the dataset
+    double t2[1][3] = {{4.0, 8.0, 6.0}};
+    dataset.select({3, 3}, {1, 3}).write(t2);
 
-        // we print it out and see:
-        // 2 0 0 0 0 0
-        // 2 0 0 0 0 0
-        // 4 0 0 0 0 0
-        // 0 0 0 4 8 6
-        for (auto row: result) {
-            for (auto col: row)
-                std::cout << " " << col;
-            std::cout << std::endl;
-        }
+    // now we read it back
+    std::vector<std::vector<double>> result;
+    dataset.read(result);
 
-    } catch (const Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+    // we print it out and see:
+    // 2 0 0 0 0 0
+    // 2 0 0 0 0 0
+    // 4 0 0 0 0 0
+    // 0 0 0 4 8 6
+    for (auto row: result) {
+        for (auto col: row)
+            std::cout << " " << col;
+        std::cout << std::endl;
     }
 
-    return 0;  // successfully terminated
+    return 0;
 }

--- a/src/examples/create_page_allocated_files.cpp
+++ b/src/examples/create_page_allocated_files.cpp
@@ -17,9 +17,6 @@
 // This example requires HDF5 version 1.10.1 or newer.
 #if H5_VERSION_GE(1, 10, 1)
 
-const std::string FILE_NAME("create_page_allocated_files.h5");
-const std::string DATASET_NAME("array");
-
 // This example show how to create an HDF5 file that internally aggregates
 // metadata and raw data into separate pages. The advantage of this approach
 // is that reading a single page, pulls in the metadata for a large chunk of
@@ -40,34 +37,29 @@ const std::string DATASET_NAME("array");
 
 int main() {
     using namespace HighFive;
-    try {
-        // Create a new file requesting paged allocation.
-        auto create_props = FileCreateProps{};
 
-        // Let request pagesizes of 16 kB. This setting should be tuned
-        // in real applications. We'll allow HDF5 to not keep track of
-        // left-over free space of size less than 128 bytes. Finally,
-        // we don't need the free space manager to be stored in the
-        // HDF5 file.
-        size_t pagesize = 16 * 1024;  // Must be tuned.
-        size_t threshold = 128;
-        size_t persist = false;
+    // Create a new file requesting paged allocation.
+    auto create_props = FileCreateProps{};
 
-        create_props.add(FileSpaceStrategy(H5F_FSPACE_STRATEGY_PAGE, persist, threshold));
-        create_props.add(FileSpacePageSize(pagesize));
+    // Let request pagesizes of 16 kB. This setting should be tuned
+    // in real applications. We'll allow HDF5 to not keep track of
+    // left-over free space of size less than 128 bytes. Finally,
+    // we don't need the free space manager to be stored in the
+    // HDF5 file.
+    size_t pagesize = 16 * 1024;  // Must be tuned.
+    size_t threshold = 128;
+    size_t persist = false;
 
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate, create_props);
+    create_props.add(FileSpaceStrategy(H5F_FSPACE_STRATEGY_PAGE, persist, threshold));
+    create_props.add(FileSpacePageSize(pagesize));
 
-        // The `file` (and also the low-level `file.getId()`) behave as normal, i.e.
-        // one can proceed to add content to the file as usual.
+    File file("create_page_allocated_files.h5", File::Truncate, create_props);
 
-        auto data = std::vector<double>{0.0, 1.0, 2.0};
-        file.createDataSet(DATASET_NAME, data);
+    // The `file` (and also the low-level `file.getId()`) behave as normal, i.e.
+    // one can proceed to add content to the file as usual.
 
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
-    }
+    auto data = std::vector<double>{0.0, 1.0, 2.0};
+    file.createDataSet("data", data);
 
     return 0;
 }

--- a/src/examples/easy_attribute.cpp
+++ b/src/examples/easy_attribute.cpp
@@ -34,6 +34,5 @@ int main() {
     H5Easy::dumpAttribute(file, "/path/to/measurement", "description", desc);
     H5Easy::dumpAttribute(file, "/path/to/measurement", "temperature", temperature);
 
-
     return 0;
 }

--- a/src/examples/hl_hdf5_inmemory_files.cpp
+++ b/src/examples/hl_hdf5_inmemory_files.cpp
@@ -32,43 +32,38 @@ class InMemoryFile: public HighFive::File {
 // Create a 2D dataset 10x3 of double with eigen matrix
 // and write it to a file
 int main(void) {
-    const std::string FILE_NAME("inmemory_file.h5");
-    const std::string DATASET_NAME("dset");
+    const std::string file_name("inmemory_file.h5");
+    const std::string dataset_name("dset");
 
-    try {
-        auto data = std::vector<double>{1.0, 2.0, 3.0};
+    auto data = std::vector<double>{1.0, 2.0, 3.0};
 
-        {
-            // We create an HDF5 file.
-            File file(FILE_NAME, File::Truncate);
-            file.createDataSet(DATASET_NAME, data);
-        }
-
-        // Simulate having an inmemory file by reading a file
-        // byte-by-byte into RAM.
-        auto buffer = std::vector<std::uint8_t>(1ul << 20);
-        auto file = std::fopen(FILE_NAME.c_str(), "r");
-        auto nread = std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file);
-        std::cout << "Bytes read: " << nread << "\n";
-
-        // Create a file from a buffer.
-        auto h5 = InMemoryFile(std::move(buffer));
-
-        // Read a dataset as usual.
-        auto read_back = h5.getDataSet(DATASET_NAME).read<std::vector<double>>();
-
-        // Check if the values match.
-        for (size_t i = 0; i < read_back.size(); ++i) {
-            if (read_back[i] != data[i]) {
-                throw std::runtime_error("Values don't match.");
-            } else {
-                std::cout << "read_back[" << i << "] = " << read_back[i] << "\n";
-            }
-        }
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+    {
+        // We create an HDF5 file.
+        File file(file_name, File::Truncate);
+        file.createDataSet(dataset_name, data);
     }
 
-    return 0;  // successfully terminated
+    // Simulate having an inmemory file by reading a file
+    // byte-by-byte into RAM.
+    auto buffer = std::vector<std::uint8_t>(1ul << 20);
+    auto file = std::fopen(file_name.c_str(), "r");
+    auto nread = std::fread(buffer.data(), sizeof(buffer[0]), buffer.size(), file);
+    std::cout << "Bytes read: " << nread << "\n";
+
+    // Create a file from a buffer.
+    auto h5 = InMemoryFile(std::move(buffer));
+
+    // Read a dataset as usual.
+    auto read_back = h5.getDataSet(dataset_name).read<std::vector<double>>();
+
+    // Check if the values match.
+    for (size_t i = 0; i < read_back.size(); ++i) {
+        if (read_back[i] != data[i]) {
+            throw std::runtime_error("Values don't match.");
+        } else {
+            std::cout << "read_back[" << i << "] = " << read_back[i] << "\n";
+        }
+    }
+
+    return 0;
 }

--- a/src/examples/parallel_hdf5_collective_io.cpp
+++ b/src/examples/parallel_hdf5_collective_io.cpp
@@ -18,8 +18,8 @@
 #include <highfive/H5File.hpp>
 #include <highfive/H5PropertyList.hpp>
 
-const std::string FILE_NAME("parallel_collective_example.h5");
-const std::string DATASET_NAME("dset");
+const std::string file_name("parallel_collective_example.h5");
+const std::string dataset_name("dset");
 
 // Currently, HighFive doesn't wrap retrieving information from property lists.
 // Therefore, one needs to use HDF5 directly. For example, to see if collective
@@ -55,6 +55,7 @@ int main(int argc, char** argv) {
     MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
 
     using namespace HighFive;
+
     try {
         // MPI-IO requires informing HDF5 that we want something other than
         // the default behaviour. This is done through property lists. We
@@ -70,7 +71,7 @@ int main(int argc, char** argv) {
         fapl.add(MPIOCollectiveMetadata{});
 
         // Now we can create the file as usual.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate, fapl);
+        File file(file_name, File::Truncate, fapl);
 
         // We can create a group as usual, but all MPI ranks must participate.
         auto group = file.createGroup("grp");
@@ -81,7 +82,7 @@ int main(int argc, char** argv) {
         dims[1] = 2ul;
 
         // We follow the path for
-        DataSet dataset = group.createDataSet<double>(DATASET_NAME, DataSpace(dims));
+        DataSet dataset = group.createDataSet<double>(dataset_name, DataSpace(dims));
 
         // Each node want to write its own rank two time in
         // its associated row

--- a/src/examples/parallel_hdf5_independent_io.cpp
+++ b/src/examples/parallel_hdf5_independent_io.cpp
@@ -18,8 +18,7 @@
 #include <highfive/H5File.hpp>
 #include <highfive/H5PropertyList.hpp>
 
-const std::string FILE_NAME("parallel_independent_example.h5");
-const std::string DATASET_NAME("dset");
+const std::string file_name("parallel_independent_example.h5");
 
 // This is an example of how to let MPI ranks read independent parts of the
 // HDF5 file.
@@ -41,7 +40,7 @@ int main(int argc, char** argv) {
         //   ...
         // }
         if (mpi_rank == 0) {
-            File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+            File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
             for (int i = 0; i < mpi_size; ++i) {
                 std::stringstream group_name;
@@ -74,7 +73,7 @@ int main(int argc, char** argv) {
         // fapl.add(MPIOCollectiveMetadataWrite{});
 
         // Now we can create the file as usual.
-        File file(FILE_NAME, File::ReadOnly, fapl);
+        File file(file_name, File::ReadOnly, fapl);
 
         // Note that this operation isn't collective. Each MPI rank is requesting to
         // open a different group.

--- a/src/examples/read_write_dataset_string.cpp
+++ b/src/examples/read_write_dataset_string.cpp
@@ -16,44 +16,37 @@
 
 using namespace HighFive;
 
-const std::string FILE_NAME("create_dataset_string_example.h5");
-const std::string DATASET_NAME("story");
+const std::string file_name("create_dataset_string_example.h5");
+const std::string dataset_name("story");
 
 // create a dataset from a vector of string
 // read it back and print it
 int main(void) {
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+    // Create a new file using the default property lists.
+    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
-        std::vector<std::string> string_list;
-        string_list.push_back("Hello World !");
-        string_list.push_back(
-            "This string list is mapped to a dataset of "
-            "variable length string");
-        string_list.push_back("Encoding is done in UTF-8 - 你好 - Здравствуйте!");
-        string_list.push_back("May the force be with you");
-        string_list.push_back("Enjoy !");
+    std::vector<std::string> string_list;
+    string_list.push_back("Hello World !");
+    string_list.push_back(
+        "This string list is mapped to a dataset of "
+        "variable length string");
+    string_list.push_back("Encoding is done in UTF-8 - 你好 - Здравствуйте!");
+    string_list.push_back("May the force be with you");
+    string_list.push_back("Enjoy !");
 
-        // create a dataset ready to contains strings of the size of the vector
-        // string_list
-        DataSet dataset = file.createDataSet<std::string>(DATASET_NAME,
-                                                          DataSpace::From(string_list));
+    // create a dataset ready to contains strings of the size of the vector
+    // string_list
+    DataSet dataset = file.createDataSet<std::string>(dataset_name, DataSpace::From(string_list));
 
-        // let's write our vector of  string
-        dataset.write(string_list);
+    // let's write our vector of  string
+    dataset.write(string_list);
 
-        // now we read it back
-        std::vector<std::string> result_string_list;
-        dataset.read(result_string_list);
+    // now we read it back
+    std::vector<std::string> result_string_list;
+    dataset.read(result_string_list);
 
-        for (size_t i = 0; i < result_string_list.size(); ++i) {
-            std::cout << ":" << i << " " << result_string_list[i] << "\n";
-        }
-
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+    for (size_t i = 0; i < result_string_list.size(); ++i) {
+        std::cout << ":" << i << " " << result_string_list[i] << "\n";
     }
 
     return 0;  // successfully terminated

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -8,7 +8,6 @@
  */
 #include <iostream>
 #include <string>
-#include <vector>
 
 #include <highfive/H5File.hpp>
 #include <highfive/H5DataSet.hpp>
@@ -16,37 +15,30 @@
 
 using namespace HighFive;
 
-static const std::string FILE_NAME("create_dataset_string_example.h5");
+// This examples shows how compile time constant strings work.
+//
+// Note, that as of version 2.8.0., writing `std::string` as fixed-length
+// strings there's a simpler API.
+int main() {
+    // Create a new file using the default property lists.
+    File file("create_dataset_string_example.h5", File::Truncate);
+    const char strings_fixed[][16] = {"abcabcabcabcabc", "123123123123123"};
 
-// create a dataset from a vector of string
-// read it back and print it
-int main(void) {
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
-        const char strings_fixed[][16] = {"abcabcabcabcabc", "123123123123123"};
+    // create a dataset ready to contains strings of the size of the vector
+    file.createDataSet<char[10]>("ds1", DataSpace(2)).write(strings_fixed);
 
-        // create a dataset ready to contains strings of the size of the vector
-        file.createDataSet<char[10]>("ds1", DataSpace(2)).write(strings_fixed);
+    // Without specific type info this will create an int8 dataset
+    file.createDataSet("ds2", strings_fixed);
 
-        // Without specific type info this will create an int8 dataset
-        file.createDataSet("ds2", strings_fixed);
+    // Now test the new interface type
+    FixedLenStringArray<10> arr{"0000000", "1111111"};
+    auto ds = file.createDataSet("ds3", arr);
 
-        // Now test the new interface type
-        FixedLenStringArray<10> arr{"0000000", "1111111"};  // also accepts std::vector
-        auto ds = file.createDataSet("ds3", arr);
+    // Read back truncating to 4 chars
+    FixedLenStringArray<4> array_back;
+    ds.read(array_back);
+    std::cout << "First item is '" << array_back[0] << "'\n"
+              << "Second item is '" << array_back[1] << "'\n";
 
-        // Read back truncating to 4 chars
-        FixedLenStringArray<4> array_back;
-        ds.read(array_back);
-        std::cout << "First item is '" << array_back[0] << "'" << std::endl
-                  << "Second item is '" << array_back[1] << "'" << std::endl;
-
-
-    } catch (const Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
-    }
-
-    return 0;  // successfully terminated
+    return 0;
 }

--- a/src/examples/read_write_raw_ptr.cpp
+++ b/src/examples/read_write_raw_ptr.cpp
@@ -15,8 +15,8 @@
 #include <highfive/H5DataSet.hpp>
 #include <highfive/H5DataSpace.hpp>
 
-const std::string FILE_NAME("read_write_raw_ptr.h5");
-const std::string DATASET_NAME("array");
+const std::string file_name("read_write_raw_ptr.h5");
+const std::string dataset_name("array");
 
 // This create a "multi-dimensional" array. Meaning a pointer with
 // dimensions. The `std::vector<double>` is mearly a convenient way
@@ -40,41 +40,35 @@ std::vector<double> make_array(const std::vector<size_t>& dims) {
 
 int main(void) {
     using namespace HighFive;
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // Let's write to file.
-        {
-            std::vector<size_t> dims{3, 5};
-            auto nd_array = make_array(dims);
+    // Create a new file using the default property lists.
+    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
-            // First, create a dataset with the correct dimensions.
-            auto dataset = file.createDataSet<double>(DATASET_NAME, DataSpace(dims));
+    // Let's write to file.
+    {
+        std::vector<size_t> dims{3, 5};
+        auto nd_array = make_array(dims);
 
-            // Then write, using the raw pointer.
-            dataset.write_raw(nd_array.data());
-        }
+        // First, create a dataset with the correct dimensions.
+        auto dataset = file.createDataSet<double>(dataset_name, DataSpace(dims));
 
-        // Let's read from file.
-        {
-            auto dataset = file.getDataSet(DATASET_NAME);
+        // Then write, using the raw pointer.
+        dataset.write_raw(nd_array.data());
+    }
 
-            // First read the dimensions.
-            auto dims = dataset.getDimensions();
+    // Let's read from file.
+    {
+        auto dataset = file.getDataSet(dataset_name);
 
-            // Then allocate memory.
-            auto n_elements = dims[0] * dims[1];
-            auto nd_array = std::vector<double>(n_elements);
+        // First read the dimensions.
+        auto dims = dataset.getDimensions();
 
-            // Finally, read into the memory by passing a raw pointer to the library.
-            dataset.read<double>(nd_array.data());
-        }
+        // Then allocate memory.
+        auto n_elements = dims[0] * dims[1];
+        auto nd_array = std::vector<double>(n_elements);
 
-
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+        // Finally, read into the memory by passing a raw pointer to the library.
+        dataset.read<double>(nd_array.data());
     }
 
     return 0;

--- a/src/examples/read_write_single_scalar.cpp
+++ b/src/examples/read_write_single_scalar.cpp
@@ -14,40 +14,35 @@
 #include <highfive/H5DataSet.hpp>
 #include <highfive/H5DataSpace.hpp>
 
-const std::string FILE_NAME("read_write_scalar.h5");
-const std::string DATASET_NAME("single_scalar");
+const std::string file_name("read_write_scalar.h5");
+const std::string dataset_name("single_scalar");
 
 // Create a dataset name "single_scalar"
 // which contains only the perfect integer number "42"
 //
 int main(void) {
     using namespace HighFive;
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        int perfect_number = 42;
+    // Create a new file using the default property lists.
+    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
-        // Create the dataset
-        DataSet dataset = file.createDataSet<double>(DATASET_NAME, DataSpace::From(perfect_number));
+    int perfect_number = 42;
 
-        // write it
-        dataset.write(perfect_number);
+    // Create the dataset
+    DataSet dataset = file.createDataSet<double>(dataset_name, DataSpace::From(perfect_number));
 
-        // flush everything
-        file.flush();
+    // write it
+    dataset.write(perfect_number);
 
-        // let's read it back
-        int potentially_perfect_number;
+    // flush everything
+    file.flush();
 
-        dataset.read(potentially_perfect_number);
+    // let's read it back
+    int potentially_perfect_number;
 
-        std::cout << "perfect number: " << potentially_perfect_number << std::endl;
+    dataset.read(potentially_perfect_number);
 
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
-    }
+    std::cout << "perfect number: " << potentially_perfect_number << std::endl;
 
     return 0;  // successfully terminated
 }

--- a/src/examples/read_write_vector_dataset.cpp
+++ b/src/examples/read_write_vector_dataset.cpp
@@ -16,14 +16,14 @@
 
 using namespace HighFive;
 
-const std::string FILE_NAME("dataset_integer.h5");
-const std::string DATASET_NAME("dset");
+const std::string file_name("dataset_integer.h5");
+const std::string dataset_name("dset");
 const size_t size_dataset = 20;
 
 // create a dataset 1D from a vector of string
 void write_dataset() {
     // we create a new hdf5 file
-    File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
+    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
     std::vector<int> data(size_dataset);
     for (size_t i = 0; i < data.size(); ++i) {
@@ -32,7 +32,7 @@ void write_dataset() {
 
     // let's create a dataset of native integer with the size of the vector
     // 'data'
-    DataSet dataset = file.createDataSet<int>(DATASET_NAME, DataSpace::From(data));
+    DataSet dataset = file.createDataSet<int>(dataset_name, DataSpace::From(data));
 
     // let's write our vector of int to the HDF5 dataset
     dataset.write(data);
@@ -41,12 +41,12 @@ void write_dataset() {
 // read our data back
 void read_dataset() {
     // we open the existing hdf5 file we created before
-    File file(FILE_NAME, File::ReadOnly);
+    File file(file_name, File::ReadOnly);
 
     std::vector<int> read_data;
 
     // we get the dataset
-    DataSet dataset = file.getDataSet(DATASET_NAME);
+    DataSet dataset = file.getDataSet(dataset_name);
 
     // we convert the hdf5 dataset to a single dimension vector
     dataset.read(read_data);
@@ -58,14 +58,8 @@ void read_dataset() {
 }
 
 int main(void) {
-    try {
-        write_dataset();
-        read_dataset();
+    write_dataset();
+    read_dataset();
 
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
-    }
-
-    return 0;  // successfully terminated
+    return 0;
 }

--- a/src/examples/read_write_vector_dataset_references.cpp
+++ b/src/examples/read_write_vector_dataset_references.cpp
@@ -69,13 +69,8 @@ void read_dataset() {
 }
 
 int main() {
-    try {
-        write_dataset();
-        read_dataset();
+    write_dataset();
+    read_dataset();
 
-    } catch (const HighFive::Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
-    }
-    return 0;  // successfully terminated
+    return 0;
 }

--- a/src/examples/readme_snippet.cpp
+++ b/src/examples/readme_snippet.cpp
@@ -22,9 +22,10 @@ int main() {
         // Read back, with allocating:
         auto data = dataset.read<std::vector<int>>();
 
-        // Because `data` has the correct size, this will
-        // not cause `data` to be reallocated:
-        dataset.read(data);
+        // Because `pre_allocated` has the correct size, this will
+        // not cause `pre_allocated` to be reallocated:
+        auto pre_allocated = std::vector<int>(50);
+        dataset.read(pre_allocated);
     }
 
     return 0;

--- a/src/examples/select_by_id_dataset_cpp11.cpp
+++ b/src/examples/select_by_id_dataset_cpp11.cpp
@@ -15,60 +15,54 @@
 #include <highfive/H5DataSet.hpp>
 #include <highfive/H5DataSpace.hpp>
 
-const std::string FILE_NAME("select_partial_string.h5");
-const std::string DATASET_NAME("message");
+const std::string file_name("select_partial_string.h5");
+const std::string dataset_name("message");
 
 // Create a dataset name "dset" of double 4x6
 //
 int main(void) {
     using namespace HighFive;
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        {
-            // We have a set of string
-            std::vector<std::string> values = {
-                "Cat",
-                "Dog",
-                "Hello",
-                "Tree",
-                "World",
-                "Plane",
-                ", ",
-                "你好",
-                "Tea",
-                "Moon",
-                "صباح جميل",
-                "Spaceship",
-            };
+    // Create a new file using the default property lists.
+    File file(file_name, File::Truncate);
 
-            // let's create a dataset
-            DataSet dataset = file.createDataSet<std::string>(DATASET_NAME,
-                                                              DataSpace::From(values));
+    {
+        // We have a set of string
+        std::vector<std::string> values = {
+            "Cat",
+            "Dog",
+            "Hello",
+            "Tree",
+            "World",
+            "Plane",
+            ", ",
+            "你好",
+            "Tea",
+            "Moon",
+            "صباح جميل",
+            "Spaceship",
+        };
 
-            // and write them
-            dataset.write(values);
+        // let's create a dataset
+        DataSet dataset = file.createDataSet<std::string>(dataset_name, DataSpace::From(values));
+
+        // and write them
+        dataset.write(values);
+    }
+
+    {
+        DataSet dataset = file.getDataSet(dataset_name);
+
+        // now let's read back by cherry pick our interesting string
+        std::vector<std::string> result;
+        // we select only element N° 2 and 5
+        dataset.select(ElementSet({2, 4, 6, 7, 6, 10})).read(result);
+
+        // and display it
+        for (auto i: result) {
+            std::cout << i << " ";
         }
-
-        {
-            DataSet dataset = file.getDataSet(DATASET_NAME);
-
-            // now let's read back by cherry pick our interesting string
-            std::vector<std::string> result;
-            // we select only element N° 2 and 5
-            dataset.select(ElementSet({2, 4, 6, 7, 6, 10})).read(result);
-
-            // and display it
-            for (auto i: result) {
-                std::cout << i << " ";
-            }
-            std::cout << "\n";
-        }
-
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+        std::cout << "\n";
     }
 
     return 0;  // successfully terminated

--- a/src/examples/select_partial_dataset_cpp11.cpp
+++ b/src/examples/select_partial_dataset_cpp11.cpp
@@ -15,41 +15,36 @@
 #include <highfive/H5DataSet.hpp>
 #include <highfive/H5DataSpace.hpp>
 
-const std::string FILE_NAME("select_partial_example.h5");
-const std::string DATASET_NAME("dset");
+const std::string file_name("select_partial_example.h5");
+const std::string dataset_name("dset");
 
 // Create a dataset name "dset" of double 4x6
 //
 int main(void) {
     using namespace HighFive;
-    try {
-        // Create a new file using the default property lists.
-        File file(FILE_NAME, File::ReadWrite | File::Create | File::Truncate);
 
-        // we have some example values in a 2D vector 2x5
-        std::vector<std::vector<double>> values = {{1.0, 2.0, 4.0, 8.0, 16.0},
-                                                   {32.0, 64.0, 128.0, 256.0, 512.0}};
+    // Create a new file using the default property lists.
+    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
-        // let's create a dataset of this size
-        DataSet dataset = file.createDataSet<double>(DATASET_NAME, DataSpace::From(values));
-        // and write them
-        dataset.write(values);
+    // we have some example values in a 2D vector 2x5
+    std::vector<std::vector<double>> values = {{1.0, 2.0, 4.0, 8.0, 16.0},
+                                               {32.0, 64.0, 128.0, 256.0, 512.0}};
 
-        // now we read back 2x2 values after an offset of 0x2
-        std::vector<std::vector<double>> result;
-        dataset.select({0, 2}, {2, 2}).read(result);
+    // let's create a dataset of this size
+    DataSet dataset = file.createDataSet<double>(dataset_name, DataSpace::From(values));
+    // and write them
+    dataset.write(values);
 
-        // we print out 4 values
-        for (auto i: result) {
-            for (auto j: i) {
-                std::cout << " " << j;
-            }
-            std::cout << "\n";
+    // now we read back 2x2 values after an offset of 0x2
+    std::vector<std::vector<double>> result;
+    dataset.select({0, 2}, {2, 2}).read(result);
+
+    // we print out 4 values
+    for (auto i: result) {
+        for (auto j: i) {
+            std::cout << " " << j;
         }
-
-    } catch (Exception& err) {
-        // catch and print any HDF5 error
-        std::cerr << err.what() << std::endl;
+        std::cout << "\n";
     }
 
     return 0;  // successfully terminated


### PR DESCRIPTION
This is a mostly mechanical change to remove the catch-all blocks from the examples. The idea is that if we run them during CI, we'd like to know if they fail.