### PR TITLE
No constexpr rank via constexpr min-max rank.

### DIFF
--- a/include/highfive/bits/H5Attribute_misc.hpp
+++ b/include/highfive/bits/H5Attribute_misc.hpp
@@ -19,6 +19,7 @@
 
 #include "../H5DataSpace.hpp"
 #include "H5Converter_misc.hpp"
+#include "H5Inspector_misc.hpp"
 #include "H5ReadWrite_misc.hpp"
 #include "H5Utils.hpp"
 #include "h5a_wrapper.hpp"
@@ -73,10 +74,11 @@ inline void Attribute::read(T& array) const {
         [this]() -> std::string { return this->getName(); },
         details::BufferInfo<T>::Operation::read);
 
-    if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
+    if (!details::checkDimensions(mem_space, buffer_info.getMinRank(), buffer_info.getMaxRank())) {
         std::ostringstream ss;
-        ss << "Impossible to read Attribute of dimensions " << mem_space.getNumberDimensions()
-           << " into arrays of dimensions " << buffer_info.n_dimensions;
+        ss << "Impossible to read attribute of dimensions " << mem_space.getNumberDimensions()
+           << " into arrays of dimensions: " << buffer_info.getMinRank() << "(min) to "
+           << buffer_info.getMaxRank() << "(max)";
         throw DataSpaceException(ss.str());
     }
     auto dims = mem_space.getDimensions();
@@ -137,10 +139,11 @@ inline void Attribute::write(const T& buffer) {
         [this]() -> std::string { return this->getName(); },
         details::BufferInfo<T>::Operation::write);
 
-    if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
+    if (!details::checkDimensions(mem_space, buffer_info.getMinRank(), buffer_info.getMaxRank())) {
         std::ostringstream ss;
-        ss << "Impossible to write buffer of dimensions " << buffer_info.n_dimensions
-           << " into dataset of dimensions " << mem_space.getNumberDimensions();
+        ss << "Impossible to write attribute of dimensions " << mem_space.getNumberDimensions()
+           << " into arrays of dimensions: " << buffer_info.getMinRank() << "(min) to "
+           << buffer_info.getMaxRank() << "(max)";
         throw DataSpaceException(ss.str());
     }
     auto w = details::data_converter::serialize<T>(buffer, dims, file_datatype);

--- a/include/highfive/bits/H5DataType_misc.hpp
+++ b/include/highfive/bits/H5DataType_misc.hpp
@@ -226,9 +226,9 @@ inline EnumType<details::Boolean> create_enum_boolean() {
 // Other cases not supported. Fail early with a user message
 template <typename T>
 AtomicType<T>::AtomicType() {
-    static_assert(details::inspector<T>::recursive_ndim == 0,
-                  "Atomic types cant be arrays, except for char[] (fixed-length strings)");
-    static_assert(details::inspector<T>::recursive_ndim > 0, "Type not supported");
+    static_assert(
+        true,
+        "Missing specialization of AtomicType<T>. Therefore, type T is not supported by HighFive.");
 }
 
 

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -131,9 +131,10 @@ inline DataSpace DataSpace::FromCharArrayStrings(const char (&)[N][Width]) {
 
 namespace details {
 
-/// dimension checks @internal
-inline bool checkDimensions(const DataSpace& mem_space, size_t n_dim_requested) {
-    return checkDimensions(mem_space.getDimensions(), n_dim_requested);
+inline bool checkDimensions(const DataSpace& mem_space,
+                            size_t min_dim_requested,
+                            size_t max_dim_requested) {
+    return checkDimensions(mem_space.getDimensions(), min_dim_requested, max_dim_requested);
 }
 
 }  // namespace details

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -180,10 +180,11 @@ inline void SliceTraits<Derivate>::read(T& array, const DataTransferProps& xfer_
         [&slice]() -> std::string { return details::get_dataset(slice).getPath(); },
         details::BufferInfo<T>::Operation::read);
 
-    if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
+    if (!details::checkDimensions(mem_space, buffer_info.getMinRank(), buffer_info.getMaxRank())) {
         std::ostringstream ss;
         ss << "Impossible to read DataSet of dimensions " << mem_space.getNumberDimensions()
-           << " into arrays of dimensions " << buffer_info.n_dimensions;
+           << " into arrays of dimensions: " << buffer_info.getMinRank() << "(min) to "
+           << buffer_info.getMaxRank() << "(max)";
         throw DataSpaceException(ss.str());
     }
     auto dims = mem_space.getDimensions();
@@ -254,11 +255,11 @@ inline void SliceTraits<Derivate>::write(const T& buffer, const DataTransferProp
         [&slice]() -> std::string { return details::get_dataset(slice).getPath(); },
         details::BufferInfo<T>::Operation::write);
 
-    if (!details::checkDimensions(mem_space, buffer_info.n_dimensions)) {
+    if (!details::checkDimensions(mem_space, buffer_info.getMinRank(), buffer_info.getMaxRank())) {
         std::ostringstream ss;
-        ss << "Impossible to write buffer of dimensions "
-           << details::format_vector(mem_space.getDimensions())
-           << " into dataset with n = " << buffer_info.n_dimensions << " dimensions.";
+        ss << "Impossible to write buffer with dimensions n = " << buffer_info.getRank(buffer)
+           << "into dataset with dimensions " << details::format_vector(mem_space.getDimensions())
+           << ".";
         throw DataSpaceException(ss.str());
     }
     auto w = details::data_converter::serialize<T>(buffer, dims, file_datatype);

--- a/include/highfive/boost.hpp
+++ b/include/highfive/boost.hpp
@@ -17,19 +17,31 @@ struct inspector<boost::multi_array<T, Dims>> {
     using hdf5_type = typename inspector<value_type>::hdf5_type;
 
     static constexpr size_t ndim = Dims;
-    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
+    static constexpr size_t min_ndim = ndim + inspector<value_type>::min_ndim;
+    static constexpr size_t max_ndim = ndim + inspector<value_type>::max_ndim;
+
     static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
                                                   inspector<value_type>::is_trivially_nestable;
     static constexpr bool is_trivially_nestable = false;
 
 
+    static size_t getRank(const type& val) {
+        return ndim + inspector<value_type>::getRank(val.data()[0]);
+    }
+
     static std::vector<size_t> getDimensions(const type& val) {
-        std::vector<size_t> sizes;
+        auto rank = getRank(val);
+        std::vector<size_t> sizes(rank, 1ul);
         for (size_t i = 0; i < ndim; ++i) {
-            sizes.push_back(val.shape()[i]);
+            sizes[i] = val.shape()[i];
         }
-        auto s = inspector<value_type>::getDimensions(val.data()[0]);
-        sizes.insert(sizes.end(), s.begin(), s.end());
+        if (val.size() != 0) {
+            auto s = inspector<value_type>::getDimensions(val.data()[0]);
+            sizes.resize(ndim + s.size());
+            for (size_t i = 0; i < s.size(); ++i) {
+                sizes[ndim + i] = s[i];
+            }
+        }
         return sizes;
     }
 
@@ -101,10 +113,16 @@ struct inspector<boost::numeric::ublas::matrix<T>> {
     using hdf5_type = typename inspector<value_type>::hdf5_type;
 
     static constexpr size_t ndim = 2;
-    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
+    static constexpr size_t min_ndim = ndim + inspector<value_type>::min_ndim;
+    static constexpr size_t max_ndim = ndim + inspector<value_type>::max_ndim;
+
     static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
                                                   inspector<value_type>::is_trivially_copyable;
     static constexpr bool is_trivially_nestable = false;
+
+    static size_t getRank(const type& val) {
+        return ndim + inspector<value_type>::getRank(val(0, 0));
+    }
 
     static std::vector<size_t> getDimensions(const type& val) {
         std::vector<size_t> sizes{val.size1(), val.size2()};

--- a/include/highfive/eigen.hpp
+++ b/include/highfive/eigen.hpp
@@ -16,6 +16,7 @@ struct eigen_inspector {
     using base_type = typename inspector<value_type>::base_type;
     using hdf5_type = base_type;
 
+
     static_assert(int(EigenType::ColsAtCompileTime) == int(EigenType::MaxColsAtCompileTime),
                   "Padding isn't supported.");
     static_assert(int(EigenType::RowsAtCompileTime) == int(EigenType::MaxRowsAtCompileTime),
@@ -26,12 +27,18 @@ struct eigen_inspector {
                EigenType::IsRowMajor;
     }
 
+
     static constexpr size_t ndim = 2;
-    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
+    static constexpr size_t min_ndim = ndim + inspector<value_type>::min_ndim;
+    static constexpr size_t max_ndim = ndim + inspector<value_type>::max_ndim;
     static constexpr bool is_trivially_copyable = is_row_major() &&
                                                   std::is_trivially_copyable<value_type>::value &&
                                                   inspector<value_type>::is_trivially_nestable;
     static constexpr bool is_trivially_nestable = false;
+
+    static size_t getRank(const type& val) {
+        return ndim + inspector<value_type>::getRank(val.data()[0]);
+    }
 
     static std::vector<size_t> getDimensions(const type& val) {
         std::vector<size_t> sizes{static_cast<size_t>(val.rows()), static_cast<size_t>(val.cols())};

--- a/include/highfive/span.hpp
+++ b/include/highfive/span.hpp
@@ -25,14 +25,25 @@ struct inspector<std::span<T, Extent>> {
     using hdf5_type = typename inspector<value_type>::hdf5_type;
 
     static constexpr size_t ndim = 1;
-    static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
+    static constexpr size_t min_ndim = ndim + inspector<value_type>::min_ndim;
+    static constexpr size_t max_ndim = ndim + inspector<value_type>::max_ndim;
+
     static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
                                                   inspector<value_type>::is_trivially_nestable;
-
     static constexpr bool is_trivially_nestable = false;
 
+
+    static size_t getRank(const type& val) {
+        if (!val.empty()) {
+            return ndim + inspector<value_type>::getRank(val[0]);
+        } else {
+            return min_ndim;
+        }
+    }
+
     static std::vector<size_t> getDimensions(const type& val) {
-        std::vector<size_t> sizes(recursive_ndim, 1ul);
+        auto rank = getRank(val);
+        std::vector<size_t> sizes(rank, 1ul);
         sizes[0] = val.size();
         if (!val.empty()) {
             auto s = inspector<value_type>::getDimensions(val[0]);

--- a/tests/unit/data_generator.hpp
+++ b/tests/unit/data_generator.hpp
@@ -79,6 +79,7 @@ struct ScalarContainerTraits {
     using base_type = T;
 
     static constexpr bool is_view = false;
+    static constexpr size_t rank = 0;
 
     static void set(container_type& array, std::vector<size_t> /* indices */, base_type value) {
         array = value;
@@ -120,6 +121,7 @@ struct ContainerTraits<std::vector<bool>> {
     using base_type = bool;
 
     static constexpr bool is_view = false;
+    static constexpr size_t rank = 1;
 
     static void set(container_type& array,
                     const std::vector<size_t>& indices,
@@ -154,6 +156,7 @@ struct STLLikeContainerTraits {
     using base_type = typename ContainerTraits<value_type>::base_type;
 
     static constexpr bool is_view = ContainerTraits<value_type>::is_view;
+    static constexpr size_t rank = 1 + ContainerTraits<value_type>::rank;
 
     static void set(container_type& array,
                     const std::vector<size_t>& indices,
@@ -281,6 +284,7 @@ struct ContainerTraits<boost::multi_array<T, n>> {
     using base_type = typename ContainerTraits<value_type>::base_type;
 
     static constexpr bool is_view = ContainerTraits<value_type>::is_view;
+    static constexpr size_t rank = n + ContainerTraits<value_type>::rank;
 
     static void set(container_type& array,
                     const std::vector<size_t>& indices,
@@ -333,6 +337,7 @@ struct ContainerTraits<boost::numeric::ublas::matrix<T>> {
     using base_type = typename ContainerTraits<value_type>::base_type;
 
     static constexpr bool is_view = ContainerTraits<value_type>::is_view;
+    static constexpr size_t rank = 2 + ContainerTraits<value_type>::rank;
 
     static void set(container_type& array,
                     const std::vector<size_t>& indices,
@@ -392,6 +397,7 @@ struct EigenContainerTraits {
     using base_type = typename ContainerTraits<value_type>::base_type;
 
     static constexpr bool is_view = ContainerTraits<value_type>::is_view;
+    static constexpr size_t rank = 2 + ContainerTraits<value_type>::rank;
 
     static void set(container_type& array,
                     const std::vector<size_t>& indices,
@@ -629,10 +635,11 @@ struct MultiDimVector<T, 0> {
 template <class Container>
 class DataGenerator {
   public:
-    constexpr static size_t rank = details::inspector<Container>::recursive_ndim;
     using traits = ContainerTraits<Container>;
     using base_type = typename traits::base_type;
     using container_type = Container;
+
+    constexpr static size_t rank = traits::rank;
 
   public:
     static container_type allocate(const std::vector<size_t>& dims) {


### PR DESCRIPTION
The commit removes the requirement for a constexpr rank. Instead
containers need a minimum and maximum constexpr rank.

The difficulties are:

  * Empty arrays can't figure out their runtime rank. This is an issue
    when deducing the dimension when writing to disk. The "solution" is
    to deduce with lowest rank possible. 