### PR TITLE
Use enum class for DataSpace::DataspaceType. 

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -45,11 +45,15 @@ class DataSpace: public Object {
     /// This enum is needed otherwise we will not be able to distringuish between both with normal
     /// constructors. Both have a dimension of 0.
     /// \since 1.3
-    enum DataspaceType {
+    enum class DataspaceType {
         dataspace_scalar,  ///< Value to create scalar DataSpace
         dataspace_null,    ///< Value to create null DataSpace
         // simple dataspace are handle directly from their dimensions
     };
+
+    // For backward compatibility: `DataSpace::dataspace_scalar`.
+    constexpr static DataspaceType dataspace_scalar = DataspaceType::dataspace_scalar;
+    constexpr static DataspaceType dataspace_null = DataspaceType::dataspace_null;
 
     /// \brief Create a DataSpace of N-dimensions from a std::vector<size_t>.
     /// \param dims Dimensions of the new DataSpace

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -786,6 +786,12 @@ TEST_CASE("DataSpace::getElementCount") {
         CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_NULL);
     }
 
+    SECTION("null initializer_list") {
+        auto space = DataSpace{DataSpace::dataspace_null};
+        CHECK(space.getElementCount() == 0);
+        CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_NULL);
+    }
+
     SECTION("null named ctor") {
         auto space = DataSpace::Null();
         CHECK(space.getElementCount() == 0);
@@ -794,6 +800,12 @@ TEST_CASE("DataSpace::getElementCount") {
 
     SECTION("scalar") {
         auto space = DataSpace(DataSpace::dataspace_scalar);
+        CHECK(space.getElementCount() == 1);
+        CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_SCALAR);
+    }
+
+    SECTION("scalar initializer_list") {
+        auto space = DataSpace{DataSpace::dataspace_scalar};
         CHECK(space.getElementCount() == 1);
         CHECK(detail::h5s_get_simple_extent_type(space.getId()) == H5S_SCALAR);
     }


### PR DESCRIPTION
See #899 for what the issue is and a safe alternative. Unfortunately, changing an enum to an enum class is a breaking change and can't be done until `3.0.0`.