### PR TITLE
Macro free dependency handling.

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -520,7 +520,3 @@ inline DataType create_datatype<bool>() {
 }
 
 }  // namespace HighFive
-
-#ifdef H5_USE_HALF_FLOAT
-#include <highfive/half_float.hpp>
-#endif

--- a/include/highfive/bits/H5Inspector_misc.hpp
+++ b/include/highfive/bits/H5Inspector_misc.hpp
@@ -640,11 +640,3 @@ struct inspector<T[N]> {
 
 }  // namespace details
 }  // namespace HighFive
-
-#ifdef H5_USE_BOOST
-#include <highfive/boost.hpp>
-#endif
-
-#ifdef H5_USE_EIGEN
-#include <highfive/eigen.hpp>
-#endif

--- a/include/highfive/boost.hpp
+++ b/include/highfive/boost.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef H5_USE_BOOST
 
 #include "bits/H5Inspector_decl.hpp"
 #include "H5Exception.hpp"
@@ -160,5 +159,3 @@ struct inspector<boost::numeric::ublas::matrix<T>> {
 
 }  // namespace details
 }  // namespace HighFive
-
-#endif

--- a/include/highfive/eigen.hpp
+++ b/include/highfive/eigen.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef H5_USE_EIGEN
 
 #include "bits/H5Inspector_decl.hpp"
 #include "H5Exception.hpp"
@@ -89,5 +88,3 @@ struct inspector<Eigen::Matrix<T, M, N>> {
 
 }  // namespace details
 }  // namespace HighFive
-
-#endif

--- a/include/highfive/half_float.hpp
+++ b/include/highfive/half_float.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#ifdef H5_USE_HALF_FLOAT
 
 #include <half.hpp>
 
@@ -16,6 +15,5 @@ inline AtomicType<float16_t>::AtomicType() {
     // Floating point exponent bias
     detail::h5t_set_ebias(_hid, 15);
 }
-}  // namespace HighFive
 
-#endif
+}  // namespace HighFive

--- a/src/examples/boost_multi_array_2D.cpp
+++ b/src/examples/boost_multi_array_2D.cpp
@@ -8,11 +8,9 @@
  */
 #include <iostream>
 
-#undef H5_USE_BOOST
-#define H5_USE_BOOST
-
 #include <boost/multi_array.hpp>
 #include <highfive/highfive.hpp>
+#include <highfive/boost.hpp>
 
 using namespace HighFive;
 

--- a/src/examples/boost_multiarray_complex.cpp
+++ b/src/examples/boost_multiarray_complex.cpp
@@ -9,12 +9,9 @@
 #include <algorithm>
 #include <complex>
 
-#undef H5_USE_BOOST
-#define H5_USE_BOOST
-
 #include <highfive/highfive.hpp>
 
-#include <boost/multi_array.hpp>
+#include <highfive/boost.hpp>
 
 typedef std::complex<double> complex_t;
 

--- a/src/examples/boost_ublas_double.cpp
+++ b/src/examples/boost_ublas_double.cpp
@@ -8,10 +8,9 @@
  */
 #include <iostream>
 
-#undef H5_USE_BOOST
-#define H5_USE_BOOST
-
 #include <highfive/highfive.hpp>
+
+#include <highfive/boost.hpp>
 
 // In some versions of Boost (starting with 1.64), you have to include the serialization header
 // before ublas

--- a/src/examples/create_dataset_half_float.cpp
+++ b/src/examples/create_dataset_half_float.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <highfive/highfive.hpp>
+#include <highfive/half_float.hpp>
 
 const std::string FILE_NAME("create_dataset_half_float_example.h5");
 const std::string DATASET_NAME("dset");

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -46,6 +46,18 @@ option(HIGHFIVE_TEST_SINGLE_INCLUDES "Enable testing single includes" FALSE)
 if(HIGHFIVE_TEST_SINGLE_INCLUDES)
     file(GLOB public_headers LIST_DIRECTORIES false RELATIVE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/include/highfive/*.hpp)
     foreach(PUBLIC_HEADER ${public_headers})
+        if(PUBLIC_HEADER STREQUAL "highfive/boost.hpp" AND NOT HIGHFIVE_USE_BOOST)
+          continue()
+        endif()
+
+        if(PUBLIC_HEADER STREQUAL "highfive/half_float.hpp" AND NOT HIGHFIVE_USE_HALF_FLOAT)
+          continue()
+        endif()
+
+        if(PUBLIC_HEADER STREQUAL "highfive/eigen.hpp" AND NOT HIGHFIVE_USE_EIGEN)
+          continue()
+        endif()
+
         get_filename_component(CLASS_NAME ${PUBLIC_HEADER} NAME_WE)
         configure_file(tests_import_public_headers.cpp "tests_${CLASS_NAME}.cpp" @ONLY)
         add_executable("tests_include_${CLASS_NAME}" "${CMAKE_CURRENT_BINARY_DIR}/tests_${CLASS_NAME}.cpp")

--- a/tests/unit/data_generator.hpp
+++ b/tests/unit/data_generator.hpp
@@ -8,7 +8,7 @@
 #include <array>
 
 #ifdef H5_USE_BOOST
-#include <boost/multi_array.hpp>
+#include <highfive/boost.hpp>
 #endif
 
 #include <highfive/bits/H5Inspector_misc.hpp>

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -43,6 +43,8 @@ using base_test_types = std::tuple<int,
                                    fcomplex>;
 
 #ifdef H5_USE_HALF_FLOAT
+#include <highfive/half_float.hpp>
+
 using float16_t = half_float::half;
 using numerical_test_types =
     decltype(std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -27,6 +27,15 @@
 #include <highfive/highfive.hpp>
 #include "tests_high_five.hpp"
 
+#ifdef H5_USE_BOOST
+#include <highfive/boost.hpp>
+#endif
+
+#ifdef H5_USE_EIGEN
+#include <highfive/eigen.hpp>
+#endif
+
+
 using namespace HighFive;
 using Catch::Matchers::Equals;
 

--- a/tests/unit/tests_high_five_multi_dims.cpp
+++ b/tests/unit/tests_high_five_multi_dims.cpp
@@ -15,6 +15,7 @@
 
 #ifdef H5_USE_BOOST
 #include <boost/multi_array.hpp>
+#include <highfive/boost.hpp>
 #endif
 
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
Sketch of how we could reorganize our headers to allow each code to pick their dependencies simply by choosing which headers they include. This is similar to how pybind11 handles their convertors between Python types and say STL containers.