### PR TITLE
Check `ctest` output for HDF5-DIAG.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,9 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
+      run: |
+        ctest -j2 --output-on-failure -C $BUILD_TYPE
+        ! ctest --verbose -C $BUILD_TYPE | grep HDF5-DIAG
 
 
   # Job testing several versions of hdf5
@@ -118,7 +120,9 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
+      run: |
+        ctest -j2 --output-on-failure -C $BUILD_TYPE
+        ! ctest --verbose -C $BUILD_TYPE | grep HDF5-DIAG
 
 
     - name: Examples
@@ -156,7 +160,9 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
+      run: |
+        ctest -j2 --output-on-failure -C $BUILD_TYPE
+        ! ctest --verbose -C $BUILD_TYPE | grep HDF5-DIAG
 
     - name: Examples
       working-directory: ${{github.workspace}}/build/src/examples
@@ -199,7 +205,9 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
+      run: |
+        ctest -j2 --output-on-failure -C $BUILD_TYPE
+        ! ctest --verbose -C $BUILD_TYPE | grep HDF5-DIAG
 
     - name: Examples
       working-directory: ${{github.workspace}}/build/src/examples
@@ -295,7 +303,9 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
+      run: |
+        ctest -j2 --output-on-failure -C $BUILD_TYPE
+        ! ctest --verbose -C $BUILD_TYPE | grep HDF5-DIAG
 
     - name: Examples
       working-directory: ${{github.workspace}}/build/src/examples
@@ -348,4 +358,6 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       shell: bash -l {0}
-      run: ctest -j2 --output-on-failure -C $BUILD_TYPE
+      run: |
+        ctest -j2 --output-on-failure -C $BUILD_TYPE
+        ! ctest --verbose -C $BUILD_TYPE | grep HDF5-DIAG

--- a/include/highfive/H5DataType.hpp
+++ b/include/highfive/H5DataType.hpp
@@ -70,7 +70,7 @@ class DataType: public Object {
     /// \brief Returns the length (in bytes) of this type elements
     ///
     /// Notice that the size of variable length sequences may have limited applicability
-    ///   given that it refers to the size of the control structure. For info see
+    /// given that it refers to the size of the control structure. For info see
     ///   https://support.hdfgroup.org/HDF5/doc/RM/RM_H5T.html#Datatype-GetSize
     size_t getSize() const;
 


### PR DESCRIPTION
HDF5 errors that aren't promoted to an exception by HighFive will simply print an error message. This means that tests can pass even if there are HDF5 errors. This will run the tests with `ctest --verbose` and check that the output doesn't contain `"HDF5-DIAG"`.