### PR TITLE
fix typo in developer_guide.md

### DIFF
--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -42,7 +42,7 @@ the git repository. Conveniently, `clang-format` is available via `pip`:
 python -m venv venv
 source venv/bin/activate
 
-pip install clang-format=12.0.1
+pip install clang-format==12.0.1
 ```
 
 The changed lines can be formatted with `git-clang-format`, e.g. to format all lines changed compared to master:


### PR DESCRIPTION
**Description**

Adds a missing equal sign to pin the version of clang.

**How to test this?**

Create virtual environment according to current guide...

```
$ pip install clang-format=12.0.1
ERROR: Invalid requirement: 'clang-format=12.0.1'
Hint: = is not a valid operator. Did you mean == ?
```

...versus running it according to the fixed guide:
```
$ pip install clang-format==12.0.1
Collecting clang-format==12.0.1
```
