### PR TITLE
Read datatype

### DIFF
--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -112,6 +112,8 @@ class DataType: public Object {
     friend class File;
     friend class DataSet;
     friend class CompoundType;
+    template <typename Derivate>
+    friend class NodeTraits;
 };
 
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -129,6 +129,10 @@ class NodeTraits {
     /// \return the group object
     Group getGroup(const std::string& group_name) const;
 
+    DataType getDataType(
+        const std::string& type_name,
+        const DataTypeAccessProps& accessProps = DataTypeAccessProps::Default()) const;
+
     ///
     /// \brief return the number of leaf objects of the node / group
     /// \return number of leaf objects

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -129,6 +129,10 @@ class NodeTraits {
     /// \return the group object
     Group getGroup(const std::string& group_name) const;
 
+    ///
+    /// \brief open a commited datatype with the name type_name
+    /// \param type_name
+    /// \return the datatype object
     DataType getDataType(
         const std::string& type_name,
         const DataTypeAccessProps& accessProps = DataTypeAccessProps::Default()) const;

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -175,6 +175,19 @@ inline Group NodeTraits<Derivate>::getGroup(const std::string& group_name) const
 }
 
 template <typename Derivate>
+inline DataType NodeTraits<Derivate>::getDataType(const std::string& type_name,
+                                                  const DataTypeAccessProps& accessProps) const {
+    const auto hid = H5Topen2(static_cast<const Derivate*>(this)->getId(),
+                              type_name.c_str(),
+                              accessProps.getId());
+    if (hid < 0) {
+        HDF5ErrMapper::ToException<DataTypeException>(
+            std::string("Unable to open the datatype \"") + type_name + "\":");
+    }
+    return DataType(hid);
+}
+
+template <typename Derivate>
 inline size_t NodeTraits<Derivate>::getNumberObjects() const {
     hsize_t res;
     if (H5Gget_num_objs(static_cast<const Derivate*>(this)->getId(), &res) < 0) {

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -2870,16 +2870,22 @@ TEST_CASE("HighFiveEnum") {
 TEST_CASE("HighFiveReadType") {
     const std::string file_name("readtype_test.h5");
     const std::string datatype_name1("my_type");
+    const std::string datatype_name2("position");
 
     File file(file_name, File::ReadWrite | File::Create | File::Truncate);
 
-    auto t3 = AtomicType<int>();
     CompoundType t1 = create_compound_csl1();
     t1.commit(file, datatype_name1);
 
     CompoundType t2 = file.getDataType(datatype_name1);
 
+    auto t3 = create_enum_position();
+    t3.commit(file, datatype_name2);
+
+    DataType t4 = file.getDataType(datatype_name2);
+
     CHECK(t2 == t1);
+    CHECK(t4 == t3);
 }
 
 TEST_CASE("HighFiveFixedString") {

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -2867,6 +2867,21 @@ TEST_CASE("HighFiveEnum") {
     }
 }
 
+TEST_CASE("HighFiveReadType") {
+    const std::string file_name("readtype_test.h5");
+    const std::string datatype_name1("my_type");
+
+    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
+
+    auto t3 = AtomicType<int>();
+    CompoundType t1 = create_compound_csl1();
+    t1.commit(file, datatype_name1);
+
+    CompoundType t2 = file.getDataType(datatype_name1);
+
+    CHECK(t2 == t1);
+}
+
 TEST_CASE("HighFiveFixedString") {
     const std::string file_name("array_atomic_types.h5");
     const std::string group_1("group1");


### PR DESCRIPTION
**Description**

HighFive provides the ability to commit datatypes to files with CompoundType::commit for example but does not provide the ability to open the previously commited datatypes.
This PR enhance the Node Traits to get the datatype stored in that node.

**How to test this?**

```bash
cmake ..
make -j8
make test
```

**Test System**
-OS: Ubuntu 22.04.2 LTS (WSL)
-Compiler: gcc 11.3.0
-Dependency versions: hdf5 1.10.7
