### PR TITLE
Make ci.yml DRYer.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,13 +260,23 @@ jobs:
 
   # Job testing in Windows
   # ======================
-  Windows-2022:
+  Windows:
     runs-on:  ${{matrix.os}}
     strategy:
       matrix:
         os: [ "windows-2022"]
         vs-toolset: [ "v141", "v143" ]
         cxxstd: ["14", "17"]
+
+        include:
+          - os: "windows-2019"
+            vs-toolset: "v142"
+            cxxstd: "14"
+
+          - os: "windows-2019"
+            vs-toolset: "v142"
+            cxxstd: "17"
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -296,39 +306,4 @@ jobs:
       shell: bash -l {0}
       run: ctest --output-on-failure -C $BUILD_TYPE
 
-  Windows-2019:
-    runs-on:  ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ "windows-2019"]
-        vs-toolset: [ "v142" ]
-        cxxstd: ["14", "17"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-
-      - uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: doc/environment.yaml
-          environment-name: win-test
-
-      - name: Build
-        shell: bash -l {0}
-        run: |
-          CMAKE_OPTIONS=(
-            -T ${{matrix.vs-toolset}}
-            -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
-            -DHIGHFIVE_UNIT_TESTS=ON
-            -DHIGHFIVE_USE_BOOST:BOOL=ON
-            -DHIGHFIVE_USE_EIGEN:BOOL=ON
-            -DHIGHFIVE_USE_XTENSOR:BOOL=ON
-            -DHIGHFIVE_TEST_SINGLE_INCLUDES=ON
-          )
-          source $GITHUB_WORKSPACE/.github/build.sh
-
-      - name: Test
-        working-directory: ${{github.workspace}}/build
-        shell: bash -l {0}
-        run: ctest --output-on-failure -C $BUILD_TYPE
 


### PR DESCRIPTION
We use `include:` to run all combinations of Windows, even if they cant' exactly be described by a matrix.