### PR TITLE
Use codecov in "informational" mode.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 0%
-        threshold: 50%
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
The previous attempt was incomplete and didn't cover patches. This means that we can't commit examples anymore, since those count as no tested.

See https://docs.codecov.com/docs/common-recipe-list