### PR TITLE
Add `inspector::is_trivially_nestable`.

### DIFF
--- a/include/highfive/boost.hpp
+++ b/include/highfive/boost.hpp
@@ -19,7 +19,9 @@ struct inspector<boost::multi_array<T, Dims>> {
     static constexpr size_t ndim = Dims;
     static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
     static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
-                                                  inspector<value_type>::is_trivially_copyable;
+                                                  inspector<value_type>::is_trivially_nestable;
+    static constexpr bool is_trivially_nestable = false;
+
 
     static std::vector<size_t> getDimensions(const type& val) {
         std::vector<size_t> sizes;
@@ -92,6 +94,7 @@ struct inspector<boost::numeric::ublas::matrix<T>> {
     static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
     static constexpr bool is_trivially_copyable = std::is_trivially_copyable<value_type>::value &&
                                                   inspector<value_type>::is_trivially_copyable;
+    static constexpr bool is_trivially_nestable = false;
 
     static std::vector<size_t> getDimensions(const type& val) {
         std::vector<size_t> sizes{val.size1(), val.size2()};

--- a/include/highfive/eigen.hpp
+++ b/include/highfive/eigen.hpp
@@ -30,7 +30,8 @@ struct eigen_inspector {
     static constexpr size_t recursive_ndim = ndim + inspector<value_type>::recursive_ndim;
     static constexpr bool is_trivially_copyable = is_row_major() &&
                                                   std::is_trivially_copyable<value_type>::value &&
-                                                  inspector<value_type>::is_trivially_copyable;
+                                                  inspector<value_type>::is_trivially_nestable;
+    static constexpr bool is_trivially_nestable = false;
 
     static std::vector<size_t> getDimensions(const type& val) {
         std::vector<size_t> sizes{static_cast<size_t>(val.rows()), static_cast<size_t>(val.cols())};


### PR DESCRIPTION
We need this because `std::span` is considered `std::is_trivially_copyable`.