### PR TITLE
Optimize chained hyperslab selection.

### DIFF
--- a/include/highfive/bits/h5s_wrapper.hpp
+++ b/include/highfive/bits/h5s_wrapper.hpp
@@ -121,7 +121,7 @@ inline H5S_sel_type h5s_get_select_type(hid_t space_id) {
 }
 
 #if H5_VERSION_GE(1, 10, 6)
-hid_t h5s_combine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id) {
+inline hid_t h5s_combine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id) {
     auto space_id = H5Scombine_select(space1_id, op, space2_id);
     if (space_id == H5I_INVALID_HID) {
         HDF5ErrMapper::ToException<DataSpaceException>("Unable to combine two selections.");

--- a/include/highfive/bits/h5s_wrapper.hpp
+++ b/include/highfive/bits/h5s_wrapper.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <H5Ipublic.h>
 #include <H5Spublic.h>
 namespace HighFive {
 namespace detail {
@@ -109,6 +110,26 @@ inline H5S_class_t h5s_get_simple_extent_type(hid_t space_id) {
 
     return cls;
 }
+
+inline H5S_sel_type h5s_get_select_type(hid_t space_id) {
+    H5S_sel_type type = H5Sget_select_type(space_id);
+    if (type < 0) {
+        HDF5ErrMapper::ToException<DataSpaceException>("Unable to get type of selection.");
+    }
+
+    return type;
+}
+
+#if H5_VERSION_GE(1, 10, 6)
+hid_t h5s_combine_select(hid_t space1_id, H5S_seloper_t op, hid_t space2_id) {
+    auto space_id = H5Scombine_select(space1_id, op, space2_id);
+    if (space_id == H5I_INVALID_HID) {
+        HDF5ErrMapper::ToException<DataSpaceException>("Unable to combine two selections.");
+    }
+
+    return space_id;
+}
+#endif
 
 
 }  // namespace detail


### PR DESCRIPTION
A common pattern for creating semi-unstructured selection is to use many
(small) RegularHyperSlab and chain them:

```
HyperSlab hyperslab;
for(auto slab : regular_hyper_slabs) {
  hyperslab |= slab;
}
```

This eventually triggers calling:
```
for(auto slab : regular_hyper_slabs) {
  auto [offset, stride, counts, blocks] = slab;
  H5Sselect_hyperslab(space_id, offset, stride, counts, block);
}
```

Measurements show that this has runtime that's quadratic in the number
of regular hyper slabs. This starts becoming prohibitive at 10k - 40k
slabs.

We noticed that `H5Scombine_select` does not suffer from the same
performance issue. This allows us to optimize (long) chain of `Op::Or`
using divide and conquer.

The current implementation only optimizes streaks of `Op::Or`.