### PR TITLE
Move strange test to `test_legacy.cpp`.

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,7 +7,7 @@ if(MSVC)
 endif()
 
 ## Base tests
-foreach(test_name tests_high_five_base tests_high_five_multi_dims tests_high_five_easy test_all_types test_high_five_selection tests_high_five_data_type)
+foreach(test_name tests_high_five_base tests_high_five_multi_dims tests_high_five_easy test_all_types test_high_five_selection tests_high_five_data_type test_legacy)
   add_executable(${test_name} "${test_name}.cpp")
   target_link_libraries(${test_name} HighFive HighFiveWarnings Catch2::Catch2WithMain)
   catch_discover_tests(${test_name})

--- a/tests/unit/test_legacy.cpp
+++ b/tests/unit/test_legacy.cpp
@@ -1,0 +1,39 @@
+// This file collects tests the require legacy behaviour of v2 (and older) to
+// pass. Tests in this file could be bugs too.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+
+#include <highfive/highfive.hpp>
+
+using namespace HighFive;
+
+TEST_CASE("HighFiveReadWriteConsts") {
+    // This test seems really strange. Essentially, it malloc's a 3**3 doubles.
+    // Then reinterpret_cast's the pointer to the first double (a `double *`)
+    // as a `double***`. And then uses `inspector` based code to write from the
+    // `double***`.
+
+    const std::string file_name("3d_dataset_from_flat.h5");
+    const std::string dataset_name("dset");
+    const std::array<std::size_t, 3> DIMS{3, 3, 3};
+    using datatype = int;
+
+    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
+    DataSpace dataspace = DataSpace(DIMS);
+
+    DataSet dataset = file.createDataSet<datatype>(dataset_name, dataspace);
+    std::vector<datatype> const t1(DIMS[0] * DIMS[1] * DIMS[2], 1);
+    auto raw_3d_vec_const = reinterpret_cast<datatype const* const* const*>(t1.data());
+    dataset.write_raw(raw_3d_vec_const);
+
+    std::vector<std::vector<std::vector<datatype>>> result;
+    dataset.read(result);
+    for (const auto& vec2d: result) {
+        for (const auto& vec1d: vec2d) {
+            REQUIRE(vec1d == (std::vector<datatype>{1, 1, 1}));
+        }
+    }
+}
+

--- a/tests/unit/test_legacy.cpp
+++ b/tests/unit/test_legacy.cpp
@@ -36,4 +36,3 @@ TEST_CASE("HighFiveReadWriteConsts") {
         }
     }
 }
-

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -2520,29 +2520,6 @@ TEST_CASE("HighFiveReference") {
     }
 }
 
-TEST_CASE("HighFiveReadWriteConsts") {
-    const std::string file_name("3d_dataset_from_flat.h5");
-    const std::string dataset_name("dset");
-    const std::array<std::size_t, 3> DIMS{3, 3, 3};
-    using datatype = int;
-
-    File file(file_name, File::ReadWrite | File::Create | File::Truncate);
-    DataSpace dataspace = DataSpace(DIMS);
-
-    DataSet dataset = file.createDataSet<datatype>(dataset_name, dataspace);
-    std::vector<datatype> const t1(DIMS[0] * DIMS[1] * DIMS[2], 1);
-    auto raw_3d_vec_const = reinterpret_cast<datatype const* const* const*>(t1.data());
-    dataset.write(raw_3d_vec_const);
-
-    std::vector<std::vector<std::vector<datatype>>> result;
-    dataset.read(result);
-    for (const auto& vec2d: result) {
-        for (const auto& vec1d: vec2d) {
-            REQUIRE(vec1d == (std::vector<datatype>{1, 1, 1}));
-        }
-    }
-}
-
 TEST_CASE("HighFiveDataTypeClass") {
     auto Float = DataTypeClass::Float;
     auto String = DataTypeClass::String;


### PR DESCRIPTION
This new groups of tests isolates tests the are counter-intuitive from the rest. This makes it easier to review them, and makes it clear that they're considered odd by someone else; and therefore might even be testing buggy behaviour.