### PR TITLE
Fix when CI is run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ concurrency:
 on:
   push:
     branches:
-      - ci_test
-      - release/**
+      - master
+      - main
+      - v2.x
   pull_request:
     branches:
       - master
-      - release/**
+      - main
+      - v2.x
     paths-ignore:
       - '**.md'
       - '**.rst'

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -8,10 +8,8 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore:
-      - '**.md'
-      - '**.rst'
-      - 'doc/**'
+      - main
+      - v2.x
 
 jobs:
   Code_Format:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,12 +8,13 @@ on:
   push:
     branches:
       - master
-      - ci_test
-      - release/**
+      - main
+      - v2.x
   pull_request:
     branches:
       - master
-      - release/**
+      - main
+      - v2.x
     paths-ignore:
       - '**.md'
       - '**.rst'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,10 +3,10 @@ name: gh-pages
 on:
   push:
     branches:
-      - master
+      - v2.x
   pull_request:
     branches:
-      - master
+      - v2.x
 
 jobs:
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - v2.x
+      - master
+      - main
 
 jobs:
 
@@ -39,7 +41,7 @@ jobs:
         cp -r doc/poster build/doc/html/
 
     - name: Deploy to GitHub Pages
-      if: ${{ success() && github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+      if: ${{ success() && github.ref == 'refs/heads/v2.x' && github.event_name == 'push' }}
       uses: crazy-max/ghaction-github-pages@v2
       with:
         target_branch: gh-pages

--- a/.github/workflows/version_file.yml
+++ b/.github/workflows/version_file.yml
@@ -3,12 +3,14 @@ name: HighFive Check Version File
 on:
   push:
     branches:
-      - ci_test
-      - release/**
+      - master
+      - main
+      - v2.x
   pull_request:
     branches:
       - master
-      - release/**
+      - main
+      - v2.x
 
 jobs:
   CheckVersion:


### PR DESCRIPTION
The tests should run for every PR and when merged into the main or `v2.x` branch. Docs should be published only when merging into `v2.x` (for now).

We've removed `release/**` since we don't have those. It also removes `ci_test` because I haven't seen anyone test the CI that way, `git commit --allow-empty` can be used instead.