### PR TITLE
Implement XTensor support in core.

### DIFF
--- a/include/highfive/xtensor.hpp
+++ b/include/highfive/xtensor.hpp
@@ -64,7 +64,7 @@ struct xtensor_inspector_base {
 
     static hdf5_type* data(type& val) {
         if (!is_trivially_copyable) {
-            throw DataSetException("Invalid used of `inspector<xarray>::data`.");
+            throw DataSetException("Invalid used of `inspector<XTensor>::data`.");
         }
 
         if (val.size() == 0) {
@@ -76,7 +76,7 @@ struct xtensor_inspector_base {
 
     static const hdf5_type* data(const type& val) {
         if (!is_trivially_copyable) {
-            throw DataSetException("Invalid used of `inspector<xarray>::data`.");
+            throw DataSetException("Invalid used of `inspector<XTensor>::data`.");
         }
 
         if (val.size() == 0) {

--- a/include/highfive/xtensor.hpp
+++ b/include/highfive/xtensor.hpp
@@ -1,0 +1,212 @@
+#pragma once
+
+#include "bits/H5Inspector_decl.hpp"
+#include "H5Exception.hpp"
+
+#include <xtensor/xtensor.hpp>
+#include <xtensor/xarray.hpp>
+#include <xtensor/xadapt.hpp>
+
+namespace HighFive {
+namespace details {
+
+template <class XTensor>
+struct xtensor_get_rank;
+
+template <typename T, size_t N, xt::layout_type L>
+struct xtensor_get_rank<xt::xtensor<T, N, L>> {
+    static constexpr size_t value = N;
+};
+
+template <class EC, size_t N, xt::layout_type L, class Tag>
+struct xtensor_get_rank<xt::xtensor_adaptor<EC, N, L, Tag>> {
+    static constexpr size_t value = N;
+};
+
+template <class Derived, class XTensorType, xt::layout_type L>
+struct xtensor_inspector_base {
+    using type = XTensorType;
+    using value_type = typename type::value_type;
+    using base_type = typename inspector<value_type>::base_type;
+    using hdf5_type = base_type;
+
+    static_assert(std::is_same<value_type, base_type>::value,
+                  "HighFive's XTensor support only works for scalar elements.");
+
+    static constexpr bool IsConstExprRowMajor = L == xt::layout_type::row_major;
+    static constexpr bool is_trivially_copyable = IsConstExprRowMajor &&
+                                                  std::is_trivially_copyable<value_type>::value &&
+                                                  inspector<value_type>::is_trivially_copyable;
+
+    static constexpr bool is_trivially_nestable = false;
+
+    static size_t getRank(const type& val) {
+        // Non-scalar elements are not supported.
+        return val.shape().size();
+    }
+
+    static const value_type& getAnyElement(const type& val) {
+        return val.unchecked(0);
+    }
+
+    static value_type& getAnyElement(type& val) {
+        return val.unchecked(0);
+    }
+
+    static std::vector<size_t> getDimensions(const type& val) {
+        auto shape = val.shape();
+        return {shape.begin(), shape.end()};
+    }
+
+    static void prepare(type& val, const std::vector<size_t>& dims) {
+        val.resize(Derived::shapeFromDims(dims));
+    }
+
+    static hdf5_type* data(type& val) {
+        if (!is_trivially_copyable) {
+            throw DataSetException("Invalid used of `inspector<xarray>::data`.");
+        }
+
+        if (val.size() == 0) {
+            return nullptr;
+        }
+
+        return inspector<value_type>::data(getAnyElement(val));
+    }
+
+    static const hdf5_type* data(const type& val) {
+        if (!is_trivially_copyable) {
+            throw DataSetException("Invalid used of `inspector<xarray>::data`.");
+        }
+
+        if (val.size() == 0) {
+            return nullptr;
+        }
+
+        return inspector<value_type>::data(getAnyElement(val));
+    }
+
+    static void serialize(const type& val, const std::vector<size_t>& dims, hdf5_type* m) {
+        // since we only support scalar types we know all dims belong to us.
+        size_t size = compute_total_size(dims);
+        xt::adapt(m, size, xt::no_ownership(), dims) = val;
+    }
+
+    static void unserialize(const hdf5_type* vec_align,
+                            const std::vector<size_t>& dims,
+                            type& val) {
+        // since we only support scalar types we know all dims belong to us.
+        size_t size = compute_total_size(dims);
+        val = xt::adapt(vec_align, size, xt::no_ownership(), dims);
+    }
+};
+
+template <class XTensorType, xt::layout_type L>
+struct xtensor_inspector
+    : public xtensor_inspector_base<xtensor_inspector<XTensorType, L>, XTensorType, L> {
+  private:
+    using super = xtensor_inspector_base<xtensor_inspector<XTensorType, L>, XTensorType, L>;
+
+  public:
+    using type = typename super::type;
+    using value_type = typename super::value_type;
+    using base_type = typename super::base_type;
+    using hdf5_type = typename super::hdf5_type;
+
+    static constexpr size_t ndim = xtensor_get_rank<XTensorType>::value;
+    static constexpr size_t min_ndim = ndim + inspector<value_type>::min_ndim;
+    static constexpr size_t max_ndim = ndim + inspector<value_type>::max_ndim;
+
+    static std::array<size_t, ndim> shapeFromDims(const std::vector<size_t>& dims) {
+        std::array<size_t, ndim> shape;
+        std::copy(dims.cbegin(), dims.cend(), shape.begin());
+        return shape;
+    }
+};
+
+template <class XArrayType, xt::layout_type L>
+struct xarray_inspector
+    : public xtensor_inspector_base<xarray_inspector<XArrayType, L>, XArrayType, L> {
+  private:
+    using super = xtensor_inspector_base<xarray_inspector<XArrayType, L>, XArrayType, L>;
+
+  public:
+    using type = typename super::type;
+    using value_type = typename super::value_type;
+    using base_type = typename super::base_type;
+    using hdf5_type = typename super::hdf5_type;
+
+    static constexpr size_t min_ndim = 0 + inspector<value_type>::min_ndim;
+    static constexpr size_t max_ndim = 1024 + inspector<value_type>::max_ndim;
+
+    static const std::vector<size_t>& shapeFromDims(const std::vector<size_t>& dims) {
+        return dims;
+    }
+};
+
+template <typename T, size_t N, xt::layout_type L>
+struct inspector<xt::xtensor<T, N, L>>: public xtensor_inspector<xt::xtensor<T, N, L>, L> {
+  private:
+    using super = xtensor_inspector<xt::xtensor<T, N, L>, L>;
+
+  public:
+    using type = typename super::type;
+    using value_type = typename super::value_type;
+    using base_type = typename super::base_type;
+    using hdf5_type = typename super::hdf5_type;
+};
+
+template <typename T, xt::layout_type L>
+struct inspector<xt::xarray<T, L>>: public xarray_inspector<xt::xarray<T, L>, L> {
+  private:
+    using super = xarray_inspector<xt::xarray<T, L>, L>;
+
+  public:
+    using type = typename super::type;
+    using value_type = typename super::value_type;
+    using base_type = typename super::base_type;
+    using hdf5_type = typename super::hdf5_type;
+};
+
+template <typename CT, class... S>
+struct inspector<xt::xview<CT, S...>>
+    : public xarray_inspector<xt::xview<CT, S...>, xt::layout_type::any> {
+  private:
+    using super = xarray_inspector<xt::xview<CT, S...>, xt::layout_type::any>;
+
+  public:
+    using type = typename super::type;
+    using value_type = typename super::value_type;
+    using base_type = typename super::base_type;
+    using hdf5_type = typename super::hdf5_type;
+};
+
+
+template <class EC, xt::layout_type L, class SC, class Tag>
+struct inspector<xt::xarray_adaptor<EC, L, SC, Tag>>
+    : public xarray_inspector<xt::xarray_adaptor<EC, L, SC, Tag>, xt::layout_type::any> {
+  private:
+    using super = xarray_inspector<xt::xarray_adaptor<EC, L, SC, Tag>, xt::layout_type::any>;
+
+  public:
+    using type = typename super::type;
+    using value_type = typename super::value_type;
+    using base_type = typename super::base_type;
+    using hdf5_type = typename super::hdf5_type;
+};
+
+template <class EC, size_t N, xt::layout_type L, class Tag>
+struct inspector<xt::xtensor_adaptor<EC, N, L, Tag>>
+    : public xtensor_inspector<xt::xtensor_adaptor<EC, N, L, Tag>, xt::layout_type::any> {
+  private:
+    using super = xtensor_inspector<xt::xtensor_adaptor<EC, N, L, Tag>, xt::layout_type::any>;
+
+  public:
+    using type = typename super::type;
+    using value_type = typename super::value_type;
+    using base_type = typename super::base_type;
+    using hdf5_type = typename super::hdf5_type;
+};
+
+}  // namespace details
+}  // namespace HighFive

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,7 +6,7 @@ if(MSVC)
 endif()
 
 ## Base tests
-foreach(test_name tests_high_five_base tests_high_five_multi_dims tests_high_five_easy test_all_types test_high_five_selection tests_high_five_data_type test_empty_arrays test_legacy test_opencv test_string)
+foreach(test_name tests_high_five_base tests_high_five_multi_dims tests_high_five_easy test_all_types test_high_five_selection tests_high_five_data_type test_empty_arrays test_legacy test_opencv test_string test_xtensor)
   add_executable(${test_name} "${test_name}.cpp")
   target_link_libraries(${test_name} HighFive HighFiveWarnings HighFiveFlags Catch2::Catch2WithMain)
   target_link_libraries(${test_name} HighFiveOptionalDependencies)
@@ -47,7 +47,7 @@ endif()
 # test succeeds if it compiles.
 file(GLOB public_headers LIST_DIRECTORIES false RELATIVE ${PROJECT_SOURCE_DIR}/include CONFIGURE_DEPENDS ${PROJECT_SOURCE_DIR}/include/highfive/*.hpp)
 foreach(PUBLIC_HEADER ${public_headers})
-  if(PUBLIC_HEADER STREQUAL "highfive/span.hpp" AND NOT HIGHFIVE_TEST_SPAN)
+    if(PUBLIC_HEADER STREQUAL "highfive/span.hpp" AND NOT HIGHFIVE_TEST_SPAN)
       continue()
     endif()
 
@@ -64,6 +64,10 @@ foreach(PUBLIC_HEADER ${public_headers})
     endif()
 
     if(PUBLIC_HEADER STREQUAL "highfive/opencv.hpp" AND NOT HIGHFIVE_TEST_OPENCV)
+      continue()
+    endif()
+
+    if(PUBLIC_HEADER STREQUAL "highfive/xtensor.hpp" AND NOT HIGHFIVE_TEST_XTENSOR)
       continue()
     endif()
 

--- a/tests/unit/supported_types.hpp
+++ b/tests/unit/supported_types.hpp
@@ -82,6 +82,20 @@ struct EigenMapMatrix {
 };
 #endif
 
+#ifdef HIGHFIVE_TEST_XTENSOR
+template <size_t rank, xt::layout_type layout, class C = type_identity>
+struct XTensor {
+    template <class T>
+    using type = xt::xtensor<typename C::template type<T>, rank, layout>;
+};
+
+template <xt::layout_type layout, class C = type_identity>
+struct XArray {
+    template <class T>
+    using type = xt::xarray<typename C::template type<T>, layout>;
+};
+#endif
+
 template <class C, class Tuple>
 struct ContainerProduct;
 
@@ -165,6 +179,16 @@ using supported_array_types = typename ConcatenateTuples<
   typename ContainerProduct<STDArray<7, STDSpan<>>, some_scalar_types>::type,
   typename ContainerProduct<STDSpan<STDVector<>>, some_scalar_types>::type,
   typename ContainerProduct<STDSpan<STDArray<3>>, some_scalar_types>::type,
+#endif
+#ifdef HIGHFIVE_TEST_XTENSOR
+  typename ContainerProduct<XTensor<3, xt::layout_type::row_major>, scalar_types_eigen>::type,
+  typename ContainerProduct<STDVector<XTensor<3, xt::layout_type::row_major>>, scalar_types_eigen>::type,
+  typename ContainerProduct<STDArray<5, XTensor<3, xt::layout_type::row_major>>, scalar_types_eigen>::type,
+  typename ContainerProduct<XTensor<3, xt::layout_type::column_major>, scalar_types_eigen>::type,
+  typename ContainerProduct<XArray<xt::layout_type::row_major>, scalar_types_eigen>::type,
+  typename ContainerProduct<STDVector<XArray<xt::layout_type::row_major>>, scalar_types_eigen>::type,
+  typename ContainerProduct<STDArray<5, XArray<xt::layout_type::row_major>>, scalar_types_eigen>::type,
+  typename ContainerProduct<XArray<xt::layout_type::column_major>, scalar_types_eigen>::type,
 #endif
   typename ContainerProduct<STDVector<>, all_scalar_types>::type,
   typename ContainerProduct<STDVector<STDVector<>>, some_scalar_types>::type,

--- a/tests/unit/test_xtensor.cpp
+++ b/tests/unit/test_xtensor.cpp
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c), 2024, Blue Brain Project - EPFL
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#if HIGHFIVE_TEST_XTENSOR
+#include <string>
+#include <sstream>
+
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <highfive/highfive.hpp>
+#include <xtensor/xtensor.hpp>
+#include <xtensor/xview.hpp>
+#include <xtensor/xio.hpp>
+#include <highfive/xtensor.hpp>
+
+#include "data_generator.hpp"
+
+using namespace HighFive;
+
+template <size_t N>
+std::array<size_t, N> asStaticShape(const std::vector<size_t>& dims) {
+    assert(dims.size() == N);
+
+    std::array<size_t, N> shape;
+    std::copy(dims.cbegin(), dims.cend(), shape.begin());
+
+    return shape;
+}
+
+TEST_CASE("xt::xarray reshape", "[xtensor]") {
+    const std::string file_name("rw_dataset_xarray.h5");
+
+    File file(file_name, File::Truncate);
+
+    std::vector<size_t> shape{3, 2, 4};
+    std::vector<size_t> compatible_shape{1, 3, 2, 4};
+    std::vector<size_t> incompatible_shape{5, 2, 4};
+
+    xt::xarray<double> a = testing::DataGenerator<xt::xtensor<double, 3>>::create(shape);
+    xt::xarray<double> b(compatible_shape);
+    xt::xarray<double> c(incompatible_shape);
+
+    auto dset = file.createDataSet("baz", a);
+
+    SECTION("xarray_adaptor") {
+        // Changes the shape.
+        auto b_adapt = xt::adapt(b.data(), b.size(), xt::no_ownership(), b.shape());
+        dset.read(b_adapt);
+        REQUIRE(b_adapt.shape() == shape);
+
+        // But can't change the number of elements.
+        auto c_adapt = xt::adapt(c.data(), c.size(), xt::no_ownership(), c.shape());
+        REQUIRE_THROWS(dset.read(c_adapt));
+    }
+
+    SECTION("xtensor_adaptor") {
+        auto b_shape = asStaticShape<4>(compatible_shape);
+        auto c_shape = asStaticShape<3>(incompatible_shape);
+
+        // Doesn't change the shape:
+        auto b_adapt = xt::adapt(b.data(), b.size(), xt::no_ownership(), b_shape);
+        REQUIRE_THROWS(dset.read(b_adapt));
+
+        // and can't change the number of elements:
+        auto c_adapt = xt::adapt(c.data(), c.size(), xt::no_ownership(), c_shape);
+        REQUIRE_THROWS(dset.read(c_adapt));
+    }
+}
+
+TEST_CASE("xt::xview example", "[xtensor]") {
+    File file("rw_dataset_xview.h5", File::Truncate);
+
+    std::vector<size_t> shape{13, 5, 7};
+    xt::xarray<double> a = testing::DataGenerator<xt::xtensor<double, 3>>::create(shape);
+    auto c = xt::view(a, xt::range(3, 31, 4), xt::all(), xt::drop(0, 3, 4, 5));
+
+    auto dset = file.createDataSet("c", c);
+    auto d = dset.read<xt::xarray<double>>();
+    auto e = dset.read<xt::xarray<double, xt::layout_type::column_major>>();
+
+    REQUIRE(d == c);
+    REQUIRE(e == c);
+}
+
+template <class XTensor>
+void check_xtensor_scalar(File& file) {
+    XTensor a;
+    a = 42.0;
+    REQUIRE(a.shape() == std::vector<size_t>{});
+
+    SECTION("read") {
+        auto dset = file.createDataSet("a", a);
+        REQUIRE(dset.template read<double>() == a(0));
+    }
+
+    SECTION("write") {
+        double b = -42.0;
+        auto dset = file.createDataSet("b", b);
+        REQUIRE(dset.template read<xt::xarray<double>>()(0) == b);
+    }
+}
+
+TEST_CASE("xt::xarray scalar", "[xtensor]") {
+    File file("rw_dataset_xarray_scalar.h5", File::Truncate);
+    check_xtensor_scalar<xt::xarray<double>>(file);
+}
+
+TEST_CASE("xt::xtensor scalar", "[xtensor]") {
+    File file("rw_dataset_xtensor_scalar.h5", File::Truncate);
+    check_xtensor_scalar<xt::xarray<double>>(file);
+}
+
+template <class XTensor>
+void check_xtensor_empty(File& file, const XTensor& a, const std::vector<size_t>& expected_dims) {
+    auto dset = file.createDataSet("a", a);
+    auto b = dset.template read<XTensor>();
+    REQUIRE(b.size() == 0);
+    REQUIRE(b == a);
+
+    auto c = std::vector<XTensor>{};
+    auto c_shape = details::inspector<decltype(c)>::getDimensions(c);
+    REQUIRE(c_shape == expected_dims);
+}
+
+TEST_CASE("xt::xtensor empty", "[xtensor]") {
+    File file("rw_dataset_xtensor_empty.h5", File::Truncate);
+    xt::xtensor<double, 3> a({0, 1, 1});
+    check_xtensor_empty(file, a, {0, 1, 1, 1});
+}
+
+TEST_CASE("xt::xarray empty", "[xtensor]") {
+    File file("rw_dataset_xarray_empty.h5", File::Truncate);
+    xt::xarray<double> a(std::vector<size_t>{1, 0, 1});
+    check_xtensor_empty(file, a, {0});
+}
+
+#endif

--- a/tests/unit/tests_high_five.hpp
+++ b/tests/unit/tests_high_five.hpp
@@ -21,6 +21,7 @@
 // The list of identifiers is taken from `Boost::Predef`.
 #if defined(_WIN32) || defined(_WIN64) || defined(__WIN32__) || defined(__TOS_WIN__) || \
     defined(__WINDOWS__)
+#define NOMINMAX
 #include <Windows.h>
 #endif
 


### PR DESCRIPTION
Adds support for `xt::xtensor`, both row and column major. We're missing `xt::xarray` and views. Views fail because they claim to have runtime variable rank.