### PR TITLE
Add named ctors for scalar and null dataspaces.

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -145,6 +145,24 @@ class DataSpace: public Object {
     /// \since 1.3
     explicit DataSpace(DataspaceType space_type);
 
+    /// \brief Create a scalar DataSpace.
+    ///
+    /// \code{.cpp}
+    /// auto dataspace = DataSpace::Scalar();
+    /// \endcode
+    ///
+    /// \since 2.9
+    static DataSpace Scalar();
+
+    /// \brief Create a null DataSpace.
+    ///
+    /// \code{.cpp}
+    /// auto dataspace = DataSpace::Null();
+    /// \endcode
+    ///
+    /// \since 2.9
+    static DataSpace Null();
+
     /// \brief Create a copy of the DataSpace which will have different id.
     ///
     /// \code{.cpp}

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -42,6 +42,14 @@ inline DataSpace::DataSpace(const IT begin, const IT end) {
     _hid = detail::h5s_create_simple(int(real_dims.size()), real_dims.data(), nullptr);
 }
 
+inline DataSpace DataSpace::Scalar() {
+    return DataSpace(DataSpace::dataspace_scalar);
+}
+
+inline DataSpace DataSpace::Null() {
+    return DataSpace(DataSpace::dataspace_null);
+}
+
 inline DataSpace::DataSpace(const std::vector<size_t>& dims, const std::vector<size_t>& maxdims) {
     if (dims.size() != maxdims.size()) {
         throw DataSpaceException("dims and maxdims must be the same length.");

--- a/include/highfive/bits/h5s_wrapper.hpp
+++ b/include/highfive/bits/h5s_wrapper.hpp
@@ -101,6 +101,15 @@ inline hssize_t h5s_get_simple_extent_npoints(hid_t space_id) {
     return nelements;
 }
 
+inline H5S_class_t h5s_get_simple_extent_type(hid_t space_id) {
+    H5S_class_t cls = H5Sget_simple_extent_type(space_id);
+    if (cls == H5S_NO_CLASS) {
+        HDF5ErrMapper::ToException<DataSpaceException>("Unable to get class of simple dataspace.");
+    }
+
+    return cls;
+}
+
 
 }  // namespace detail
 }  // namespace HighFive

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -775,11 +775,25 @@ TEST_CASE("DataSpace::getElementCount") {
     SECTION("null") {
         auto space = DataSpace(DataSpace::dataspace_null);
         CHECK(space.getElementCount() == 0);
+        CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_NULL);
+    }
+
+    SECTION("null named ctor") {
+        auto space = DataSpace::Null();
+        CHECK(space.getElementCount() == 0);
+        CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_NULL);
     }
 
     SECTION("scalar") {
         auto space = DataSpace(DataSpace::dataspace_scalar);
         CHECK(space.getElementCount() == 1);
+        CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_SCALAR);
+    }
+
+    SECTION("scalar named ctor") {
+        auto space = DataSpace::Scalar();
+        CHECK(space.getElementCount() == 1);
+        CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_SCALAR);
     }
 
     SECTION("simple, empty (1D)") {


### PR DESCRIPTION
The issue is that:
```
DataSpace{DataSpace::dataspace_scalar};
DataSpace{DataSpace::dataspace_null};
```
are a simple dataspace with 0 elements and a simple dataspace with one element, respectively. This provides a safer alternative.