### PR TITLE
Fail when reference counts are inconsistent.

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -131,7 +131,7 @@ inline StringType DataType::asStringType() const {
         throw DataTypeException("Invalid conversion to StringType.");
     }
 
-    if (isValid() && H5Iinc_ref(_hid) < 0) {
+    if (_hid > 0 && H5Iinc_ref(_hid) < 0) {
         throw ObjectException("Reference counter increase failure");
     }
 

--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -29,7 +29,7 @@ inline Object::Object(hid_t hid)
 
 inline Object::Object(const Object& other)
     : _hid(other._hid) {
-    if (other.isValid() && H5Iinc_ref(_hid) < 0) {
+    if (_hid > 0 && H5Iinc_ref(_hid) < 0) {
         throw ObjectException("Reference counter increase failure");
     }
 }
@@ -41,11 +41,12 @@ inline Object::Object(Object&& other) noexcept
 
 inline Object& Object::operator=(const Object& other) {
     if (this != &other) {
-        if (isValid())
+        if (_hid > 0) {
             H5Idec_ref(_hid);
+        }
 
         _hid = other._hid;
-        if (other.isValid() && H5Iinc_ref(_hid) < 0) {
+        if (_hid > 0 && H5Iinc_ref(_hid) < 0) {
             throw ObjectException("Reference counter increase failure");
         }
     }
@@ -53,13 +54,13 @@ inline Object& Object::operator=(const Object& other) {
 }
 
 inline Object::~Object() {
-    if (isValid() && H5Idec_ref(_hid) < 0) {
+    if (_hid > 0 && H5Idec_ref(_hid) < 0) {
         HIGHFIVE_LOG_ERROR("HighFive::~Object: reference counter decrease failure");
     }
 }
 
 inline bool Object::isValid() const noexcept {
-    return (_hid != H5I_INVALID_HID) && (H5Iis_valid(_hid) != false);
+    return (_hid > 0) && (H5Iis_valid(_hid) != false);
 }
 
 inline hid_t Object::getId() const noexcept {


### PR DESCRIPTION
In HighFive we have two types of invalid HIDs. The first category consists of:
* `H5I_INVALID_HID` which HighFive uses to indicate that the object is "empty",
* `H5P_DEFAULT` (aka `0`) which is to "optimize" the default property.

The second category consists of anything else that `H5Iis_valid` reports as invalid, e.g. identifiers that have been closed, etc.

For the first category we must not increment or decrement the reference counters. However, for the second category, we'd like to get an error, because we're expecting either `H5I_INVALID_HID`, `H5P_DEFAULT` or a valid HID, but are given something else.