### PR TITLE
Add private DataSpace (named) ctor `fromId`.

### DIFF
--- a/include/highfive/H5DataSpace.hpp
+++ b/include/highfive/H5DataSpace.hpp
@@ -19,6 +19,14 @@
 
 namespace HighFive {
 
+namespace detail {
+/// @brief Create a HighFive::DataSpace from an HID, without incrementing the id.
+///
+/// @note This is internal API and subject to change.
+/// @internal
+DataSpace make_data_space(hid_t hid);
+}  // namespace detail
+
 /// \brief Class representing the space (dimensions) of a DataSet
 ///
 /// \code{.cpp}
@@ -254,9 +262,18 @@ class DataSpace: public Object {
   protected:
     DataSpace() = default;
 
+    static DataSpace fromId(hid_t hid) {
+        DataSpace space;
+        space._hid = hid;
+
+        return space;
+    }
+
     friend class Attribute;
     friend class File;
     friend class DataSet;
+
+    friend DataSpace detail::make_data_space(hid_t hid);
 };
 
 }  // namespace HighFive

--- a/include/highfive/bits/H5Dataspace_misc.hpp
+++ b/include/highfive/bits/H5Dataspace_misc.hpp
@@ -21,6 +21,12 @@
 
 namespace HighFive {
 
+namespace detail {
+inline DataSpace make_data_space(hid_t hid) {
+    return DataSpace::fromId(hid);
+}
+}  // namespace detail
+
 inline DataSpace::DataSpace(const std::vector<size_t>& dims)
     : DataSpace(dims.begin(), dims.end()) {}
 


### PR DESCRIPTION
Certain HDF5 API creates data spaces, in order to use this API, we need to be able to create `HighFive::DataSpace` from an HID.