### PR TITLE
Remove `inspector<T>::getSize{,Val}`.

### DIFF
--- a/include/highfive/bits/H5Converter_misc.hpp
+++ b/include/highfive/bits/H5Converter_misc.hpp
@@ -69,7 +69,7 @@ struct DeepCopyBuffer {
     using hdf5_type = typename inspector<type>::hdf5_type;
 
     explicit DeepCopyBuffer(const std::vector<size_t>& _dims)
-        : buffer(inspector<T>::getSize(_dims))
+        : buffer(compute_total_size(_dims))
         , dims(_dims) {}
 
     hdf5_type* getPointer() {

--- a/include/highfive/boost.hpp
+++ b/include/highfive/boost.hpp
@@ -31,10 +31,6 @@ struct inspector<boost::multi_array<T, Dims>> {
         return sizes;
     }
 
-    static size_t getSizeVal(const type& val) {
-        return compute_total_size(getDimensions(val));
-    }
-
     static size_t getSize(const std::vector<size_t>& dims) {
         return compute_total_size(dims);
     }
@@ -70,8 +66,8 @@ struct inspector<boost::multi_array<T, Dims>> {
     template <class It>
     static void serialize(const type& val, const std::vector<size_t>& dims, It m) {
         size_t size = val.num_elements();
-        size_t subsize = inspector<value_type>::getSizeVal(*val.origin());
         auto subdims = std::vector<size_t>(dims.begin() + ndim, dims.end());
+        size_t subsize = inspector<value_type>::getSize(subdims);
         for (size_t i = 0; i < size; ++i) {
             inspector<value_type>::serialize(*(val.origin() + i), subdims, m + i * subsize);
         }
@@ -108,10 +104,6 @@ struct inspector<boost::numeric::ublas::matrix<T>> {
         return sizes;
     }
 
-    static size_t getSizeVal(const type& val) {
-        return compute_total_size(getDimensions(val));
-    }
-
     static size_t getSize(const std::vector<size_t>& dims) {
         return compute_total_size(dims);
     }
@@ -136,8 +128,8 @@ struct inspector<boost::numeric::ublas::matrix<T>> {
 
     static void serialize(const type& val, const std::vector<size_t>& dims, hdf5_type* m) {
         size_t size = val.size1() * val.size2();
-        size_t subsize = inspector<value_type>::getSizeVal(val(0, 0));
         auto subdims = std::vector<size_t>(dims.begin() + ndim, dims.end());
+        size_t subsize = inspector<value_type>::getSize(subdims);
         for (size_t i = 0; i < size; ++i) {
             inspector<value_type>::serialize(*(&val(0, 0) + i), subdims, m + i * subsize);
         }

--- a/include/highfive/boost.hpp
+++ b/include/highfive/boost.hpp
@@ -31,10 +31,6 @@ struct inspector<boost::multi_array<T, Dims>> {
         return sizes;
     }
 
-    static size_t getSize(const std::vector<size_t>& dims) {
-        return compute_total_size(dims);
-    }
-
     static void prepare(type& val, const std::vector<size_t>& dims) {
         if (dims.size() < ndim) {
             std::ostringstream os;
@@ -67,7 +63,7 @@ struct inspector<boost::multi_array<T, Dims>> {
     static void serialize(const type& val, const std::vector<size_t>& dims, It m) {
         size_t size = val.num_elements();
         auto subdims = std::vector<size_t>(dims.begin() + ndim, dims.end());
-        size_t subsize = inspector<value_type>::getSize(subdims);
+        size_t subsize = compute_total_size(subdims);
         for (size_t i = 0; i < size; ++i) {
             inspector<value_type>::serialize(*(val.origin() + i), subdims, m + i * subsize);
         }
@@ -104,10 +100,6 @@ struct inspector<boost::numeric::ublas::matrix<T>> {
         return sizes;
     }
 
-    static size_t getSize(const std::vector<size_t>& dims) {
-        return compute_total_size(dims);
-    }
-
     static void prepare(type& val, const std::vector<size_t>& dims) {
         if (dims.size() < ndim) {
             std::ostringstream os;
@@ -129,7 +121,7 @@ struct inspector<boost::numeric::ublas::matrix<T>> {
     static void serialize(const type& val, const std::vector<size_t>& dims, hdf5_type* m) {
         size_t size = val.size1() * val.size2();
         auto subdims = std::vector<size_t>(dims.begin() + ndim, dims.end());
-        size_t subsize = inspector<value_type>::getSize(subdims);
+        size_t subsize = compute_total_size(subdims);
         for (size_t i = 0; i < size; ++i) {
             inspector<value_type>::serialize(*(&val(0, 0) + i), subdims, m + i * subsize);
         }

--- a/include/highfive/eigen.hpp
+++ b/include/highfive/eigen.hpp
@@ -39,10 +39,6 @@ struct inspector<Eigen::Matrix<T, M, N>> {
         return sizes;
     }
 
-    static size_t getSize(const std::vector<size_t>& dims) {
-        return compute_total_size(dims);
-    }
-
     static void prepare(type& val, const std::vector<size_t>& dims) {
         if (dims[0] != static_cast<size_t>(val.rows()) ||
             dims[1] != static_cast<size_t>(val.cols())) {

--- a/include/highfive/eigen.hpp
+++ b/include/highfive/eigen.hpp
@@ -39,10 +39,6 @@ struct inspector<Eigen::Matrix<T, M, N>> {
         return sizes;
     }
 
-    static size_t getSizeVal(const type& val) {
-        return compute_total_size(getDimensions(val));
-    }
-
     static size_t getSize(const std::vector<size_t>& dims) {
         return compute_total_size(dims);
     }


### PR DESCRIPTION
The method `getSizeVal(T& value)` is problematic because some containers don't know their dimensions, yet they need to forward the input pointer when serializing/deserializing. After changing `serialize` to accept the `dims` the number of elements can be obtained from there. It's also tricky in the context of arrays of chars, these could be a counted as one string or as multiple characters. Inside the inspector we don't know which interpretation is correct.

The method `getSize(dims)` seems to only have a single plausible implementation. Hence, it's being removed mostly for cosmetic reasons.

