### PR TITLE
Implement `squeeze` and `reshape`.

### DIFF
--- a/include/highfive/H5Attribute.hpp
+++ b/include/highfive/H5Attribute.hpp
@@ -13,6 +13,7 @@
 #include <H5Apublic.h>
 
 #include "H5DataType.hpp"
+#include "H5DataSpace.hpp"
 #include "H5Object.hpp"
 #include "bits/H5Friends.hpp"
 #include "bits/H5Path_traits.hpp"
@@ -78,8 +79,12 @@ class Attribute: public Object, public PathTraits<Attribute> {
     /// \since 1.0
     DataSpace getSpace() const;
 
-    /// \brief Get the DataSpace of the current Attribute.
-    /// \note This is an alias of getSpace().
+    /// \brief Get the memory DataSpace of the current Attribute.
+    ///
+    /// HDF5 attributes don't support selections. Therefore, there's no need
+    /// for a memory dataspace. However, HighFive supports allocating arrays
+    /// and checking dimensions, this requires the dimensions of the memspace.
+    ///
     /// \since 1.0
     DataSpace getMemSpace() const;
 
@@ -245,10 +250,34 @@ class Attribute: public Object, public PathTraits<Attribute> {
     // No empty attributes
     Attribute() = delete;
 
+    ///
+    /// \brief Return an `Attribute` with `axes` squeezed from the memspace.
+    ///
+    /// Returns an `Attribute` in which the memspace has been modified
+    /// to not include the axes listed in `axes`.
+    ///
+    /// Throws if any axis to be squeezes has a dimension other than `1`.
+    ///
+    /// \since 3.0
+    Attribute squeezeMemSpace(const std::vector<size_t>& axes) const;
+
+    ///
+    /// \brief Return a `Attribute` with a simple memspace with `dims`.
+    ///
+    /// Returns a `Attribute` in which the memspace has been modified
+    /// to be a simple dataspace with dimensions `dims`.
+    ///
+    /// Throws if the number of elements changes.
+    ///
+    /// \since 3.0
+    Attribute reshapeMemSpace(const std::vector<size_t>& dims) const;
+
   protected:
     using Object::Object;
 
   private:
+    DataSpace _mem_space;
+
 #if HIGHFIVE_HAS_FRIEND_DECLARATIONS
     template <typename Derivate>
     friend class ::HighFive::AnnotateTraits;

--- a/include/highfive/bits/H5Inspector_decl.hpp
+++ b/include/highfive/bits/H5Inspector_decl.hpp
@@ -1,19 +1,11 @@
 #pragma once
 
-#include <cstddef>
-#include <numeric>
-#include <functional>
-#include <vector>
+#include "compute_total_size.hpp"
 
 namespace HighFive {
 
-inline size_t compute_total_size(const std::vector<size_t>& dims) {
-    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<size_t>());
-}
-
 template <typename T>
 using unqualified_t = typename std::remove_const<typename std::remove_reference<T>::type>::type;
-
 
 namespace details {
 

--- a/include/highfive/bits/H5Slice_traits.hpp
+++ b/include/highfive/bits/H5Slice_traits.hpp
@@ -368,6 +368,28 @@ class SliceTraits {
     ///
     template <typename T>
     void write_raw(const T* buffer, const DataTransferProps& xfer_props = DataTransferProps());
+
+    ///
+    /// \brief Return a `Selection` with `axes` squeezed from the memspace.
+    ///
+    /// Returns a selection in which the memspace has been modified
+    /// to not include the axes listed in `axes`.
+    ///
+    /// Throws if any axis to be squeezes has a dimension other than `1`.
+    ///
+    /// \since 3.0
+    Selection squeezeMemSpace(const std::vector<size_t>& axes) const;
+
+    ///
+    /// \brief Return a `Selection` with a simple memspace with `dims`.
+    ///
+    /// Returns a selection in which the memspace has been modified
+    /// to be a simple dataspace with dimensions `dims`.
+    ///
+    /// Throws if the number of elements changes.
+    ///
+    /// \since 3.0
+    Selection reshapeMemSpace(const std::vector<size_t>& dims) const;
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Slice_traits_misc.hpp
+++ b/include/highfive/bits/H5Slice_traits_misc.hpp
@@ -291,11 +291,11 @@ inline void SliceTraits<Derivate>::write_raw(const T* buffer, const DataTransfer
 }
 
 namespace detail {
-const DataSet& getDataSet(const Selection& selection) {
+inline const DataSet& getDataSet(const Selection& selection) {
     return selection.getDataset();
 }
 
-const DataSet& getDataSet(const DataSet& dataset) {
+inline const DataSet& getDataSet(const DataSet& dataset) {
     return dataset;
 }
 

--- a/include/highfive/bits/compute_total_size.hpp
+++ b/include/highfive/bits/compute_total_size.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstddef>
+#include <numeric>
+#include <functional>
+#include <vector>
+
+namespace HighFive {
+
+inline size_t compute_total_size(const std::vector<size_t>& dims) {
+    return std::accumulate(dims.begin(), dims.end(), size_t{1u}, std::multiplies<size_t>());
+}
+
+}  // namespace HighFive

--- a/include/highfive/bits/squeeze.hpp
+++ b/include/highfive/bits/squeeze.hpp
@@ -22,7 +22,7 @@ namespace detail {
 ///
 /// Example:
 ///   squeeze({1, 3, 2, 1}, {0, 3}) == {3, 2}
-std::vector<size_t> squeeze(const std::vector<size_t>& dims, const std::vector<size_t>& axes) {
+inline std::vector<size_t> squeeze(const std::vector<size_t>& dims, const std::vector<size_t>& axes) {
     auto n_dims = dims.size();
     auto mask = std::vector<bool>(n_dims, false);
     for (size_t i = 0; i < axes.size(); ++i) {

--- a/include/highfive/bits/squeeze.hpp
+++ b/include/highfive/bits/squeeze.hpp
@@ -22,7 +22,8 @@ namespace detail {
 ///
 /// Example:
 ///   squeeze({1, 3, 2, 1}, {0, 3}) == {3, 2}
-inline std::vector<size_t> squeeze(const std::vector<size_t>& dims, const std::vector<size_t>& axes) {
+inline std::vector<size_t> squeeze(const std::vector<size_t>& dims,
+                                   const std::vector<size_t>& axes) {
     auto n_dims = dims.size();
     auto mask = std::vector<bool>(n_dims, false);
     for (size_t i = 0; i < axes.size(); ++i) {

--- a/include/highfive/bits/squeeze.hpp
+++ b/include/highfive/bits/squeeze.hpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c), 2024, BlueBrain Project, EPFL
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ *
+ */
+#pragma once
+
+#include <vector>
+#include "../H5Exception.hpp"
+
+namespace HighFive {
+namespace detail {
+
+/// \brief Squeeze `axes` from `dims`.
+///
+/// An axis can only be squeezed if it's dimension is `1`. The elements of
+/// `axes` must be in the range `0, ..., dims.size()` (exclusive) and don't
+/// have to be sorted.
+///
+/// Example:
+///   squeeze({1, 3, 2, 1}, {0, 3}) == {3, 2}
+std::vector<size_t> squeeze(const std::vector<size_t>& dims, const std::vector<size_t>& axes) {
+    auto n_dims = dims.size();
+    auto mask = std::vector<bool>(n_dims, false);
+    for (size_t i = 0; i < axes.size(); ++i) {
+        if (axes[i] >= n_dims) {
+            throw Exception("Out of range: axes[" + std::to_string(i) +
+                            "] == " + std::to_string(axes[i]) + " >= " + std::to_string(n_dims));
+        }
+
+        mask[axes[i]] = true;
+    }
+
+    auto squeezed_dims = std::vector<size_t>{};
+    for (size_t i = 0; i < n_dims; ++i) {
+        if (!mask[i]) {
+            squeezed_dims.push_back(dims[i]);
+        } else {
+            if (dims[i] != 1) {
+                throw Exception("Squeezing non-unity axis: axes[" + std::to_string(i) +
+                                "] = " + std::to_string(axes[i]));
+            }
+        }
+    }
+
+    return squeezed_dims;
+}
+
+}  // namespace detail
+}  // namespace HighFive

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(core_examples
   ${CMAKE_CURRENT_SOURCE_DIR}/compound_types.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/broadcasting_arrays.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/create_attribute_string_integer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/create_dataset_double.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/create_datatype.cpp

--- a/src/examples/broadcasting_arrays.cpp
+++ b/src/examples/broadcasting_arrays.cpp
@@ -1,0 +1,51 @@
+#include <highfive/highfive.hpp>
+
+// This example explains how to read a dataset with some shape into an array of
+// some other shape. Naturally, this only makes sense if the number of elements
+// doesn't change.
+//
+// Note that due to how HDF5 works, writing from one shape into some other
+// shape is expected to work automatically.
+//
+// Same is true for reading. However, HighFive also allocates memory, the array
+// into which the data is read is forced to have the same shape as the
+// memspace. When performing selections it can often happen that one selects a
+// one-dimensional slice from a higher dimensional array.  In this case we want
+// to be able to read into a one dimensional array, e.g. `std::vector<double>`.
+//
+// Broadcasting is a common technique for hiding benign differences in
+// dimensionality. In HighFive we suggest to either "squeeze" or "reshape" the
+// memspace, rather than broadcasting. This example demonstrates the required
+// syntax.
+//
+// Note: These techniques can also be used for general hyperslabs which the
+// user knows are in fact hypercubes, i.e. regular.
+//
+// Note: HighFive v2 has support for broadcasting; but because it's quirky,
+// less powerful than the demonstrated technique, relied on a compile-time
+// constant rank and is quite complex to maintain, the functionality was
+// removed from v3.
+
+using namespace HighFive;
+
+int main(void) {
+    File file("broadcasting_arrays.h5", File::Truncate);
+
+    std::vector<size_t> dims{3, 1};
+    std::vector<double> values{1.0, 2.0, 3.0};
+
+    auto dset = file.createDataSet("dset", DataSpace(dims), create_datatype<double>());
+
+    // Note that even though `values` is one-dimensional, we can still write it
+    // to an array of dimensions `[3, 1]`. Only the number of elements needs to
+    // match.
+    dset.write(values);
+
+    // When reading, (re-)allocation might occur. The shape to be allocated is
+    // the dimensions of the memspace. Therefore, one might want to either remove
+    // an axis:
+    dset.squeezeMemSpace({1}).read(values);
+
+    // or reshape the memspace:
+    dset.reshapeMemSpace({3}).read(values);
+}

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1792,13 +1792,13 @@ void check_empty_read_write_cycle(const std::vector<size_t>& dims) {
     SECTION("read; one-dimensional vector (empty)") {
         auto output_data = CreateEmptyVector<1>::create({0ul});
 
-        ReadWriteInterface::get(file, dataset_name).read(output_data);
+        ReadWriteInterface::get(file, dataset_name).reshapeMemSpace({0ul}).read(output_data);
         check_empty_dimensions(output_data, {0ul});
     }
 
     SECTION("read; pre-allocated (empty)") {
         auto output_data = CreateContainer::create(dims);
-        ReadWriteInterface::get(file, dataset_name).read(output_data);
+        ReadWriteInterface::get(file, dataset_name).reshapeMemSpace(dims).read(output_data);
 
         check_empty_dimensions(output_data, dims);
     }
@@ -1806,14 +1806,15 @@ void check_empty_read_write_cycle(const std::vector<size_t>& dims) {
     SECTION("read; pre-allocated (oversized)") {
         auto oversize_dims = std::vector<size_t>(dims.size(), 2ul);
         auto output_data = CreateContainer::create(oversize_dims);
-        ReadWriteInterface::get(file, dataset_name).read(output_data);
+        ReadWriteInterface::get(file, dataset_name).reshapeMemSpace(dims).read(output_data);
 
         check_empty_dimensions(output_data, dims);
     }
 
     SECTION("read; auto-allocated") {
-        auto output_data =
-            ReadWriteInterface::get(file, dataset_name).template read<container_type>();
+        auto output_data = ReadWriteInterface::get(file, dataset_name)
+                               .reshapeMemSpace(dims)
+                               .template read<container_type>();
         check_empty_dimensions(output_data, dims);
     }
 }

--- a/tests/unit/tests_high_five_base.cpp
+++ b/tests/unit/tests_high_five_base.cpp
@@ -1634,6 +1634,45 @@ TEST_CASE("ReadInBroadcastDims") {
     }
 }
 
+TEST_CASE("squeeze") {
+    CHECK(detail::squeeze({}, {}) == std::vector<size_t>{});
+    CHECK(detail::squeeze({3, 1, 1}, {}) == std::vector<size_t>{3, 1, 1});
+    CHECK(detail::squeeze({3, 1, 1}, {2, 1}) == std::vector<size_t>{3});
+    CHECK(detail::squeeze({1, 3, 1, 2}, {2, 0}) == std::vector<size_t>{3, 2});
+
+    CHECK_THROWS(detail::squeeze({3, 1, 1}, {3}));
+    CHECK_THROWS(detail::squeeze({3, 1, 1}, {0}));
+    CHECK_THROWS(detail::squeeze({}, {0}));
+}
+
+TEST_CASE("SqueezeMemSpace") {
+    const std::string file_name("h5_squeeze_memspace.h5");
+    const std::string dataset_name("dset");
+
+    File file(file_name, File::Truncate);
+
+    auto expected_values = std::vector<double>{1.0, 2.0, 3.0};
+    auto values = std::vector<std::vector<double>>{expected_values};
+
+    auto dset = file.createDataSet(dataset_name, values);
+    SECTION("squeeze") {
+        auto actual_values = dset.squeezeMemSpace({0}).read<std::vector<double>>();
+
+        REQUIRE(actual_values.size() == expected_values.size());
+        for (size_t i = 0; i < actual_values.size(); ++i) {
+            REQUIRE(actual_values[i] == expected_values[i]);
+        }
+    }
+
+    SECTION("reshape") {
+        auto actual_values = dset.reshapeMemSpace({3}).read<std::vector<double>>();
+
+        REQUIRE(actual_values.size() == expected_values.size());
+        for (size_t i = 0; i < actual_values.size(); ++i) {
+            REQUIRE(actual_values[i] == expected_values[i]);
+        }
+    }
+}
 
 template <int n_dim>
 struct CreateEmptyVector;


### PR DESCRIPTION
These methods allow reshaping the memory space. This can be used as
an alternative to broadcasting.

Example:

Let `dset` be a dataset with shape `[3, 1, 1]`. Then,

    dset.reshapeMemSpace({3}).read<std::vector<double>>();
    dset.squeezeMemSpace({1, 2}).read<std::vector<double>>();

can be used to read into a one-dimensional dataset.