### PR TITLE
Distinguish between buffer pointer and iterator.

### DIFF
--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -84,7 +84,7 @@ inline void Attribute::read(T& array) const {
     }
 
     auto r = details::data_converter::get_reader<T>(dims, array, file_datatype);
-    read(r.get_pointer(), buffer_info.data_type);
+    read(r.getPointer(), buffer_info.data_type);
     // re-arrange results
     r.unserialize(array);
     auto t = create_datatype<typename details::inspector<T>::base_type>();
@@ -92,10 +92,10 @@ inline void Attribute::read(T& array) const {
     if (c == DataTypeClass::VarLen || t.isVariableStr()) {
 #if H5_VERSION_GE(1, 12, 0)
         // This one have been created in 1.12.0
-        (void) H5Treclaim(t.getId(), mem_space.getId(), H5P_DEFAULT, r.get_pointer());
+        (void) H5Treclaim(t.getId(), mem_space.getId(), H5P_DEFAULT, r.getPointer());
 #else
         // This one is deprecated since 1.12.0
-        (void) H5Dvlen_reclaim(t.getId(), mem_space.getId(), H5P_DEFAULT, r.get_pointer());
+        (void) H5Dvlen_reclaim(t.getId(), mem_space.getId(), H5P_DEFAULT, r.getPointer());
 #endif
     }
 }
@@ -140,7 +140,7 @@ inline void Attribute::write(const T& buffer) {
         throw DataSpaceException(ss.str());
     }
     auto w = details::data_converter::serialize<T>(buffer, file_datatype);
-    write_raw(w.get_pointer(), buffer_info.data_type);
+    write_raw(w.getPointer(), buffer_info.data_type);
 }
 
 template <typename T>

--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -22,7 +22,6 @@ struct enable_shallow_copy: public std::enable_if<inspector<T>::is_trivially_cop
 template <class T, class V = void>
 struct enable_deep_copy: public std::enable_if<!inspector<T>::is_trivially_copyable, V> {};
 
-
 template <typename T, bool IsReadOnly>
 struct ShallowCopyBuffer {
     using type = unqualified_t<T>;
@@ -36,8 +35,12 @@ struct ShallowCopyBuffer {
     explicit ShallowCopyBuffer(typename std::conditional<IsReadOnly, const T&, T&>::type val)
         : ptr(inspector<T>::data(val)){};
 
-    hdf5_type* get_pointer() const {
+    hdf5_type* getPointer() const {
         return ptr;
+    }
+
+    hdf5_type* begin() const {
+        return getPointer();
     }
 
     void unserialize(T& /* val */) const {
@@ -57,12 +60,20 @@ struct DeepCopyBuffer {
         : buffer(inspector<T>::getSize(_dims))
         , dims(_dims) {}
 
-    hdf5_type* get_pointer() {
+    hdf5_type* getPointer() {
         return buffer.data();
     }
 
-    hdf5_type const* get_pointer() const {
+    hdf5_type const* getPointer() const {
         return buffer.data();
+    }
+
+    hdf5_type* begin() {
+        return getPointer();
+    }
+
+    hdf5_type const* begin() const {
+        return getPointer();
     }
 
     void unserialize(T& val) const {
@@ -92,7 +103,7 @@ template <typename T>
 struct Writer<T, typename enable_deep_copy<T>::type>: public DeepCopyBuffer<T> {
     explicit Writer(const T& val, const DataType& /* file_datatype */)
         : DeepCopyBuffer<T>(inspector<T>::getDimensions(val)) {
-        inspector<T>::serialize(val, this->get_pointer());
+        inspector<T>::serialize(val, this->begin());
     }
 };
 

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -196,7 +196,7 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
     }
 
     auto r = details::data_converter::get_reader<T>(dims, array, file_datatype);
-    read(r.get_pointer(), buffer_info.data_type, xfer_props);
+    read(r.getPointer(), buffer_info.data_type, xfer_props);
     // re-arrange results
     r.unserialize(array);
     auto t = create_datatype<typename details::inspector<T>::base_type>();
@@ -204,10 +204,10 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
     if (c == DataTypeClass::VarLen || t.isVariableStr()) {
 #if H5_VERSION_GE(1, 12, 0)
         // This one have been created in 1.12.0
-        (void) H5Treclaim(t.getId(), mem_space.getId(), xfer_props.getId(), r.get_pointer());
+        (void) H5Treclaim(t.getId(), mem_space.getId(), xfer_props.getId(), r.getPointer());
 #else
         // This one is deprecated since 1.12.0
-        (void) H5Dvlen_reclaim(t.getId(), mem_space.getId(), xfer_props.getId(), r.get_pointer());
+        (void) H5Dvlen_reclaim(t.getId(), mem_space.getId(), xfer_props.getId(), r.getPointer());
 #endif
     }
 }
@@ -268,7 +268,7 @@ inline void SliceTraits<Derivate>::write(const T& buffer, const DataTransferProp
         throw DataSpaceException(ss.str());
     }
     auto w = details::data_converter::serialize<T>(buffer, file_datatype);
-    write_raw(w.get_pointer(), buffer_info.data_type, xfer_props);
+    write_raw(w.getPointer(), buffer_info.data_type, xfer_props);
 }
 
 


### PR DESCRIPTION
There's a notion of pointer to the first byte of the buffer. This is what one passes to HDF5, e.g. in `H5Dread`. There's also the concept of a iterator which is used for serialization.

Currently, both ideas are represented by an `hdf5_type*`. However, the StringBuffer will need to return proxy objects. This commits splits the notion. Conveniently, we can rename `get_pointer` to the more in-style `getPointer` and hence the compiler checks that we've considered all occurrences of `get_pointer`.