### PR TITLE
Include `H5Version.hpp` in the sources.

### DIFF
--- a/.github/workflows/version_file.yml
+++ b/.github/workflows/version_file.yml
@@ -1,0 +1,36 @@
+name: HighFive Check Version File
+
+on:
+  push:
+    branches:
+      - ci_test
+      - release/**
+  pull_request:
+    branches:
+      - master
+      - release/**
+
+jobs:
+  CheckVersion:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: "Install libraries"
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get -qq install libhdf5-dev ninja-build
+
+    - name: Build
+      run: |
+        # Will trigger `configure_file` for H5Version.hpp.
+        cmake -DHIGHFIVE_USE_BOOST=Off -B build .
+
+    - name: Test
+      run: |
+        # Check that the file hasn't changed, i.e. was updated
+        # after changing the version number.
+        ! git status | grep include/highfive/H5Version.hpp

--- a/CMake/HighFiveTargetExport.cmake
+++ b/CMake/HighFiveTargetExport.cmake
@@ -4,7 +4,6 @@ add_library(libheaders INTERFACE)
 
 target_include_directories(libheaders INTERFACE
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
-  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 
 # Combined HighFive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 project(HighFive VERSION 2.7.1)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp.in
-               ${CMAKE_CURRENT_BINARY_DIR}/include/highfive/H5Version.hpp)
+               ${CMAKE_CURRENT_SOURCE_DIR}/include/highfive/H5Version.hpp)
 # INCLUDES
 list(APPEND CMAKE_MODULE_PATH
   ${CMAKE_CURRENT_SOURCE_DIR}/CMake
@@ -102,11 +102,6 @@ include(${PROJECT_SOURCE_DIR}/CMake/HighFiveTargetExport.cmake)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
   DESTINATION "include"
   PATTERN "*.in" EXCLUDE)
-
-# Installation of configured headers
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
-  DESTINATION "include")
-
 
 # Preparing local building (tests, examples)
 # ------------------------------------------

--- a/include/highfive/H5Version.hpp
+++ b/include/highfive/H5Version.hpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c), 2020
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#pragma once
+
+#define HIGHFIVE_VERSION_MAJOR 2
+#define HIGHFIVE_VERSION_MINOR 7
+#define HIGHFIVE_VERSION_PATCH 1
+
+/** \brief Concatenated representation of the HighFive version.
+ *
+ *  \warning The macro `HIGHFIVE_VERSION` by itself isn't valid C/C++.
+ *
+ *  However, it can be stringified with two layers of macros, e.g.,
+ *  \code{.cpp}
+ *  #define STRINGIFY_VALUE(s) STRINGIFY_NAME(s)
+ *  #define STRINGIFY_NAME(s) #s
+ *
+ *  std::cout << STRINGIFY_VALUE(HIGHFIVE_VERSION) << "\n";
+ *  \endcode
+ */
+#define HIGHFIVE_VERSION 2.7.1
+
+/** \brief String representation of the HighFive version.
+ *
+ *  \warning This macro only exists from 2.7.1 onwards.
+ */
+#define HIGHFIVE_VERSION_STRING "2.7.1"


### PR DESCRIPTION
Generated files require users to "build" and "install" HighFive, for the sole purpose of having files generated via `configure_file` available. The only file that generated in HighFive is the version file.

This PR proposes to automatically generate the file but also commit it to the repo. The advantage of doing so, is that users can clone the repo, set the appropriate value for `-I` and they're done (if they don't need any addons).

In order to check that the version number in `CMakeLists.txt` and `H5Version.hpp` are consistent we configure HighFive during CI and check that the file hasn't changed.