### PR TITLE
Avoid non-collective behaviour.

### DIFF
--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -185,14 +185,6 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
     }
     auto dims = mem_space.getDimensions();
 
-    if (mem_space.getElementCount() == 0) {
-        auto effective_dims = details::squeezeDimensions(dims,
-                                                         details::inspector<T>::recursive_ndim);
-
-        details::inspector<T>::prepare(array, effective_dims);
-        return;
-    }
-
     auto r = details::data_converter::get_reader<T>(dims, array, file_datatype);
     read(r.getPointer(), buffer_info.data_type, xfer_props);
     // re-arrange results
@@ -249,10 +241,6 @@ template <typename T>
 inline void SliceTraits<Derivate>::write(const T& buffer, const DataTransferProps& xfer_props) {
     const auto& slice = static_cast<const Derivate&>(*this);
     const DataSpace& mem_space = slice.getMemSpace();
-
-    if (mem_space.getElementCount() == 0) {
-        return;
-    }
 
     auto file_datatype = slice.getDataType();
 


### PR DESCRIPTION
MPI collective IO, requires that certain HDF5 functions are called collectively. Here some short-circuiting logic for empty datasets interferes when some, but not all, selections from different MPI ranks are empty.