### PR TITLE
Make `~Object` protected.

### DIFF
--- a/include/highfive/H5Object.hpp
+++ b/include/highfive/H5Object.hpp
@@ -31,33 +31,11 @@ enum class ObjectType {
     Other  // Internal/custom object type
 };
 
-namespace detail {
-/// \brief Internal hack to create an `Object` from an ID.
-///
-/// WARNING: Creating an Object from an ID has implications w.r.t. the lifetime of the object
-///          that got passed via its ID. Using this method careless opens up the suite of issues
-///          related to C-style resource management, including the analog of double free, dangling
-///          pointers, etc.
-///
-/// NOTE: This is not part of the API and only serves to work around a compiler issue in GCC which
-///       prevents us from using `friend`s instead. This function should only be used for internal
-///       purposes. The problematic construct is:
-///
-///           template<class Derived>
-///           friend class SomeCRTP<Derived>;
-///
-/// \private
-Object make_object(hid_t hid);
-}  // namespace detail
-
 
 class Object {
   public:
     // move constructor, reuse hid
     Object(Object&& other) noexcept;
-
-    // decrease reference counter
-    ~Object();
 
     ///
     /// \brief isValid
@@ -99,13 +77,15 @@ class Object {
     // Init with an low-level object id
     explicit Object(hid_t);
 
+    // decrease reference counter
+    ~Object();
+
     // Copy-Assignment operator
     Object& operator=(const Object& other);
 
     hid_t _hid;
 
   private:
-    friend Object detail::make_object(hid_t);
     friend class Reference;
     friend class CompoundType;
 

--- a/include/highfive/bits/H5Node_traits.hpp
+++ b/include/highfive/bits/H5Node_traits.hpp
@@ -217,9 +217,6 @@ class NodeTraits {
     // It makes behavior consistent among versions and by default transforms
     // errors to exceptions
     bool _exist(const std::string& node_name, bool raise_errors = true) const;
-
-    // Opens an arbitrary object to obtain info
-    Object _open(const std::string& node_name) const;
 };
 
 

--- a/include/highfive/bits/H5Node_traits_misc.hpp
+++ b/include/highfive/bits/H5Node_traits_misc.hpp
@@ -254,7 +254,12 @@ inline LinkType NodeTraits<Derivate>::getLinkType(const std::string& node_name) 
 
 template <typename Derivate>
 inline ObjectType NodeTraits<Derivate>::getObjectType(const std::string& node_name) const {
-    return _open(node_name).getType();
+    const auto id = detail::h5o_open(static_cast<const Derivate*>(this)->getId(),
+                                     node_name.c_str(),
+                                     H5P_DEFAULT);
+    auto object_type = _convert_object_type(detail::h5i_get_type(id));
+    detail::h5o_close(id);
+    return object_type;
 }
 
 
@@ -311,15 +316,6 @@ inline void NodeTraits<Derivate>::createHardLink(const std::string& link_name,
                             link_name.c_str(),
                             linkCreateProps.getId(),
                             linkAccessProps.getId());
-}
-
-
-template <typename Derivate>
-inline Object NodeTraits<Derivate>::_open(const std::string& node_name) const {
-    const auto id = detail::h5o_open(static_cast<const Derivate*>(this)->getId(),
-                                     node_name.c_str(),
-                                     H5P_DEFAULT);
-    return detail::make_object(id);
 }
 
 

--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -15,12 +15,6 @@
 #include "h5i_wrapper.hpp"
 
 namespace HighFive {
-namespace detail {
-inline Object make_object(hid_t hid) {
-    return Object(hid);
-}
-}  // namespace detail
-
 
 inline Object::Object()
     : _hid(H5I_INVALID_HID) {}

--- a/include/highfive/bits/h5o_wrapper.hpp
+++ b/include/highfive/bits/h5o_wrapper.hpp
@@ -15,5 +15,14 @@ inline hid_t h5o_open(hid_t loc_id, const char* name, hid_t lapl_id) {
     return hid;
 }
 
+inline herr_t h5o_close(hid_t id) {
+    herr_t err = H5Oclose(id);
+    if (err < 0) {
+        HDF5ErrMapper::ToException<ObjectException>("Unable to close object.");
+    }
+
+    return err;
+}
+
 }  // namespace detail
 }  // namespace HighFive


### PR DESCRIPTION
Since deleting HighFive objects through their common base class `Object` is not supported, we should make the dtor protected.

See Core Guidelines C35, e.g.
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual