### PR TITLE
H5Easy support for complex integral type

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -300,8 +300,8 @@ class AtomicType<std::complex<T>>: public DataType {
         : DataType(
               CompoundType({{"r", create_datatype<T>(), 0}, {"i", create_datatype<T>(), sizeof(T)}},
                            sizeof(std::complex<T>))) {
-        static_assert(std::is_floating_point<T>::value,
-                      "std::complex accepts only floating point numbers.");
+        static_assert(std::is_floating_point<T>::value or std::is_integral<T>::value,
+                      "std::complex accepts only floating point and integral numbers.");
     }
 };
 

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -300,7 +300,7 @@ class AtomicType<std::complex<T>>: public DataType {
         : DataType(
               CompoundType({{"r", create_datatype<T>(), 0}, {"i", create_datatype<T>(), sizeof(T)}},
                            sizeof(std::complex<T>))) {
-        static_assert(std::is_floating_point<T>::value or std::is_integral<T>::value,
+        static_assert((std::is_floating_point<T>::value) or (std::is_integral<T>::value),
                       "std::complex accepts only floating point and integral numbers.");
     }
 };

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -300,7 +300,7 @@ class AtomicType<std::complex<T>>: public DataType {
         : DataType(
               CompoundType({{"r", create_datatype<T>(), 0}, {"i", create_datatype<T>(), sizeof(T)}},
                            sizeof(std::complex<T>))) {
-        static_assert((std::is_floating_point<T>::value) or (std::is_integral<T>::value),
+        static_assert(std::is_arithmetic<T>::value,
                       "std::complex accepts only floating point and integral numbers.");
     }
 };

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -61,31 +61,47 @@ TEST_CASE("H5Easy_scalar") {
     double a = 1.2345;
     int b = 12345;
     std::string c = "12345";
+    std::complex<double> d = std::complex<double>(1.2345, -5.4321);
+    std::complex<int32_t> e = std::complex<int32_t>(12345, -54321);
 
     H5Easy::dump(file, "/path/to/a", a);
     H5Easy::dump(file, "/path/to/b", b);
     H5Easy::dump(file, "/path/to/c", c);
     H5Easy::dump(file, "/path/to/c", c, H5Easy::DumpMode::Overwrite);
+    H5Easy::dump(file, "/path/to/d", d);
+    H5Easy::dump(file, "/path/to/e", e);
 
     double a_r = H5Easy::load<double>(file, "/path/to/a");
     int b_r = H5Easy::load<int>(file, "/path/to/b");
     std::string c_r = H5Easy::load<std::string>(file, "/path/to/c");
+    std::complex<double> d_r = H5Easy::load<std::complex<double>>(file, "/path/to/d");
+    std::complex<int32_t> e_r = H5Easy::load<std::complex<int32_t>>(file, "/path/to/e");
 
     CHECK(a == a_r);
     CHECK(b == b_r);
     CHECK(c == c_r);
+    CHECK(d == d_r);
+    CHECK(e == e_r);
 }
 
 TEST_CASE("H5Easy_vector1d") {
     H5Easy::File file("h5easy_vector1d.h5", H5Easy::File::Overwrite);
 
     std::vector<size_t> a = {1, 2, 3, 4, 5};
+    std::vector<std::complex<double>> b = {std::complex<double>(1, .1), std::complex<double>(2, -.4), std::complex<double>(3, .9), std::complex<double>(4, -.16), std::complex<double>(5, .25)};
+    std::vector<std::complex<int32_t>> c = {std::complex<int32_t>(1, -5), std::complex<int32_t>(2, -4), std::complex<int32_t>(3, -3), std::complex<int32_t>(4, -2), std::complex<int32_t>(5, -1)};
 
     H5Easy::dump(file, "/path/to/a", a);
+    H5Easy::dump(file, "/path/to/b", b);
+    H5Easy::dump(file, "/path/to/c", c);
 
     std::vector<size_t> a_r = H5Easy::load<std::vector<size_t>>(file, "/path/to/a");
+    std::vector<std::complex<double>> b_r = H5Easy::load<std::vector<std::complex<double>>>(file, "/path/to/b");
+    std::vector<std::complex<int32_t>> c_r = H5Easy::load<std::vector<std::complex<int32_t>>>(file, "/path/to/c");
 
     CHECK(a == a_r);
+    CHECK(b == b_r);
+    CHECK(c == c_r);
 }
 
 TEST_CASE("H5Easy_vector2d") {

--- a/tests/unit/tests_high_five_easy.cpp
+++ b/tests/unit/tests_high_five_easy.cpp
@@ -88,16 +88,26 @@ TEST_CASE("H5Easy_vector1d") {
     H5Easy::File file("h5easy_vector1d.h5", H5Easy::File::Overwrite);
 
     std::vector<size_t> a = {1, 2, 3, 4, 5};
-    std::vector<std::complex<double>> b = {std::complex<double>(1, .1), std::complex<double>(2, -.4), std::complex<double>(3, .9), std::complex<double>(4, -.16), std::complex<double>(5, .25)};
-    std::vector<std::complex<int32_t>> c = {std::complex<int32_t>(1, -5), std::complex<int32_t>(2, -4), std::complex<int32_t>(3, -3), std::complex<int32_t>(4, -2), std::complex<int32_t>(5, -1)};
+    std::vector<std::complex<double>> b = {std::complex<double>(1, .1),
+                                           std::complex<double>(2, -.4),
+                                           std::complex<double>(3, .9),
+                                           std::complex<double>(4, -.16),
+                                           std::complex<double>(5, .25)};
+    std::vector<std::complex<int32_t>> c = {std::complex<int32_t>(1, -5),
+                                            std::complex<int32_t>(2, -4),
+                                            std::complex<int32_t>(3, -3),
+                                            std::complex<int32_t>(4, -2),
+                                            std::complex<int32_t>(5, -1)};
 
     H5Easy::dump(file, "/path/to/a", a);
     H5Easy::dump(file, "/path/to/b", b);
     H5Easy::dump(file, "/path/to/c", c);
 
     std::vector<size_t> a_r = H5Easy::load<std::vector<size_t>>(file, "/path/to/a");
-    std::vector<std::complex<double>> b_r = H5Easy::load<std::vector<std::complex<double>>>(file, "/path/to/b");
-    std::vector<std::complex<int32_t>> c_r = H5Easy::load<std::vector<std::complex<int32_t>>>(file, "/path/to/c");
+    std::vector<std::complex<double>> b_r =
+        H5Easy::load<std::vector<std::complex<double>>>(file, "/path/to/b");
+    std::vector<std::complex<int32_t>> c_r =
+        H5Easy::load<std::vector<std::complex<int32_t>>>(file, "/path/to/c");
 
     CHECK(a == a_r);
     CHECK(b == b_r);


### PR DESCRIPTION
**Description**

Among other functionality, H5Easy allows reading and writing of vectors of standard types.
However, an assertion prevents use of vector of complex integral numbers for `H5Easy::load` and `H5Easy::dump`.

Example:
```
std::vector<std::complex<int16_t>> ds;
ds = H5Easy::load<std::vector<std::complex<int16_t>>>(const File& file, const std::string& path)

H5Easy::dump(const File& file, const std::string& path, ds)
```

This pull request modifies the the assertion to allow integral types and enable H5Easy support for complex integral type.

**How to test this?**
I have tested the modified code in a non-public application for `complex<int16_t>`. ~~I have not tested other cases at this time, but would be happy to extend HighFive test's where appropriate. I am not familiar with the development of this library at this time.~~ Furthermore, this pull requests extends HighFive's unit tests.


**Test System**
 - OS: Debian 12
 - Compiler: gcc 12.2.0
 - (Using hdf5 1.10.8)
