### PR TITLE
Fix `create_datatype<bool>()`.

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -541,3 +541,12 @@ inline DataType create_and_check_datatype() {
 
 }  // namespace HighFive
 HIGHFIVE_REGISTER_TYPE(HighFive::details::Boolean, HighFive::create_enum_boolean)
+
+namespace HighFive {
+
+template <>
+inline DataType create_datatype<bool>() {
+    return create_datatype<HighFive::details::Boolean>();
+}
+
+}  // namespace HighFive

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -2962,7 +2962,7 @@ TEST_CASE("DirectWriteBool") {
     bool* expected = new bool[n];
     bool* actual = new bool[n];
 
-    for (size_t i = 0; i < 4; ++i) {
+    for (size_t i = 0; i < n; ++i) {
         expected[i] = i % 2 == 0;
     }
 


### PR DESCRIPTION
Create the specialization from `create_datatype<bool>` and adds the tests to check that raw arrays of bool are bitwise compatible with the enum that's serialized.