### PR TITLE
Use unique filenames in tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
 
 
   # Job testing several versions of hdf5
@@ -118,7 +118,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
 
 
     - name: Examples
@@ -156,7 +156,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
 
     - name: Examples
       working-directory: ${{github.workspace}}/build/src/examples
@@ -199,7 +199,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
 
     - name: Examples
       working-directory: ${{github.workspace}}/build/src/examples
@@ -295,7 +295,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
 
     - name: Examples
       working-directory: ${{github.workspace}}/build/src/examples
@@ -348,4 +348,4 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash -l {0}
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest -j2 --output-on-failure -C $BUILD_TYPE

--- a/tests/unit/test_all_types.cpp
+++ b/tests/unit/test_all_types.cpp
@@ -22,7 +22,7 @@
 using namespace HighFive;
 
 TEMPLATE_TEST_CASE("Scalar in DataSet", "[Types]", bool, std::string) {
-    const std::string FILE_NAME("Test_type.h5");
+    const std::string FILE_NAME("rw_dataset" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     TestType t1{};
 
@@ -52,7 +52,7 @@ TEMPLATE_TEST_CASE("Scalar in DataSet", "[Types]", bool, std::string) {
 }
 
 TEMPLATE_PRODUCT_TEST_CASE("Scalar in std::vector", "[Types]", std::vector, (bool, std::string)) {
-    const std::string FILE_NAME("Test_vector.h5");
+    const std::string FILE_NAME("rw_dataset" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     TestType t1(5);
 
@@ -84,7 +84,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Scalar in std::vector<std::vector>",
                            "[Types]",
                            std::vector,
                            (bool, std::string)) {
-    const std::string FILE_NAME("Test_vector_vector.h5");
+    const std::string FILE_NAME("rw_dataset_vector_" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     std::vector<TestType> t1(5);
     for (auto&& e: t1) {
@@ -118,7 +118,7 @@ TEMPLATE_PRODUCT_TEST_CASE("Scalar in std::vector<std::vector>",
 }
 
 TEMPLATE_TEST_CASE("Scalar in std::array", "[Types]", bool, std::string) {
-    const std::string FILE_NAME("Test_array.h5");
+    const std::string FILE_NAME("rw_dataset_array_" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     std::array<TestType, 5> t1{};
 
@@ -149,7 +149,7 @@ TEMPLATE_TEST_CASE("Scalar in std::array", "[Types]", bool, std::string) {
 }
 
 TEMPLATE_TEST_CASE("Scalar in std::vector<std::array>", "[Types]", bool, std::string) {
-    const std::string FILE_NAME("Test_vector_array.h5");
+    const std::string FILE_NAME("rw_dataset_vector_array_" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     std::vector<std::array<TestType, 6>> t1(5);
 
@@ -182,7 +182,7 @@ TEMPLATE_TEST_CASE("Scalar in std::vector<std::array>", "[Types]", bool, std::st
 
 #if HIGHFIVE_CXX_STD >= 17
 TEMPLATE_PRODUCT_TEST_CASE("Scalar in std::vector<std::byte>", "[Types]", std::vector, std::byte) {
-    const std::string FILE_NAME("Test_vector_byte.h5");
+    const std::string FILE_NAME("rw_dataset_vector_" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     TestType t1(5, std::byte(0xCD));
 

--- a/tests/unit/test_all_types.cpp
+++ b/tests/unit/test_all_types.cpp
@@ -22,7 +22,7 @@
 using namespace HighFive;
 
 TEMPLATE_TEST_CASE("Scalar in DataSet", "[Types]", bool, std::string) {
-    const std::string FILE_NAME("rw_dataset" + typeNameHelper<TestType>() + ".h5");
+    const std::string FILE_NAME("rw_dataset_" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     TestType t1{};
 
@@ -52,7 +52,7 @@ TEMPLATE_TEST_CASE("Scalar in DataSet", "[Types]", bool, std::string) {
 }
 
 TEMPLATE_PRODUCT_TEST_CASE("Scalar in std::vector", "[Types]", std::vector, (bool, std::string)) {
-    const std::string FILE_NAME("rw_dataset" + typeNameHelper<TestType>() + ".h5");
+    const std::string FILE_NAME("rw_dataset_" + typeNameHelper<TestType>() + ".h5");
     const std::string DATASET_NAME("dset");
     TestType t1(5);
 

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -12,6 +12,9 @@
 #include <string>
 #include <vector>
 #include <tuple>
+#include <sstream>
+#include <functional>
+#include <iomanip>
 
 // We don't need windows specific functionality. However, to better detect defects caused by macros,
 // we include this header.
@@ -162,15 +165,21 @@ struct ContentGenerate<std::string> {
 template <typename T>
 inline std::string typeNameHelper() {
     std::string name = typeid(T).name();
-#if defined(WIN32)
-    // Replace illegal windows file path characters
     std::replace(std::begin(name), std::end(name), ' ', '_');
     std::replace(std::begin(name), std::end(name), '<', '_');
     std::replace(std::begin(name), std::end(name), '>', '_');
     std::replace(std::begin(name), std::end(name), ':', '_');
-#endif
-    return name;
+
+    if (name.size() > 64) {
+        std::stringstream hash;
+        hash << std::hex << std::hash<std::string>{}(name);
+
+        return hash.str();
+    } else {
+        return name;
+    }
 }
+
 
 template <typename ElemT, typename DataT>
 inline HighFive::DataSet readWriteDataset(const DataT& ndvec,

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -318,7 +318,7 @@ TEST_CASE("Test allocation time") {
 }
 
 TEST_CASE("Test default constructors") {
-    const std::string file_name("h5_group_test.h5");
+    const std::string file_name("h5_default_ctors.h5");
     const std::string dataset_name("dset");
     File file(file_name, File::Truncate);
     auto ds = file.createDataSet(dataset_name, std::vector<int>{1, 2, 3, 4, 5});
@@ -2439,7 +2439,7 @@ TEST_CASE("HighFiveHardLinks Group") {
 }
 
 TEST_CASE("HighFiveRename") {
-    File file("move.h5", File::ReadWrite | File::Create | File::Truncate);
+    File file("h5_rename.h5", File::ReadWrite | File::Create | File::Truncate);
 
     int number = 100;
 
@@ -2464,7 +2464,7 @@ TEST_CASE("HighFiveRename") {
 }
 
 TEST_CASE("HighFiveRenameRelative") {
-    File file("move.h5", File::ReadWrite | File::Create | File::Truncate);
+    File file("h5_rename_relative.h5", File::ReadWrite | File::Create | File::Truncate);
     Group group = file.createGroup("group");
 
     int number = 100;

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -56,7 +56,7 @@ TEST_CASE("H5Easy_Compression") {
 }
 
 TEST_CASE("H5Easy_scalar") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_scalar.h5", H5Easy::File::Overwrite);
 
     double a = 1.2345;
     int b = 12345;
@@ -77,7 +77,7 @@ TEST_CASE("H5Easy_scalar") {
 }
 
 TEST_CASE("H5Easy_vector1d") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_vector1d.h5", H5Easy::File::Overwrite);
 
     std::vector<size_t> a = {1, 2, 3, 4, 5};
 
@@ -89,7 +89,7 @@ TEST_CASE("H5Easy_vector1d") {
 }
 
 TEST_CASE("H5Easy_vector2d") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_vector2d.h5", H5Easy::File::Overwrite);
 
     std::vector<std::vector<size_t>> a({{0, 1}, {2, 3}, {4, 5}});
 
@@ -101,7 +101,7 @@ TEST_CASE("H5Easy_vector2d") {
 }
 
 TEST_CASE("H5Easy_vector2d_compression") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_vector2d_compression.h5", H5Easy::File::Overwrite);
 
     std::vector<std::vector<size_t>> a({{0, 1}, {2, 3}, {4, 5}});
 
@@ -118,7 +118,7 @@ TEST_CASE("H5Easy_vector2d_compression") {
 }
 
 TEST_CASE("H5Easy_vector3d") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_vector3d.h5", H5Easy::File::Overwrite);
 
     using type = std::vector<std::vector<std::vector<size_t>>>;
 
@@ -132,7 +132,7 @@ TEST_CASE("H5Easy_vector3d") {
 }
 
 TEST_CASE("H5Easy_Attribute_scalar") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_attribute_scalar.h5", H5Easy::File::Overwrite);
 
     double a = 1.2345;
     int b = 12345;
@@ -155,7 +155,7 @@ TEST_CASE("H5Easy_Attribute_scalar") {
 
 #ifdef H5_USE_XTENSOR
 TEST_CASE("H5Easy_extend1d") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_extend1d.h5", H5Easy::File::Overwrite);
 
     for (size_t i = 0; i < 10; ++i) {
         H5Easy::dump(file, "/path/to/A", i, {i});
@@ -172,7 +172,7 @@ TEST_CASE("H5Easy_extend1d") {
 }
 
 TEST_CASE("H5Easy_extend2d") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_extend2d.h5", H5Easy::File::Overwrite);
 
     for (size_t i = 0; i < 10; ++i) {
         for (size_t j = 0; j < 5; ++j) {
@@ -193,7 +193,7 @@ TEST_CASE("H5Easy_extend2d") {
 }
 
 TEST_CASE("H5Easy_xtensor") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_xtensor.h5", H5Easy::File::Overwrite);
 
     xt::xtensor<double, 2> A = 100. * xt::random::randn<double>({20, 5});
     xt::xtensor<int, 2> B = A;
@@ -209,7 +209,7 @@ TEST_CASE("H5Easy_xtensor") {
 }
 
 TEST_CASE("H5Easy_xarray") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_xarray.h5", H5Easy::File::Overwrite);
 
     xt::xarray<double> A = 100. * xt::random::randn<double>({20, 5});
     xt::xarray<int> B = A;
@@ -225,7 +225,7 @@ TEST_CASE("H5Easy_xarray") {
 }
 
 TEST_CASE("H5Easy_view") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_view.h5", H5Easy::File::Overwrite);
 
     xt::xtensor<double, 2> A = 100. * xt::random::randn<double>({20, 5});
     auto a = xt::view(A, xt::range(0, 10), xt::range(0, 10));
@@ -238,7 +238,7 @@ TEST_CASE("H5Easy_view") {
 }
 
 TEST_CASE("H5Easy_xtensor_compress") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_xtensor_compress.h5", H5Easy::File::Overwrite);
 
     xt::xtensor<double, 2> A = 100. * xt::random::randn<double>({20, 5});
     xt::xtensor<int, 2> B = A;
@@ -260,7 +260,7 @@ TEST_CASE("H5Easy_xtensor_compress") {
 }
 
 TEST_CASE("H5Easy_Attribute_xtensor") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_attribute_xtensor.h5", H5Easy::File::Overwrite);
 
     xt::xtensor<double, 2> A = 100. * xt::random::randn<double>({20, 5});
     xt::xtensor<int, 2> B = A;
@@ -280,7 +280,7 @@ TEST_CASE("H5Easy_Attribute_xtensor") {
 
 #ifdef H5_USE_EIGEN
 TEST_CASE("H5Easy_Eigen_MatrixX") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_eigen_MatrixX.h5", H5Easy::File::Overwrite);
 
     Eigen::MatrixXd A = 100. * Eigen::MatrixXd::Random(20, 5);
     Eigen::MatrixXi B = A.cast<int>();
@@ -296,7 +296,7 @@ TEST_CASE("H5Easy_Eigen_MatrixX") {
 }
 
 TEST_CASE("H5Easy_Eigen_ArrayXX") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_eigen_ArrayXX.h5", H5Easy::File::Overwrite);
 
     Eigen::ArrayXXf A = 100. * Eigen::ArrayXXf::Random(20, 5);
     Eigen::ArrayXXi B = A.cast<int>();
@@ -312,7 +312,7 @@ TEST_CASE("H5Easy_Eigen_ArrayXX") {
 }
 
 TEST_CASE("H5Easy_Eigen_ArrayX") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_eigen_ArrayX.h5", H5Easy::File::Overwrite);
 
     Eigen::ArrayXf A = Eigen::ArrayXf::Random(50);
     Eigen::ArrayXi B = A.cast<int>();
@@ -329,7 +329,7 @@ TEST_CASE("H5Easy_Eigen_ArrayX") {
 
 
 TEST_CASE("H5Easy_Eigen_VectorX") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_eigen_VectorX.h5", H5Easy::File::Overwrite);
 
     Eigen::VectorXd A = 100. * Eigen::VectorXd::Random(20);
     Eigen::VectorXi B = A.cast<int>();
@@ -348,7 +348,7 @@ TEST_CASE("H5Easy_Eigen_MatrixXRowMajor") {
     typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> MatrixXd;
     typedef Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> MatrixXi;
 
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("H5Easy_Eigen_MatrixXRowMajor.h5", H5Easy::File::Overwrite);
 
     MatrixXd A = 100. * MatrixXd::Random(20, 5);
     MatrixXi B = A.cast<int>();
@@ -367,7 +367,7 @@ TEST_CASE("H5Easy_Eigen_VectorXRowMajor") {
     typedef Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor> VectorXd;
     typedef Eigen::Matrix<int, 1, Eigen::Dynamic, Eigen::RowMajor> VectorXi;
 
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_eigen_VectorXRowMajor.h5", H5Easy::File::Overwrite);
 
     VectorXd A = 100. * VectorXd::Random(20);
     VectorXi B = A.cast<int>();
@@ -383,7 +383,7 @@ TEST_CASE("H5Easy_Eigen_VectorXRowMajor") {
 }
 
 TEST_CASE("H5Easy_Eigen_Map") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_eigen_Map.h5", H5Easy::File::Overwrite);
 
     std::vector<int> A = {1, 2, 3, 4, 5, 6, 7, 8, 9};
     Eigen::Map<Eigen::VectorXi> mapped_vector(A.data(), static_cast<int>(A.size()));
@@ -396,7 +396,7 @@ TEST_CASE("H5Easy_Eigen_Map") {
 }
 
 TEST_CASE("H5Easy_Attribute_Eigen_MatrixX") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_attribute_eigen_MatrixX.h5", H5Easy::File::Overwrite);
 
     Eigen::MatrixXd A = 100. * Eigen::MatrixXd::Random(20, 5);
     Eigen::MatrixXi B = A.cast<int>();
@@ -415,7 +415,7 @@ TEST_CASE("H5Easy_Attribute_Eigen_MatrixX") {
 
 #ifdef H5_USE_OPENCV
 TEST_CASE("H5Easy_OpenCV_Mat_") {
-    H5Easy::File file("test.h5", H5Easy::File::Overwrite);
+    H5Easy::File file("h5easy_opencv_Mat_.h5", H5Easy::File::Overwrite);
 
     using T = typename cv::Mat_<double>;
 
@@ -435,6 +435,7 @@ TEST_CASE("H5Easy_OpenCV_Mat_") {
 
     H5Easy::dump(file, "/path/to/A", A);
     H5Easy::dumpAttribute(file, "/path/to/A", "attr", A);
+
 
     T A_r = H5Easy::load<T>(file, "/path/to/A");
     T B_r = H5Easy::loadAttribute<T>(file, "/path/to/A", "attr");


### PR DESCRIPTION
Since HDF5 locks a file, running tests in parallel will fail if the file names aren't unique.