### PR TITLE
Add and use `<highfive/highfive.hpp>`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It integrates nicely with other CMake projects by defining (and exporting) a Hig
 #### Write a std::vector<int> to 1D HDF5 dataset and read it back
 
 ```c++
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -218,7 +218,7 @@ Okay, on to configure, compile and install. The CMake commands are
 ### Confirming It Works
 We again need a dummy file called `dummy.cpp` with the following contents
 
-    #include <highfive/H5File.hpp>
+    #include <highfive/highfive.hpp>
 
     int main() {
       auto file = HighFive::File("foo.h5", HighFive::File::Create);

--- a/doc/poster/example3.cpp
+++ b/doc/poster/example3.cpp
@@ -1,4 +1,4 @@
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 
 typedef struct {

--- a/doc/poster/example6.cpp
+++ b/doc/poster/example6.cpp
@@ -2,9 +2,7 @@
 
 #include <mpi.h>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 
 int main(int argc, char** argv) {

--- a/doc/poster/example_boost.cpp
+++ b/doc/poster/example_boost.cpp
@@ -1,11 +1,9 @@
 #include <complex>
 
 #define H5_USE_BOOST 1
+#include <highfive/highfive.hpp>
 
 #include <boost/multi_array.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
 
 using complex_t = std::complex<double>;
 

--- a/doc/poster/example_boost_ublas.cpp
+++ b/doc/poster/example_boost_ublas.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 
 #define H5_USE_BOOST 1
+#include <highfive/highfive.hpp>
 
 // In some versions of Boost (starting with 1.64), you have to
 // include the serialization header before ublas
@@ -8,7 +9,6 @@
 
 #include <boost/numeric/ublas/io.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
-#include <highfive/H5File.hpp>
 
 using namespace HighFive;
 

--- a/doc/poster/example_easy_highfive.cpp
+++ b/doc/poster/example_easy_highfive.cpp
@@ -1,4 +1,5 @@
 #include <xtensor/xarray.hpp>
+
 #include <highfive/H5Easy.hpp>
 
 int main() {

--- a/doc/poster/example_props.cpp
+++ b/doc/poster/example_props.cpp
@@ -1,4 +1,4 @@
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/include/highfive/highfive.hpp
+++ b/include/highfive/highfive.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <highfive/H5Attribute.hpp>
+#include <highfive/H5DataSet.hpp>
+#include <highfive/H5DataSpace.hpp>
+#include <highfive/H5DataType.hpp>
+#include <highfive/H5File.hpp>
+#include <highfive/H5FileDriver.hpp>
+#include <highfive/H5Group.hpp>
+#include <highfive/H5PropertyList.hpp>
+#include <highfive/H5Reference.hpp>
+#include <highfive/H5Selection.hpp>
+#include <highfive/H5Utility.hpp>
+#include <highfive/H5Version.hpp>

--- a/src/benchmarks/highfive_bench.cpp
+++ b/src/benchmarks/highfive_bench.cpp
@@ -1,4 +1,4 @@
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 #include <vector>
 
 const std::vector<std::vector<int>> data(1000000, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});

--- a/src/examples/boost_multi_array_2D.cpp
+++ b/src/examples/boost_multi_array_2D.cpp
@@ -12,7 +12,7 @@
 #define H5_USE_BOOST
 
 #include <boost/multi_array.hpp>
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/boost_multiarray_complex.cpp
+++ b/src/examples/boost_multiarray_complex.cpp
@@ -12,10 +12,9 @@
 #undef H5_USE_BOOST
 #define H5_USE_BOOST
 
+#include <highfive/highfive.hpp>
+
 #include <boost/multi_array.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
 
 typedef std::complex<double> complex_t;
 

--- a/src/examples/boost_ublas_double.cpp
+++ b/src/examples/boost_ublas_double.cpp
@@ -11,13 +11,14 @@
 #undef H5_USE_BOOST
 #define H5_USE_BOOST
 
+#include <highfive/highfive.hpp>
+
 // In some versions of Boost (starting with 1.64), you have to include the serialization header
 // before ublas
 #include <boost/serialization/vector.hpp>
 
 #include <boost/numeric/ublas/io.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
-#include <highfive/H5File.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/compound_types.cpp
+++ b/src/examples/compound_types.cpp
@@ -10,7 +10,7 @@
 // Compound datatype test :: May 2021
 // //////////////////////////////////
 
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 
 typedef struct {

--- a/src/examples/create_attribute_string_integer.cpp
+++ b/src/examples/create_attribute_string_integer.cpp
@@ -10,10 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5Attribute.hpp>
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/create_dataset_double.cpp
+++ b/src/examples/create_dataset_double.cpp
@@ -10,9 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 // Create a dataset name "dset" of double 4x6
 int main(void) {

--- a/src/examples/create_dataset_half_float.cpp
+++ b/src/examples/create_dataset_half_float.cpp
@@ -13,9 +13,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string FILE_NAME("create_dataset_half_float_example.h5");
 const std::string DATASET_NAME("dset");

--- a/src/examples/create_datatype.cpp
+++ b/src/examples/create_datatype.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataType.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/create_extensible_dataset.cpp
+++ b/src/examples/create_extensible_dataset.cpp
@@ -10,9 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string FILE_NAME("create_extensible_dataset_example.h5");
 const std::string DATASET_NAME("dset");

--- a/src/examples/create_large_attribute.cpp
+++ b/src/examples/create_large_attribute.cpp
@@ -1,8 +1,7 @@
-#include <H5Fpublic.h>
-#include <highfive/H5File.hpp>
-#include <highfive/H5Group.hpp>
 #include <numeric>
 #include <vector>
+
+#include <highfive/highfive.hpp>
 
 int main() {
     std::vector<double> large_attr(16000, 0.0);

--- a/src/examples/create_page_allocated_files.cpp
+++ b/src/examples/create_page_allocated_files.cpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 // This example requires HDF5 version 1.10.1 or newer.
 #if H5_VERSION_GE(1, 10, 1)

--- a/src/examples/hl_hdf5_inmemory_files.cpp
+++ b/src/examples/hl_hdf5_inmemory_files.cpp
@@ -9,8 +9,8 @@
 #include <iostream>
 #include <vector>
 
+#include <highfive/highfive.hpp>
 
-#include <highfive/H5File.hpp>
 #include <hdf5_hl.h>
 
 using namespace HighFive;

--- a/src/examples/parallel_hdf5_collective_io.cpp
+++ b/src/examples/parallel_hdf5_collective_io.cpp
@@ -13,10 +13,7 @@
 
 #include <mpi.h>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
-#include <highfive/H5PropertyList.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string file_name("parallel_collective_example.h5");
 const std::string dataset_name("dset");

--- a/src/examples/parallel_hdf5_independent_io.cpp
+++ b/src/examples/parallel_hdf5_independent_io.cpp
@@ -13,10 +13,7 @@
 
 #include <mpi.h>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
-#include <highfive/H5PropertyList.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string file_name("parallel_independent_example.h5");
 

--- a/src/examples/read_write_dataset_string.cpp
+++ b/src/examples/read_write_dataset_string.cpp
@@ -10,9 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/read_write_fixedlen_string.cpp
+++ b/src/examples/read_write_fixedlen_string.cpp
@@ -9,9 +9,7 @@
 #include <iostream>
 #include <string>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/read_write_raw_ptr.cpp
+++ b/src/examples/read_write_raw_ptr.cpp
@@ -11,9 +11,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string file_name("read_write_raw_ptr.h5");
 const std::string dataset_name("array");

--- a/src/examples/read_write_single_scalar.cpp
+++ b/src/examples/read_write_single_scalar.cpp
@@ -10,9 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string file_name("read_write_scalar.h5");
 const std::string dataset_name("single_scalar");

--- a/src/examples/read_write_vector_dataset.cpp
+++ b/src/examples/read_write_vector_dataset.cpp
@@ -10,9 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/read_write_vector_dataset_references.cpp
+++ b/src/examples/read_write_vector_dataset_references.cpp
@@ -10,10 +10,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
-#include <highfive/H5Reference.hpp>
+#include <highfive/highfive.hpp>
 
 // create a dataset 1D from a vector of int
 void write_dataset() {

--- a/src/examples/readme_snippet.cpp
+++ b/src/examples/readme_snippet.cpp
@@ -1,4 +1,4 @@
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/renaming_objects.cpp
+++ b/src/examples/renaming_objects.cpp
@@ -1,8 +1,4 @@
-#include <highfive/H5File.hpp>
-#include <highfive/H5Group.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5Attribute.hpp>
+#include <highfive/highfive.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/select_by_id_dataset_cpp11.cpp
+++ b/src/examples/select_by_id_dataset_cpp11.cpp
@@ -11,9 +11,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string file_name("select_partial_string.h5");
 const std::string dataset_name("message");

--- a/src/examples/select_partial_dataset_cpp11.cpp
+++ b/src/examples/select_partial_dataset_cpp11.cpp
@@ -11,9 +11,7 @@
 #include <string>
 #include <vector>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
+#include <highfive/highfive.hpp>
 
 const std::string file_name("select_partial_example.h5");
 const std::string dataset_name("dset");

--- a/tests/test_dependent_library/include/simpleton.hpp
+++ b/tests/test_dependent_library/include/simpleton.hpp
@@ -3,21 +3,7 @@
 
 // Include all headers here to catch any missing `inline` statements, since
 // they will be included by two different compilation units.
-#include <highfive/H5Attribute.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5DataType.hpp>
-#include <highfive/H5Easy.hpp>
-#include <highfive/H5Exception.hpp>
-#include <highfive/H5File.hpp>
-#include <highfive/H5FileDriver.hpp>
-#include <highfive/H5Group.hpp>
-#include <highfive/H5Object.hpp>
-#include <highfive/H5PropertyList.hpp>
-#include <highfive/H5Reference.hpp>
-#include <highfive/H5Selection.hpp>
-#include <highfive/H5Utility.hpp>
-#include <highfive/H5Version.hpp>
+#include <highfive/highfive.hpp>
 
 // Boost should always be found in this setup
 #include <boost/numeric/ublas/matrix.hpp>

--- a/tests/unit/test_all_types.cpp
+++ b/tests/unit/test_all_types.cpp
@@ -8,15 +8,9 @@
  */
 #include <string>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
-#include <highfive/H5Group.hpp>
-#include <highfive/H5Reference.hpp>
-#include <highfive/H5Utility.hpp>
-
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <highfive/highfive.hpp>
 #include "tests_high_five.hpp"
 
 using namespace HighFive;

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -18,18 +18,11 @@
 #include <typeinfo>
 #include <vector>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5File.hpp>
-#include <highfive/H5Group.hpp>
-#include <highfive/H5Reference.hpp>
-#include <highfive/H5Utility.hpp>
-#include <highfive/H5Version.hpp>
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 
+#include <highfive/highfive.hpp>
 #include "tests_high_five.hpp"
 
 using namespace HighFive;

--- a/tests/unit/tests_high_five_multi_dims.cpp
+++ b/tests/unit/tests_high_five_multi_dims.cpp
@@ -10,8 +10,7 @@
 #include <string>
 #include <iostream>
 
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5File.hpp>
+#include <highfive/highfive.hpp>
 
 
 #ifdef H5_USE_BOOST

--- a/tests/unit/tests_high_five_parallel.cpp
+++ b/tests/unit/tests_high_five_parallel.cpp
@@ -13,15 +13,11 @@
 #include <typeinfo>
 #include <vector>
 
-#include <highfive/H5File.hpp>
-#include <highfive/H5DataSet.hpp>
-#include <highfive/H5DataSpace.hpp>
-#include <highfive/H5Group.hpp>
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_session.hpp>
 
+#include <highfive/highfive.hpp>
 #include "tests_high_five.hpp"
 
 using namespace HighFive;


### PR DESCRIPTION
The header `<highfive/highfive.hpp>` is the top-level header for everything HighFive. It's recommended to use it instead of the other headers, unless compilation time is a concern. However, currently `<highfive/H5File.hpp>` includes almost all of HighFive. Hence, the savings are likely very modest, if any.

