### PR TITLE
Remove `Object{Create,Access}Props`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,18 +346,8 @@ jobs:
     runs-on:  ${{matrix.os}}
     strategy:
       matrix:
-        os: [ "windows-2022"]
-        vs-toolset: [ "v141", "v143" ]
+        os: [ "windows-2019", "windows-2022"]
         cxxstd: ["14", "17", "20"]
-
-        include:
-          - os: "windows-2019"
-            vs-toolset: "v142"
-            cxxstd: "14"
-
-          - os: "windows-2019"
-            vs-toolset: "v142"
-            cxxstd: "17"
 
     steps:
     - uses: actions/checkout@v3
@@ -373,7 +363,6 @@ jobs:
       shell: bash -l {0}
       run: |
         CMAKE_OPTIONS=(
-          -T ${{matrix.vs-toolset}}
           -DCMAKE_CXX_STANDARD=${{matrix.cxxstd}}
           -DHIGHFIVE_UNIT_TESTS=ON
           -DHIGHFIVE_TEST_BOOST:BOOL=ON

--- a/doc/migration_guide.md
+++ b/doc/migration_guide.md
@@ -233,4 +233,6 @@ multi-dimensional array isn't supported, because if we want to support array
 with runtime-defined rank, we can't deduce the correct shape, e.g. `[1]` vs.
 `[1, 1, 1]`, when read into an array.
 
-
+# Removal of `Object*Props`.
+To out knowledge these could not be used meaningfully. Please create an issue
+if you relied on these.

--- a/include/highfive/H5PropertyList.hpp
+++ b/include/highfive/H5PropertyList.hpp
@@ -87,7 +87,6 @@ namespace HighFive {
 /// \brief Types of property lists
 ///
 enum class PropertyType : int {
-    OBJECT_CREATE,
     FILE_CREATE,
     FILE_ACCESS,
     DATASET_CREATE,
@@ -99,7 +98,6 @@ enum class PropertyType : int {
     DATATYPE_ACCESS,
     STRING_CREATE,
     ATTRIBUTE_CREATE,
-    OBJECT_COPY,
     LINK_CREATE,
     LINK_ACCESS,
 };
@@ -195,7 +193,6 @@ class PropertyList: public PropertyListBase {
     void _initializeIfNeeded();
 };
 
-using ObjectCreateProps = PropertyList<PropertyType::OBJECT_CREATE>;
 using FileCreateProps = PropertyList<PropertyType::FILE_CREATE>;
 using FileAccessProps = PropertyList<PropertyType::FILE_ACCESS>;
 using DataSetCreateProps = PropertyList<PropertyType::DATASET_CREATE>;
@@ -207,7 +204,6 @@ using DataTypeCreateProps = PropertyList<PropertyType::DATATYPE_CREATE>;
 using DataTypeAccessProps = PropertyList<PropertyType::DATATYPE_ACCESS>;
 using StringCreateProps = PropertyList<PropertyType::STRING_CREATE>;
 using AttributeCreateProps = PropertyList<PropertyType::ATTRIBUTE_CREATE>;
-using ObjectCopyProps = PropertyList<PropertyType::OBJECT_COPY>;
 using LinkCreateProps = PropertyList<PropertyType::LINK_CREATE>;
 using LinkAccessProps = PropertyList<PropertyType::LINK_ACCESS>;
 
@@ -606,7 +602,6 @@ class CreateIntermediateGroup {
   public:
     explicit CreateIntermediateGroup(bool create = true);
 
-    explicit CreateIntermediateGroup(const ObjectCreateProps& ocpl);
     explicit CreateIntermediateGroup(const LinkCreateProps& lcpl);
 
     bool isSet() const;
@@ -615,7 +610,6 @@ class CreateIntermediateGroup {
     void fromPropertyList(hid_t hid);
 
   private:
-    friend ObjectCreateProps;
     friend LinkCreateProps;
     void apply(hid_t hid) const;
     bool _create;

--- a/include/highfive/bits/H5PropertyList_misc.hpp
+++ b/include/highfive/bits/H5PropertyList_misc.hpp
@@ -17,8 +17,6 @@ inline hid_t convert_plist_type(PropertyType propertyType) {
     // The HP5_XXX are macros with function calls so we can't assign
     // them as the enum values
     switch (propertyType) {
-    case PropertyType::OBJECT_CREATE:
-        return H5P_OBJECT_CREATE;
     case PropertyType::FILE_CREATE:
         return H5P_FILE_CREATE;
     case PropertyType::FILE_ACCESS:
@@ -41,8 +39,6 @@ inline hid_t convert_plist_type(PropertyType propertyType) {
         return H5P_STRING_CREATE;
     case PropertyType::ATTRIBUTE_CREATE:
         return H5P_ATTRIBUTE_CREATE;
-    case PropertyType::OBJECT_COPY:
-        return H5P_OBJECT_COPY;
     case PropertyType::LINK_CREATE:
         return H5P_LINK_CREATE;
     case PropertyType::LINK_ACCESS:
@@ -389,11 +385,6 @@ inline double Caching::getW0() const {
 
 inline CreateIntermediateGroup::CreateIntermediateGroup(bool create)
     : _create(create) {}
-
-inline CreateIntermediateGroup::CreateIntermediateGroup(const ObjectCreateProps& ocpl) {
-    fromPropertyList(ocpl.getId());
-}
-
 
 inline void CreateIntermediateGroup::apply(const hid_t hid) const {
     detail::h5p_set_create_intermediate_group(hid, _create ? 1 : 0);


### PR DESCRIPTION
These are abstract concepts in the documentation of HDF5. In their current implementation they can't be used to express "one of ..." as they should.