### PR TITLE
Allow Buffers to depend on the file datatype.

### DIFF
--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -61,8 +61,9 @@ inline T Attribute::read() const {
 template <typename T>
 inline void Attribute::read(T& array) const {
     const DataSpace& mem_space = getMemSpace();
+    auto file_datatype = getDataType();
     const details::BufferInfo<T> buffer_info(
-        getDataType(),
+        file_datatype,
         [this]() -> std::string { return this->getName(); },
         details::BufferInfo<T>::read);
 
@@ -82,7 +83,7 @@ inline void Attribute::read(T& array) const {
         return;
     }
 
-    auto r = details::data_converter::get_reader<T>(dims, array);
+    auto r = details::data_converter::get_reader<T>(dims, array, file_datatype);
     read(r.get_pointer(), buffer_info.data_type);
     // re-arrange results
     r.unserialize(array);
@@ -125,8 +126,10 @@ inline void Attribute::write(const T& buffer) {
         return;
     }
 
+    auto file_datatype = getDataType();
+
     const details::BufferInfo<T> buffer_info(
-        getDataType(),
+        file_datatype,
         [this]() -> std::string { return this->getName(); },
         details::BufferInfo<T>::write);
 
@@ -136,7 +139,7 @@ inline void Attribute::write(const T& buffer) {
            << " into dataset of dimensions " << mem_space.getNumberDimensions();
         throw DataSpaceException(ss.str());
     }
-    auto w = details::data_converter::serialize<T>(buffer);
+    auto w = details::data_converter::serialize<T>(buffer, file_datatype);
     write_raw(w.get_pointer(), buffer_info.data_type);
 }
 

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -172,8 +172,10 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
     const auto& slice = static_cast<const Derivate&>(*this);
     const DataSpace& mem_space = slice.getMemSpace();
 
+    auto file_datatype = slice.getDataType();
+
     const details::BufferInfo<T> buffer_info(
-        slice.getDataType(),
+        file_datatype,
         [&slice]() -> std::string { return details::get_dataset(slice).getPath(); },
         details::BufferInfo<T>::Operation::read);
 
@@ -193,7 +195,7 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
         return;
     }
 
-    auto r = details::data_converter::get_reader<T>(dims, array);
+    auto r = details::data_converter::get_reader<T>(dims, array, file_datatype);
     read(r.get_pointer(), buffer_info.data_type, xfer_props);
     // re-arrange results
     r.unserialize(array);
@@ -251,8 +253,10 @@ inline void SliceTraits<Derivate>::write(const T& buffer, const DataTransferProp
         return;
     }
 
+    auto file_datatype = slice.getDataType();
+
     const details::BufferInfo<T> buffer_info(
-        slice.getDataType(),
+        file_datatype,
         [&slice]() -> std::string { return details::get_dataset(slice).getPath(); },
         details::BufferInfo<T>::Operation::write);
 
@@ -263,7 +267,7 @@ inline void SliceTraits<Derivate>::write(const T& buffer, const DataTransferProp
            << " into dataset with n = " << buffer_info.n_dimensions << " dimensions.";
         throw DataSpaceException(ss.str());
     }
-    auto w = details::data_converter::serialize<T>(buffer);
+    auto w = details::data_converter::serialize<T>(buffer, file_datatype);
     write_raw(w.get_pointer(), buffer_info.data_type, xfer_props);
 }
 


### PR DESCRIPTION
The upcoming `StringBuffer` will need to know the file datatype, because in HDF5 the expect datalayout, and therefore the way the buffer is populated, is different for fixed and variable length strings.