### PR TITLE
Simplify internal method `_open`.

### DIFF
--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -239,8 +239,7 @@ class NodeTraits {
     bool _exist(const std::string& node_name, bool raise_errors = true) const;
 
     // Opens an arbitrary object to obtain info
-    Object _open(const std::string& node_name,
-                 const DataSetAccessProps& accessProps = DataSetAccessProps::Default()) const;
+    Object _open(const std::string& node_name) const;
 };
 
 

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -396,11 +396,9 @@ inline void NodeTraits<Derivate>::createHardLink(const std::string& link_name,
 
 
 template <typename Derivate>
-inline Object NodeTraits<Derivate>::_open(const std::string& node_name,
-                                          const DataSetAccessProps& accessProps) const {
-    const auto id = H5Oopen(static_cast<const Derivate*>(this)->getId(),
-                            node_name.c_str(),
-                            accessProps.getId());
+inline Object NodeTraits<Derivate>::_open(const std::string& node_name) const {
+    const auto id =
+        H5Oopen(static_cast<const Derivate*>(this)->getId(), node_name.c_str(), H5P_DEFAULT);
     if (id < 0) {
         HDF5ErrMapper::ToException<GroupException>(std::string("Unable to open \"") + node_name +
                                                    "\":");


### PR DESCRIPTION
Avoids #841 since the extra complexity isn't needed.