### PR TITLE
Avoid spurious GCC 13 array-bounds warnings.

### DIFF
--- a/include/highfive/bits/H5Inspector_misc.hpp
+++ b/include/highfive/bits/H5Inspector_misc.hpp
@@ -11,6 +11,7 @@
 
 #include <type_traits>
 #include <cstring>
+#include <cassert>
 #include <numeric>
 
 #include "../H5Reference.hpp"
@@ -369,7 +370,10 @@ struct inspector<std::vector<T>> {
         sizes[0] = val.size();
         if (!val.empty()) {
             auto s = inspector<value_type>::getDimensions(val[0]);
-            std::copy(s.begin(), s.end(), sizes.begin() + 1);
+            assert(s.size() + ndim == sizes.size());
+            for (size_t i = 0; i < s.size(); ++i) {
+                sizes[i + ndim] = s[i];
+            }
         }
         return sizes;
     }


### PR DESCRIPTION
Prior to this commit GCC 13 would emit numerous warnings related to `-Warray-bounds`. There are numerous similar have been reported, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56456

This PR replaces the `std::copy` with the equivalent loop.