### PR TITLE
Remove unused specialization for createDataSet.

### DIFF
--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -53,20 +53,7 @@ class NodeTraits {
     /// \param accessProps A property list with data set access properties
     /// \param parents Create intermediate groups if needed. Default: true.
     /// \return DataSet Object
-    template <typename T,
-              typename std::enable_if<
-                  std::is_same<typename details::inspector<T>::base_type, details::Boolean>::value,
-                  int>::type* = nullptr>
-    DataSet createDataSet(const std::string& dataset_name,
-                          const DataSpace& space,
-                          const DataSetCreateProps& createProps = DataSetCreateProps::Default(),
-                          const DataSetAccessProps& accessProps = DataSetAccessProps::Default(),
-                          bool parents = true);
-
-    template <typename T,
-              typename std::enable_if<
-                  !std::is_same<typename details::inspector<T>::base_type, details::Boolean>::value,
-                  int>::type* = nullptr>
+    template <typename T>
     DataSet createDataSet(const std::string& dataset_name,
                           const DataSpace& space,
                           const DataSetCreateProps& createProps = DataSetCreateProps::Default(),

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -52,28 +52,7 @@ inline DataSet NodeTraits<Derivate>::createDataSet(const std::string& dataset_na
 }
 
 template <typename Derivate>
-template <typename T,
-          typename std::enable_if<
-              std::is_same<typename details::inspector<T>::base_type, details::Boolean>::value,
-              int>::type*>
-inline DataSet NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
-                                                   const DataSpace& space,
-                                                   const DataSetCreateProps& createProps,
-                                                   const DataSetAccessProps& accessProps,
-                                                   bool parents) {
-    return createDataSet(dataset_name,
-                         space,
-                         create_and_check_datatype<typename details::inspector<T>::base_type>(),
-                         createProps,
-                         accessProps,
-                         parents);
-}
-
-template <typename Derivate>
-template <typename T,
-          typename std::enable_if<
-              !std::is_same<typename details::inspector<T>::base_type, details::Boolean>::value,
-              int>::type*>
+template <typename T>
 inline DataSet NodeTraits<Derivate>::createDataSet(const std::string& dataset_name,
                                                    const DataSpace& space,
                                                    const DataSetCreateProps& createProps,


### PR DESCRIPTION
This was likely needed to hide the bug that the specialization for `create_datatype<bool>` was missing. See, commit 9415a7c82.