### PR TITLE
Modernize mamba Github Action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: mamba-org/provision-with-micromamba@main
+    - uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: doc/environment.yaml
         environment-name: win-test


### PR DESCRIPTION
Apparently, `provision-with-micromamba` is deprecated and we need to use `setup-micromamba` from now on. There's a migration guide here: https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba