### PR TITLE
Improve information content of GCC error messages.

### DIFF
--- a/cmake/HighFiveWarnings.cmake
+++ b/cmake/HighFiveWarnings.cmake
@@ -6,6 +6,7 @@ if(TARGET HighFiveWarnings)
 endif()
 
 add_library(HighFiveWarnings INTERFACE)
+add_library(HighFiveFlags INTERFACE)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang"
    OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
@@ -32,8 +33,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang"
                 -Wdouble-promotion
         )
 
+        target_compile_options(HighFiveWarnings
+            INTERFACE
+                -ftemplate-backtrace-limit=0
+        )
+
       if(HIGHFIVE_MAX_ERRORS)
-          target_compile_options(HighFiveWarnings
+          target_compile_options(HighFiveFlags
               INTERFACE
               -fmax-errors=${HIGHFIVE_MAX_ERRORS}
           )

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -55,7 +55,7 @@ function(compile_example example_source)
   message("example_name: ${example_name}")
 
   add_executable(${example_name} ${example_source})
-  target_link_libraries(${example_name} PUBLIC HighFive HighFiveWarnings)
+  target_link_libraries(${example_name} PUBLIC HighFive HighFiveWarnings HighFiveFlags)
   if(${ARGC} EQUAL 2)
     target_link_libraries(${example_name} PUBLIC ${ARGV1})
   endif()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 ## Base tests
 foreach(test_name tests_high_five_base tests_high_five_multi_dims tests_high_five_easy test_all_types test_high_five_selection tests_high_five_data_type test_legacy)
   add_executable(${test_name} "${test_name}.cpp")
-  target_link_libraries(${test_name} HighFive HighFiveWarnings Catch2::Catch2WithMain)
+  target_link_libraries(${test_name} HighFive HighFiveWarnings HighFiveFlags Catch2::Catch2WithMain)
   target_link_libraries(${test_name} HighFiveOptionalDependencies)
 
   catch_discover_tests(${test_name})
@@ -19,7 +19,7 @@ if(HIGHFIVE_PARALLEL_HDF5)
 
   ## parallel MPI tests
   add_executable(tests_parallel_bin ${tests_parallel_src})
-  target_link_libraries(tests_parallel_bin HighFive HighFiveWarnings Catch2::Catch2)
+  target_link_libraries(tests_parallel_bin HighFive HighFiveWarnings HighFiveFlags Catch2::Catch2)
   target_link_libraries(tests_parallel_bin HighFiveOptionalDependencies)
 
   # We need to patch in a call to `mpirun` or equivalent when using
@@ -62,6 +62,6 @@ if(HIGHFIVE_TEST_SINGLE_INCLUDES)
         get_filename_component(CLASS_NAME ${PUBLIC_HEADER} NAME_WE)
         configure_file(tests_import_public_headers.cpp "tests_${CLASS_NAME}.cpp" @ONLY)
         add_executable("tests_include_${CLASS_NAME}" "${CMAKE_CURRENT_BINARY_DIR}/tests_${CLASS_NAME}.cpp")
-        target_link_libraries("tests_include_${CLASS_NAME}" HighFive HighFiveWarnings)
+        target_link_libraries("tests_include_${CLASS_NAME}" HighFive HighFiveWarnings HighFiveFlags)
     endforeach()
 endif()


### PR DESCRIPTION
Frequently, GCC prints error messages, but, ironically, they're too short, it'll include the inner most context, somewhere deep inside the STL or some other external libary, then skip all the HighFive context and continue printing the outer most layers which typically happen to be in Catch2.