### PR TITLE
Complete the low-level wrapper of all used HDF5 functions.

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -23,6 +23,7 @@
 
 #include "H5Inspector_misc.hpp"
 #include "h5t_wrapper.hpp"
+#include "h5i_wrapper.hpp"
 
 namespace HighFive {
 
@@ -69,8 +70,8 @@ inline StringType DataType::asStringType() const {
         throw DataTypeException("Invalid conversion to StringType.");
     }
 
-    if (isValid() && H5Iinc_ref(_hid) < 0) {
-        throw ObjectException("Reference counter increase failure");
+    if (isValid()) {
+        detail::h5i_inc_ref(_hid);
     }
 
     return StringType(_hid);

--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -12,6 +12,7 @@
 
 #include "../H5Exception.hpp"
 #include "../H5Utility.hpp"
+#include "h5i_wrapper.hpp"
 
 namespace HighFive {
 namespace detail {
@@ -29,8 +30,8 @@ inline Object::Object(hid_t hid)
 
 inline Object::Object(const Object& other)
     : _hid(other._hid) {
-    if (other.isValid() && H5Iinc_ref(_hid) < 0) {
-        throw ObjectException("Reference counter increase failure");
+    if (other.isValid()) {
+        detail::h5i_inc_ref(_hid);
     }
 }
 
@@ -41,25 +42,28 @@ inline Object::Object(Object&& other) noexcept
 
 inline Object& Object::operator=(const Object& other) {
     if (this != &other) {
-        if (isValid())
-            H5Idec_ref(_hid);
+        if ((*this).isValid()) {
+            detail::h5i_dec_ref(_hid);
+        }
 
         _hid = other._hid;
-        if (other.isValid() && H5Iinc_ref(_hid) < 0) {
-            throw ObjectException("Reference counter increase failure");
+        if (other.isValid()) {
+            detail::h5i_inc_ref(_hid);
         }
     }
     return *this;
 }
 
 inline Object::~Object() {
-    if (isValid() && H5Idec_ref(_hid) < 0) {
-        HIGHFIVE_LOG_ERROR("HighFive::~Object: reference counter decrease failure");
+    if (isValid()) {
+        if (detail::nothrow::h5i_dec_ref(_hid) < 0) {
+            HIGHFIVE_LOG_ERROR("Failed to decrease reference count of HID");
+        }
     }
 }
 
 inline bool Object::isValid() const noexcept {
-    return (_hid != H5I_INVALID_HID) && (H5Iis_valid(_hid) != false);
+    return (_hid > 0) && (detail::nothrow::h5i_is_valid(_hid) > 0);
 }
 
 inline hid_t Object::getId() const noexcept {
@@ -87,11 +91,7 @@ static inline ObjectType _convert_object_type(const H5I_type_t& h5type) {
 
 inline ObjectType Object::getType() const {
     // H5Iget_type is a very lightweight func which extracts the type from the id
-    H5I_type_t h5type;
-    if ((h5type = H5Iget_type(_hid)) == H5I_BADID) {
-        HDF5ErrMapper::ToException<ObjectException>("Invalid hid or object type");
-    }
-    return _convert_object_type(h5type);
+    return _convert_object_type(detail::h5i_get_type(_hid));
 }
 
 inline ObjectInfo Object::getInfo() const {

--- a/include/highfive/bits/H5Path_traits_misc.hpp
+++ b/include/highfive/bits/H5Path_traits_misc.hpp
@@ -21,20 +21,16 @@ inline PathTraits<Derivate>::PathTraits() {
                       std::is_same<Derivate, Attribute>::value,
                   "PathTraits can only be applied to Group, DataSet and Attribute");
     const auto& obj = static_cast<const Derivate&>(*this);
-    if (!obj.isValid()) {
-        return;
+    if (obj.isValid()) {
+        const hid_t file_id = detail::h5i_get_file_id<PropertyException>(obj.getId());
+        _file_obj.reset(new File(file_id));
     }
-    const hid_t file_id = H5Iget_file_id(obj.getId());
-    if (file_id < 0) {
-        HDF5ErrMapper::ToException<PropertyException>("getFile(): Could not obtain file of object");
-    }
-    _file_obj.reset(new File(file_id));
 }
 
 template <typename Derivate>
 inline std::string PathTraits<Derivate>::getPath() const {
     return details::get_name([this](char* buffer, size_t length) {
-        return H5Iget_name(static_cast<const Derivate&>(*this).getId(), buffer, length);
+        return detail::h5i_get_name(static_cast<const Derivate&>(*this).getId(), buffer, length);
     });
 }
 

--- a/include/highfive/bits/H5Reference_misc.hpp
+++ b/include/highfive/bits/H5Reference_misc.hpp
@@ -22,8 +22,9 @@ namespace HighFive {
 
 inline Reference::Reference(const Object& location, const Object& object)
     : parent_id(location.getId()) {
-    obj_name = details::get_name(
-        [&](char* buffer, size_t length) { return H5Iget_name(object.getId(), buffer, length); });
+    obj_name = details::get_name([&](char* buffer, size_t length) {
+        return detail::h5i_get_name(object.getId(), buffer, length);
+    });
 }
 
 inline void Reference::create_ref(hobj_ref_t* refptr) const {

--- a/include/highfive/bits/h5i_wrapper.hpp
+++ b/include/highfive/bits/h5i_wrapper.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <H5Ipublic.h>
+
+namespace HighFive {
+namespace detail {
+inline int h5i_inc_ref(hid_t id) {
+    auto count = H5Iinc_ref(id);
+
+    if (count < 0) {
+        throw ObjectException("Failed to increase reference count of HID");
+    }
+
+    return count;
+}
+
+namespace nothrow {
+
+inline int h5i_dec_ref(hid_t id) {
+    return H5Idec_ref(id);
+}
+
+}  // namespace nothrow
+
+inline int h5i_dec_ref(hid_t id) {
+    int count = H5Idec_ref(id);
+    if (count < 0) {
+        throw ObjectException("Failed to decrease reference count of HID");
+    }
+
+    return count;
+}
+
+namespace nothrow {
+inline htri_t h5i_is_valid(hid_t id) {
+    return H5Iis_valid(id);
+}
+
+}  // namespace nothrow
+
+inline htri_t h5i_is_valid(hid_t id) {
+    htri_t tri = H5Iis_valid(id);
+    if (tri < 0) {
+        throw ObjectException("Failed to check if HID is valid");
+    }
+
+    return tri;
+}
+
+inline H5I_type_t h5i_get_type(hid_t id) {
+    H5I_type_t type = H5Iget_type(id);
+    if (type == H5I_BADID) {
+        HDF5ErrMapper::ToException<ObjectException>("Failed to get type of HID");
+    }
+
+    return type;
+}
+
+template <class Exception>
+inline hid_t h5i_get_file_id(hid_t id) {
+    hid_t file_id = H5Iget_file_id(id);
+    if (file_id < 0) {
+        HDF5ErrMapper::ToException<Exception>("Failed not obtain file HID of object");
+    }
+
+    return file_id;
+}
+
+inline ssize_t h5i_get_name(hid_t id, char* name, size_t size) {
+    ssize_t n_chars = H5Iget_name(id, name, size);
+    if (n_chars < 0) {
+        HDF5ErrMapper::ToException<ObjectException>("Failed to get name of HID.");
+    }
+
+    return n_chars;
+}
+
+}  // namespace detail
+}  // namespace HighFive


### PR DESCRIPTION
This wrapper enables us to see more easily notice that an error code is being ignored, makes it very clear how we wrap HDF5 function and encourages us to not ignore unchecked error codes if we see one. It'll make it easier to have uniform error handling. Additionally, it prepares the way towards more interesting features, such as thread-safety or logging each call to HDF5 (for creating pure HDF5 reproducers).

The rules are:
1. Each HDF5 "function" `H5?*` is wrapped by `detail::h5?_*`. We can't reuse the name in a namespace because some of them are macros.
2. Unless the wrapped function is in the namespace `detail::nothrow` it'll throw whenever the returned value indicates an error.
3. The arguments to `H5?*` and `detail::h5?_*` are identical.
4. Outside of the files `h5?_wrapper.hpp` we don't use any HDF5 functions or function macros.
