### PR TITLE
Restructure dependency handling.

### DIFF
--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -17,10 +17,6 @@
 
 #include <H5Ppublic.h>
 
-#ifdef H5_USE_HALF_FLOAT
-#include <half.hpp>
-#endif
-
 #include "H5Inspector_misc.hpp"
 #include "h5t_wrapper.hpp"
 #include "h5i_wrapper.hpp"
@@ -172,21 +168,6 @@ inline AtomicType<unsigned long long>::AtomicType() {
 }
 
 // half-float, float, double and long double mapping
-#ifdef H5_USE_HALF_FLOAT
-using float16_t = half_float::half;
-
-template <>
-inline AtomicType<float16_t>::AtomicType() {
-    _hid = detail::h5t_copy(H5T_NATIVE_FLOAT);
-    // Sign position, exponent position, exponent size, mantissa position, mantissa size
-    detail::h5t_set_fields(_hid, 15, 10, 5, 0, 10);
-    // Total datatype size (in bytes)
-    detail::h5t_set_size(_hid, 2);
-    // Floating point exponent bias
-    detail::h5t_set_ebias(_hid, 15);
-}
-#endif
-
 template <>
 inline AtomicType<float>::AtomicType() {
     _hid = detail::h5t_copy(H5T_NATIVE_FLOAT);
@@ -539,3 +520,7 @@ inline DataType create_datatype<bool>() {
 }
 
 }  // namespace HighFive
+
+#ifdef H5_USE_HALF_FLOAT
+#include <highfive/half_float.hpp>
+#endif

--- a/include/highfive/bits/H5Inspector_decl.hpp
+++ b/include/highfive/bits/H5Inspector_decl.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <numeric>
+#include <functional>
+#include <vector>
+
+namespace HighFive {
+
+inline size_t compute_total_size(const std::vector<size_t>& dims) {
+    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<size_t>());
+}
+
+template <typename T>
+using unqualified_t = typename std::remove_const<typename std::remove_reference<T>::type>::type;
+
+
+namespace details {
+
+template <typename T>
+struct type_helper;
+
+template <typename T>
+struct inspector;
+
+}  // namespace details
+}  // namespace HighFive

--- a/include/highfive/bits/H5Inspector_misc.hpp
+++ b/include/highfive/bits/H5Inspector_misc.hpp
@@ -21,19 +21,10 @@
 
 #include "string_padding.hpp"
 
-#ifdef H5_USE_BOOST
-#include <boost/multi_array.hpp>
-// starting Boost 1.64, serialization header must come before ublas
-#include <boost/serialization/vector.hpp>
-#include <boost/numeric/ublas/matrix.hpp>
-#endif
-#ifdef H5_USE_EIGEN
-#include <Eigen/Eigen>
-#endif
+#include "H5Inspector_decl.hpp"
 
 
 namespace HighFive {
-
 namespace details {
 
 inline bool checkDimensions(const std::vector<size_t>& dims, size_t n_dim_requested) {
@@ -124,13 +115,6 @@ inline std::vector<size_t> squeezeDimensions(const std::vector<size_t>& dims,
 }
 }  // namespace details
 
-
-inline size_t compute_total_size(const std::vector<size_t>& dims) {
-    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<size_t>());
-}
-
-template <typename T>
-using unqualified_t = typename std::remove_const<typename std::remove_reference<T>::type>::type;
 
 /*****
 inspector<T> {
@@ -632,232 +616,13 @@ struct inspector<T[N]> {
     }
 };
 
-#ifdef H5_USE_EIGEN
-template <typename T, int M, int N>
-struct inspector<Eigen::Matrix<T, M, N>> {
-    using type = Eigen::Matrix<T, M, N>;
-    using value_type = T;
-    using base_type = typename inspector<value_type>::base_type;
-    using hdf5_type = base_type;
-
-    static constexpr size_t ndim = 2;
-    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
-    static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
-                                                  inspector<value_type>::is_trivially_copyable;
-
-
-    static void assert_not_buggy(Eigen::Index nrows, Eigen::Index ncols) {
-        if (nrows > 1 && ncols > 1) {
-            throw std::runtime_error(
-                "HighFive has been broken for Eigen::Matrix. Please check "
-                "https://github.com/BlueBrain/HighFive/issues/532.");
-        }
-    }
-
-    static std::vector<size_t> getDimensions(const type& val) {
-        assert_not_buggy(val.rows(), val.cols());
-
-        std::vector<size_t> sizes{static_cast<size_t>(val.rows()), static_cast<size_t>(val.cols())};
-        auto s = inspector<value_type>::getDimensions(val.data()[0]);
-        sizes.insert(sizes.end(), s.begin(), s.end());
-        return sizes;
-    }
-
-    static size_t getSizeVal(const type& val) {
-        return compute_total_size(getDimensions(val));
-    }
-
-    static size_t getSize(const std::vector<size_t>& dims) {
-        return compute_total_size(dims);
-    }
-
-    static void prepare(type& val, const std::vector<size_t>& dims) {
-        if (dims[0] != static_cast<size_t>(val.rows()) ||
-            dims[1] != static_cast<size_t>(val.cols())) {
-            val.resize(static_cast<typename type::Index>(dims[0]),
-                       static_cast<typename type::Index>(dims[1]));
-        }
-
-        assert_not_buggy(val.rows(), val.cols());
-    }
-
-    static hdf5_type* data(type& val) {
-        assert_not_buggy(val.rows(), val.cols());
-        return inspector<value_type>::data(*val.data());
-    }
-
-    static const hdf5_type* data(const type& val) {
-        assert_not_buggy(val.rows(), val.cols());
-        return inspector<value_type>::data(*val.data());
-    }
-
-    static void serialize(const type& val, hdf5_type* m) {
-        assert_not_buggy(val.rows(), val.cols());
-        std::memcpy(m, val.data(), static_cast<size_t>(val.size()) * sizeof(hdf5_type));
-    }
-
-    static void unserialize(const hdf5_type* vec_align,
-                            const std::vector<size_t>& dims,
-                            type& val) {
-        assert_not_buggy(val.rows(), val.cols());
-        if (dims.size() < 2) {
-            std::ostringstream os;
-            os << "Impossible to pair DataSet with " << dims.size()
-               << " dimensions into an eigen-matrix.";
-            throw DataSpaceException(os.str());
-        }
-        std::memcpy(val.data(), vec_align, compute_total_size(dims) * sizeof(hdf5_type));
-    }
-};
-#endif
-
-#ifdef H5_USE_BOOST
-template <typename T, size_t Dims>
-struct inspector<boost::multi_array<T, Dims>> {
-    using type = boost::multi_array<T, Dims>;
-    using value_type = T;
-    using base_type = typename inspector<value_type>::base_type;
-    using hdf5_type = typename inspector<value_type>::hdf5_type;
-
-    static constexpr size_t ndim = Dims;
-    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
-    static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
-                                                  inspector<value_type>::is_trivially_copyable;
-
-    static std::vector<size_t> getDimensions(const type& val) {
-        std::vector<size_t> sizes;
-        for (size_t i = 0; i < ndim; ++i) {
-            sizes.push_back(val.shape()[i]);
-        }
-        auto s = inspector<value_type>::getDimensions(val.data()[0]);
-        sizes.insert(sizes.end(), s.begin(), s.end());
-        return sizes;
-    }
-
-    static size_t getSizeVal(const type& val) {
-        return compute_total_size(getDimensions(val));
-    }
-
-    static size_t getSize(const std::vector<size_t>& dims) {
-        return compute_total_size(dims);
-    }
-
-    static void prepare(type& val, const std::vector<size_t>& dims) {
-        if (dims.size() < ndim) {
-            std::ostringstream os;
-            os << "Only '" << dims.size() << "' given but boost::multi_array is of size '" << ndim
-               << "'.";
-            throw DataSpaceException(os.str());
-        }
-        boost::array<typename type::index, Dims> ext;
-        std::copy(dims.begin(), dims.begin() + ndim, ext.begin());
-        val.resize(ext);
-        std::vector<size_t> next_dims(dims.begin() + Dims, dims.end());
-        std::size_t size = std::accumulate(dims.begin(),
-                                           dims.begin() + Dims,
-                                           std::size_t{1},
-                                           std::multiplies<size_t>());
-        for (size_t i = 0; i < size; ++i) {
-            inspector<value_type>::prepare(*(val.origin() + i), next_dims);
-        }
-    }
-
-    static hdf5_type* data(type& val) {
-        return inspector<value_type>::data(*val.data());
-    }
-
-    static const hdf5_type* data(const type& val) {
-        return inspector<value_type>::data(*val.data());
-    }
-
-    template <class It>
-    static void serialize(const type& val, It m) {
-        size_t size = val.num_elements();
-        size_t subsize = inspector<value_type>::getSizeVal(*val.origin());
-        for (size_t i = 0; i < size; ++i) {
-            inspector<value_type>::serialize(*(val.origin() + i), m + i * subsize);
-        }
-    }
-
-    template <class It>
-    static void unserialize(It vec_align, const std::vector<size_t>& dims, type& val) {
-        std::vector<size_t> next_dims(dims.begin() + ndim, dims.end());
-        size_t subsize = compute_total_size(next_dims);
-        for (size_t i = 0; i < val.num_elements(); ++i) {
-            inspector<value_type>::unserialize(vec_align + i * subsize,
-                                               next_dims,
-                                               *(val.origin() + i));
-        }
-    }
-};
-
-template <typename T>
-struct inspector<boost::numeric::ublas::matrix<T>> {
-    using type = boost::numeric::ublas::matrix<T>;
-    using value_type = unqualified_t<T>;
-    using base_type = typename inspector<value_type>::base_type;
-    using hdf5_type = typename inspector<value_type>::hdf5_type;
-
-    static constexpr size_t ndim = 2;
-    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
-    static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
-                                                  inspector<value_type>::is_trivially_copyable;
-
-    static std::vector<size_t> getDimensions(const type& val) {
-        std::vector<size_t> sizes{val.size1(), val.size2()};
-        auto s = inspector<value_type>::getDimensions(val(0, 0));
-        sizes.insert(sizes.end(), s.begin(), s.end());
-        return sizes;
-    }
-
-    static size_t getSizeVal(const type& val) {
-        return compute_total_size(getDimensions(val));
-    }
-
-    static size_t getSize(const std::vector<size_t>& dims) {
-        return compute_total_size(dims);
-    }
-
-    static void prepare(type& val, const std::vector<size_t>& dims) {
-        if (dims.size() < ndim) {
-            std::ostringstream os;
-            os << "Impossible to pair DataSet with " << dims.size() << " dimensions into a " << ndim
-               << " boost::numeric::ublas::matrix";
-            throw DataSpaceException(os.str());
-        }
-        val.resize(dims[0], dims[1], false);
-    }
-
-    static hdf5_type* data(type& val) {
-        return inspector<value_type>::data(val(0, 0));
-    }
-
-    static const hdf5_type* data(const type& val) {
-        return inspector<value_type>::data(val(0, 0));
-    }
-
-    static void serialize(const type& val, hdf5_type* m) {
-        size_t size = val.size1() * val.size2();
-        size_t subsize = inspector<value_type>::getSizeVal(val(0, 0));
-        for (size_t i = 0; i < size; ++i) {
-            inspector<value_type>::serialize(*(&val(0, 0) + i), m + i * subsize);
-        }
-    }
-
-    static void unserialize(const hdf5_type* vec_align,
-                            const std::vector<size_t>& dims,
-                            type& val) {
-        std::vector<size_t> next_dims(dims.begin() + ndim, dims.end());
-        size_t subsize = compute_total_size(next_dims);
-        size_t size = val.size1() * val.size2();
-        for (size_t i = 0; i < size; ++i) {
-            inspector<value_type>::unserialize(vec_align + i * subsize,
-                                               next_dims,
-                                               *(&val(0, 0) + i));
-        }
-    }
-};
-#endif
-
 }  // namespace details
 }  // namespace HighFive
+
+#ifdef H5_USE_BOOST
+#include <highfive/boost.hpp>
+#endif
+
+#ifdef H5_USE_EIGEN
+#include <highfive/eigen.hpp>
+#endif

--- a/include/highfive/boost.hpp
+++ b/include/highfive/boost.hpp
@@ -1,0 +1,164 @@
+#pragma once
+#ifdef H5_USE_BOOST
+
+#include "bits/H5Inspector_decl.hpp"
+#include "H5Exception.hpp"
+
+#include <boost/multi_array.hpp>
+// starting Boost 1.64, serialization header must come before ublas
+#include <boost/serialization/vector.hpp>
+#include <boost/numeric/ublas/matrix.hpp>
+
+namespace HighFive {
+namespace details {
+
+template <typename T, size_t Dims>
+struct inspector<boost::multi_array<T, Dims>> {
+    using type = boost::multi_array<T, Dims>;
+    using value_type = T;
+    using base_type = typename inspector<value_type>::base_type;
+    using hdf5_type = typename inspector<value_type>::hdf5_type;
+
+    static constexpr size_t ndim = Dims;
+    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
+    static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
+                                                  inspector<value_type>::is_trivially_copyable;
+
+    static std::vector<size_t> getDimensions(const type& val) {
+        std::vector<size_t> sizes;
+        for (size_t i = 0; i < ndim; ++i) {
+            sizes.push_back(val.shape()[i]);
+        }
+        auto s = inspector<value_type>::getDimensions(val.data()[0]);
+        sizes.insert(sizes.end(), s.begin(), s.end());
+        return sizes;
+    }
+
+    static size_t getSizeVal(const type& val) {
+        return compute_total_size(getDimensions(val));
+    }
+
+    static size_t getSize(const std::vector<size_t>& dims) {
+        return compute_total_size(dims);
+    }
+
+    static void prepare(type& val, const std::vector<size_t>& dims) {
+        if (dims.size() < ndim) {
+            std::ostringstream os;
+            os << "Only '" << dims.size() << "' given but boost::multi_array is of size '" << ndim
+               << "'.";
+            throw DataSpaceException(os.str());
+        }
+        boost::array<typename type::index, Dims> ext;
+        std::copy(dims.begin(), dims.begin() + ndim, ext.begin());
+        val.resize(ext);
+        std::vector<size_t> next_dims(dims.begin() + Dims, dims.end());
+        std::size_t size = std::accumulate(dims.begin(),
+                                           dims.begin() + Dims,
+                                           std::size_t{1},
+                                           std::multiplies<size_t>());
+        for (size_t i = 0; i < size; ++i) {
+            inspector<value_type>::prepare(*(val.origin() + i), next_dims);
+        }
+    }
+
+    static hdf5_type* data(type& val) {
+        return inspector<value_type>::data(*val.data());
+    }
+
+    static const hdf5_type* data(const type& val) {
+        return inspector<value_type>::data(*val.data());
+    }
+
+    template <class It>
+    static void serialize(const type& val, It m) {
+        size_t size = val.num_elements();
+        size_t subsize = inspector<value_type>::getSizeVal(*val.origin());
+        for (size_t i = 0; i < size; ++i) {
+            inspector<value_type>::serialize(*(val.origin() + i), m + i * subsize);
+        }
+    }
+
+    template <class It>
+    static void unserialize(It vec_align, const std::vector<size_t>& dims, type& val) {
+        std::vector<size_t> next_dims(dims.begin() + ndim, dims.end());
+        size_t subsize = compute_total_size(next_dims);
+        for (size_t i = 0; i < val.num_elements(); ++i) {
+            inspector<value_type>::unserialize(vec_align + i * subsize,
+                                               next_dims,
+                                               *(val.origin() + i));
+        }
+    }
+};
+
+template <typename T>
+struct inspector<boost::numeric::ublas::matrix<T>> {
+    using type = boost::numeric::ublas::matrix<T>;
+    using value_type = unqualified_t<T>;
+    using base_type = typename inspector<value_type>::base_type;
+    using hdf5_type = typename inspector<value_type>::hdf5_type;
+
+    static constexpr size_t ndim = 2;
+    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
+    static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
+                                                  inspector<value_type>::is_trivially_copyable;
+
+    static std::vector<size_t> getDimensions(const type& val) {
+        std::vector<size_t> sizes{val.size1(), val.size2()};
+        auto s = inspector<value_type>::getDimensions(val(0, 0));
+        sizes.insert(sizes.end(), s.begin(), s.end());
+        return sizes;
+    }
+
+    static size_t getSizeVal(const type& val) {
+        return compute_total_size(getDimensions(val));
+    }
+
+    static size_t getSize(const std::vector<size_t>& dims) {
+        return compute_total_size(dims);
+    }
+
+    static void prepare(type& val, const std::vector<size_t>& dims) {
+        if (dims.size() < ndim) {
+            std::ostringstream os;
+            os << "Impossible to pair DataSet with " << dims.size() << " dimensions into a " << ndim
+               << " boost::numeric::ublas::matrix";
+            throw DataSpaceException(os.str());
+        }
+        val.resize(dims[0], dims[1], false);
+    }
+
+    static hdf5_type* data(type& val) {
+        return inspector<value_type>::data(val(0, 0));
+    }
+
+    static const hdf5_type* data(const type& val) {
+        return inspector<value_type>::data(val(0, 0));
+    }
+
+    static void serialize(const type& val, hdf5_type* m) {
+        size_t size = val.size1() * val.size2();
+        size_t subsize = inspector<value_type>::getSizeVal(val(0, 0));
+        for (size_t i = 0; i < size; ++i) {
+            inspector<value_type>::serialize(*(&val(0, 0) + i), m + i * subsize);
+        }
+    }
+
+    static void unserialize(const hdf5_type* vec_align,
+                            const std::vector<size_t>& dims,
+                            type& val) {
+        std::vector<size_t> next_dims(dims.begin() + ndim, dims.end());
+        size_t subsize = compute_total_size(next_dims);
+        size_t size = val.size1() * val.size2();
+        for (size_t i = 0; i < size; ++i) {
+            inspector<value_type>::unserialize(vec_align + i * subsize,
+                                               next_dims,
+                                               *(&val(0, 0) + i));
+        }
+    }
+};
+
+}  // namespace details
+}  // namespace HighFive
+
+#endif

--- a/include/highfive/eigen.hpp
+++ b/include/highfive/eigen.hpp
@@ -1,0 +1,93 @@
+#pragma once
+#ifdef H5_USE_EIGEN
+
+#include "bits/H5Inspector_decl.hpp"
+#include "H5Exception.hpp"
+
+#include <Eigen/Eigen>
+
+
+namespace HighFive {
+namespace details {
+
+template <typename T, int M, int N>
+struct inspector<Eigen::Matrix<T, M, N>> {
+    using type = Eigen::Matrix<T, M, N>;
+    using value_type = T;
+    using base_type = typename inspector<value_type>::base_type;
+    using hdf5_type = base_type;
+
+    static constexpr size_t ndim = 2;
+    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
+    static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
+                                                  inspector<value_type>::is_trivially_copyable;
+
+
+    static void assert_not_buggy(Eigen::Index nrows, Eigen::Index ncols) {
+        if (nrows > 1 && ncols > 1) {
+            throw std::runtime_error(
+                "HighFive has been broken for Eigen::Matrix. Please check "
+                "https://github.com/BlueBrain/HighFive/issues/532.");
+        }
+    }
+
+    static std::vector<size_t> getDimensions(const type& val) {
+        assert_not_buggy(val.rows(), val.cols());
+
+        std::vector<size_t> sizes{static_cast<size_t>(val.rows()), static_cast<size_t>(val.cols())};
+        auto s = inspector<value_type>::getDimensions(val.data()[0]);
+        sizes.insert(sizes.end(), s.begin(), s.end());
+        return sizes;
+    }
+
+    static size_t getSizeVal(const type& val) {
+        return compute_total_size(getDimensions(val));
+    }
+
+    static size_t getSize(const std::vector<size_t>& dims) {
+        return compute_total_size(dims);
+    }
+
+    static void prepare(type& val, const std::vector<size_t>& dims) {
+        if (dims[0] != static_cast<size_t>(val.rows()) ||
+            dims[1] != static_cast<size_t>(val.cols())) {
+            val.resize(static_cast<typename type::Index>(dims[0]),
+                       static_cast<typename type::Index>(dims[1]));
+        }
+
+        assert_not_buggy(val.rows(), val.cols());
+    }
+
+    static hdf5_type* data(type& val) {
+        assert_not_buggy(val.rows(), val.cols());
+        return inspector<value_type>::data(*val.data());
+    }
+
+    static const hdf5_type* data(const type& val) {
+        assert_not_buggy(val.rows(), val.cols());
+        return inspector<value_type>::data(*val.data());
+    }
+
+    static void serialize(const type& val, hdf5_type* m) {
+        assert_not_buggy(val.rows(), val.cols());
+        std::memcpy(m, val.data(), static_cast<size_t>(val.size()) * sizeof(hdf5_type));
+    }
+
+    static void unserialize(const hdf5_type* vec_align,
+                            const std::vector<size_t>& dims,
+                            type& val) {
+        assert_not_buggy(val.rows(), val.cols());
+        if (dims.size() < 2) {
+            std::ostringstream os;
+            os << "Impossible to pair DataSet with " << dims.size()
+               << " dimensions into an eigen-matrix.";
+            throw DataSpaceException(os.str());
+        }
+        std::memcpy(val.data(), vec_align, compute_total_size(dims) * sizeof(hdf5_type));
+    }
+};
+
+}  // namespace details
+}  // namespace HighFive
+
+#endif

--- a/include/highfive/half_float.hpp
+++ b/include/highfive/half_float.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#ifdef H5_USE_HALF_FLOAT
+
+#include <half.hpp>
+
+namespace HighFive {
+using float16_t = half_float::half;
+
+template <>
+inline AtomicType<float16_t>::AtomicType() {
+    _hid = detail::h5t_copy(H5T_NATIVE_FLOAT);
+    // Sign position, exponent position, exponent size, mantissa position, mantissa size
+    detail::h5t_set_fields(_hid, 15, 10, 5, 0, 10);
+    // Total datatype size (in bytes)
+    detail::h5t_set_size(_hid, 2);
+    // Floating point exponent bias
+    detail::h5t_set_ebias(_hid, 15);
+}
+}  // namespace HighFive
+
+#endif

--- a/src/examples/create_dataset_half_float.cpp
+++ b/src/examples/create_dataset_half_float.cpp
@@ -7,8 +7,6 @@
  *
  */
 
-#ifdef H5_USE_HALF_FLOAT
-
 #include <iostream>
 #include <string>
 #include <vector>
@@ -45,5 +43,3 @@ int main(void) {
 
     return 0;
 }
-
-#endif

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -43,8 +43,6 @@ using base_test_types = std::tuple<int,
                                    fcomplex>;
 
 #ifdef H5_USE_HALF_FLOAT
-#include <half.hpp>
-
 using float16_t = half_float::half;
 using numerical_test_types =
     decltype(std::tuple_cat(std::declval<base_test_types>(), std::tuple<float16_t>()));


### PR DESCRIPTION
The file containing the specializations of traits for specific optional dependencies have been moved to their own files. This allows us to move to macro free dependency handling, simply by removing certain guarded includes.